### PR TITLE
ethiopicaa -> ethioaa

### DIFF
--- a/index.html
+++ b/index.html
@@ -2589,14 +2589,14 @@ li.menu-search-result-term:before {
         </tr>
         <tr>
           <td><emu-val>"ethiopic"</emu-val></td>
-          <td><emu-val>"ethiopicaa"</emu-val></td>
+          <td><emu-val>"ethioaa"</emu-val></td>
           <td><emu-val>"ethiopic-amete-alem"</emu-val>, <emu-val>"mundi"</emu-val></td>
           <td><emu-val>-∞</emu-val><sub>𝔽</sub></td>
           <td><emu-val>5500</emu-val><sub>𝔽</sub></td>
         </tr>
         <tr>
-          <td><emu-val>"ethiopicaa"</emu-val></td>
-          <td><emu-val>"ethiopicaa"</emu-val></td>
+          <td><emu-val>"ethioaa"</emu-val></td>
+          <td><emu-val>"ethioaa"</emu-val></td>
           <td><emu-val>"ethiopic-amete-alem"</emu-val>, <emu-val>"mundi"</emu-val></td>
           <td><emu-val>-∞</emu-val><sub>𝔽</sub></td>
           <td><emu-val>+∞</emu-val><sub>𝔽</sub></td>
@@ -2780,7 +2780,7 @@ li.menu-search-result-term:before {
           <td><emu-val>"M13"</emu-val></td>
         </tr>
         <tr>
-          <td><emu-val>"ethiopicaa"</emu-val></td>
+          <td><emu-val>"ethioaa"</emu-val></td>
           <td><emu-val>"M13"</emu-val></td>
         </tr>
         <tr>

--- a/spec.emu
+++ b/spec.emu
@@ -84,14 +84,14 @@ contributors: Google, Ecma International
         </tr>
         <tr>
           <td>*"ethiopic"*</td>
-          <td>*"ethiopicaa"*</td>
+          <td>*"ethioaa"*</td>
           <td>*"ethiopic-amete-alem"*, *"mundi"*</td>
           <td>*-&infin;*<sub>𝔽</sub></td>
           <td>*5500*<sub>𝔽</sub></td>
         </tr>
         <tr>
-          <td>*"ethiopicaa"*</td>
-          <td>*"ethiopicaa"*</td>
+          <td>*"ethioaa"*</td>
+          <td>*"ethioaa"*</td>
           <td>*"ethiopic-amete-alem"*, *"mundi"*</td>
           <td>*-&infin;*<sub>𝔽</sub></td>
           <td>*+&infin;*<sub>𝔽</sub></td>
@@ -306,7 +306,7 @@ contributors: Google, Ecma International
           <td>*"M13"*</td>
         </tr>
         <tr>
-          <td>*"ethiopicaa"*</td>
+          <td>*"ethioaa"*</td>
           <td>*"M13"*</td>
         </tr>
         <tr>


### PR DESCRIPTION
ethioaa is the correct BCP47 name for this calendar, and thus the era named after it