### PR TITLE
Bump setup-node and Node.js version for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
-        node-version: '12.x'
+        node-version: 'node'
     - run: npm install
     - run: npm run build
     - name: commit changes


### PR DESCRIPTION
Switched to the alias `node` which would update as new Node versions come out.

Fixes: #35 

Workflow running here: https://github.com/tc39/proposal-intl-era-monthcode/actions/runs/15445859762/job/43475193206