### PR TITLE
Calendars islamic and islamic-rgsa should fall back to other values

### DIFF
--- a/index.html
+++ b/index.html
@@ -1620,7 +1620,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{}`);
-let biblio = JSON.parse(`{"refsByClause":{"sup-availablecalendars":["_ref_0","_ref_8","_ref_9"],"sec-temporal-calendarsupportsera":["_ref_1"],"sec-temporal-canonicalizeeraincalendar":["_ref_2"],"sec-temporal-isvalidmonthecodeforcalendar":["_ref_3","_ref_4"],"sec-temporal-isvaliderayearforcalendar":["_ref_5","_ref_11"],"sup-temporal-calendar-date-records":["_ref_6","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17"],"sec-temporal-calendardatearithmeticyear":["_ref_7","_ref_21"],"sec-ecma402-calendar-types":["_ref_10"],"sec-temporal-calendardateera":["_ref_18","_ref_19"],"sec-temporal-calendardateerayear":["_ref_20"],"sup-temporal-calendardateuntil":["_ref_22"],"sup-temporal-calendarextrafields":["_ref_23","_ref_24"],"sup-temporal-calendarfieldkeystoignore":["_ref_25","_ref_26"]},"entries":[{"type":"term","term":"calendar type","refId":"sec-ecma402-calendar-types"},{"type":"op","aoid":"AvailableCalendars","refId":"sup-availablecalendars"},{"type":"clause","id":"sup-availablecalendars","titleHTML":"AvailableCalendars ( )","number":"1.1"},{"type":"table","id":"table-calendar-types","number":1,"caption":"Table 1: Calendar types described in CLDR","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-ecma402-calendar-types","titleHTML":"Calendar Types","number":"1","referencingIds":["_ref_8","_ref_9","_ref_10","_ref_21","_ref_22","_ref_23","_ref_25"]},{"type":"table","id":"table-eras","number":2,"caption":"Table 2: era aliases and range of eraYear","referencingIds":["_ref_1","_ref_2","_ref_5"]},{"type":"op","aoid":"CalendarSupportsEra","refId":"sec-temporal-calendarsupportsera"},{"type":"clause","id":"sec-temporal-calendarsupportsera","title":"CalendarSupportsEra ( calendar )","titleHTML":"CalendarSupportsEra ( <var>calendar</var> )","number":"2.1","referencingIds":["_ref_18","_ref_20","_ref_24","_ref_26"]},{"type":"op","aoid":"CanonicalizeEraInCalendar","refId":"sec-temporal-canonicalizeeraincalendar"},{"type":"clause","id":"sec-temporal-canonicalizeeraincalendar","title":"CanonicalizeEraInCalendar ( calendar, era )","titleHTML":"CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )","number":"2.2","referencingIds":["_ref_11","_ref_19"]},{"type":"table","id":"table-additional-month-codes","number":3,"caption":"Table 3: Additional Month Codes in Calendars","referencingIds":["_ref_3","_ref_4"]},{"type":"op","aoid":"IsValidMonthCodeForCalendar","refId":"sec-temporal-isvalidmonthecodeforcalendar"},{"type":"clause","id":"sec-temporal-isvalidmonthecodeforcalendar","title":"IsValidMonthCodeForCalendar ( calendar, monthCode )","titleHTML":"IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )","number":"2.3"},{"type":"op","aoid":"IsValidEraYearForCalendar","refId":"sec-temporal-isvaliderayearforcalendar"},{"type":"clause","id":"sec-temporal-isvaliderayearforcalendar","title":"IsValidEraYearForCalendar ( calendar, era, eraYear )","titleHTML":"IsValidEraYearForCalendar ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )","number":"2.4"},{"type":"term","term":"Calendar Date Record","refId":"sup-temporal-calendar-date-records"},{"type":"table","id":"table-temporal-calendar-date-record-fields","number":4,"caption":"Table 4: Calendar Date Record Fields","referencingIds":["_ref_6"]},{"type":"clause","id":"sup-temporal-calendar-date-records","titleHTML":"Calendar Date Records","number":"2.5","referencingIds":["_ref_12","_ref_16","_ref_17"]},{"type":"op","aoid":"CalendarDateEra","refId":"sec-temporal-calendardateera"},{"type":"clause","id":"sec-temporal-calendardateera","title":"CalendarDateEra ( calendar, date )","titleHTML":"CalendarDateEra ( <var>calendar</var>, <var>date</var> )","number":"2.6","referencingIds":["_ref_13"]},{"type":"op","aoid":"CalendarDateEraYear","refId":"sec-temporal-calendardateerayear"},{"type":"clause","id":"sec-temporal-calendardateerayear","title":"CalendarDateEraYear ( calendar, date )","titleHTML":"CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )","number":"2.7","referencingIds":["_ref_14"]},{"type":"table","id":"table-epoch-years","number":5,"caption":"Table 5: epoch years","referencingIds":["_ref_7"]},{"type":"op","aoid":"CalendarDateArithmeticYear","refId":"sec-temporal-calendardatearithmeticyear"},{"type":"clause","id":"sec-temporal-calendardatearithmeticyear","title":"CalendarDateArithmeticYear ( calendar, date )","titleHTML":"CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )","number":"2.8","referencingIds":["_ref_15"]},{"type":"op","aoid":"CalendarDateUntil","refId":"sup-temporal-calendardateuntil"},{"type":"clause","id":"sup-temporal-calendardateuntil","title":"CalendarDateUntil ( calendar, one, two, largestUnit )","titleHTML":"CalendarDateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )","number":"2.9"},{"type":"op","aoid":"CalendarExtraFields","refId":"sup-temporal-calendarextrafields"},{"type":"clause","id":"sup-temporal-calendarextrafields","title":"CalendarExtraFields ( calendar, fields )","titleHTML":"CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )","number":"2.10"},{"type":"op","aoid":"CalendarFieldKeysToIgnore","refId":"sup-temporal-calendarfieldkeystoignore"},{"type":"clause","id":"sup-temporal-calendarfieldkeystoignore","title":"CalendarFieldKeysToIgnore ( calendar, keys )","titleHTML":"CalendarFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )","number":"2.11"},{"type":"clause","id":"sup-temporal-calendar-abstract-ops","titleHTML":"Abstract Operations","number":"2"},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"sup-availablecalendars":["_ref_0","_ref_10","_ref_11"],"sec-ecma402-intl.datetimeformat-internal-slots":["_ref_1","_ref_2"],"sec-temporal-calendarsupportsera":["_ref_3"],"sec-temporal-canonicalizeeraincalendar":["_ref_4"],"sec-temporal-isvalidmonthecodeforcalendar":["_ref_5","_ref_6"],"sec-temporal-isvaliderayearforcalendar":["_ref_7","_ref_15"],"sup-temporal-calendar-date-records":["_ref_8","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21"],"sec-temporal-calendardatearithmeticyear":["_ref_9","_ref_25"],"sec-ecma402-calendar-types":["_ref_12"],"sec-createdatetimeformat":["_ref_13","_ref_14"],"sec-temporal-calendardateera":["_ref_22","_ref_23"],"sec-temporal-calendardateerayear":["_ref_24"],"sup-temporal-calendardateuntil":["_ref_26"],"sup-temporal-calendarextrafields":["_ref_27","_ref_28"],"sup-temporal-calendarfieldkeystoignore":["_ref_29","_ref_30"]},"entries":[{"type":"term","term":"calendar type","refId":"sec-ecma402-calendar-types"},{"type":"op","aoid":"AvailableCalendars","refId":"sup-availablecalendars"},{"type":"clause","id":"sup-availablecalendars","titleHTML":"AvailableCalendars ( )","number":"1.1","referencingIds":["_ref_14"]},{"type":"table","id":"table-calendar-types","number":1,"caption":"Table 1: Calendar types described in CLDR","referencingIds":["_ref_0","_ref_2"]},{"type":"clause","id":"sec-ecma402-calendar-types","titleHTML":"Calendar Types","number":"1","referencingIds":["_ref_10","_ref_11","_ref_12","_ref_13","_ref_25","_ref_26","_ref_27","_ref_29"]},{"type":"clause","id":"sec-internal-slots","titleHTML":"Internal slots of Service Constructors","number":"2.1","referencingIds":["_ref_1"]},{"type":"clause","id":"locale-and-parameter-negotiation","titleHTML":"Locale and Parameter Negotiation","number":"2"},{"type":"op","aoid":"CreateDateTimeFormat","refId":"sec-createdatetimeformat"},{"type":"clause","id":"sec-createdatetimeformat","title":"CreateDateTimeFormat ( newTarget, locales, options, required, defaults )","titleHTML":"CreateDateTimeFormat ( <var>newTarget</var>, <var>locales</var>, <var>options</var>, <var>required</var>, <var>defaults</var> )","number":"3.1.1"},{"type":"clause","id":"sec-ecma402-intl-datetimeformat-constructor","titleHTML":"The Intl.DateTimeFormat Constructor","number":"3.1"},{"type":"clause","id":"sec-ecma402-intl.datetimeformat-internal-slots","titleHTML":"Internal slots","number":"3.2.1"},{"type":"clause","id":"sec-ecma402-properties-of-intl-datetimeformat-constructor","titleHTML":"Properties of the Intl.DateTimeFormat Constructor","number":"3.2"},{"type":"clause","id":"ecma402-datetimeformat-objects","titleHTML":"DateTimeFormat Objects","number":"3"},{"type":"table","id":"table-eras","number":2,"caption":"Table 2: era aliases and range of eraYear","referencingIds":["_ref_3","_ref_4","_ref_7"]},{"type":"op","aoid":"CalendarSupportsEra","refId":"sec-temporal-calendarsupportsera"},{"type":"clause","id":"sec-temporal-calendarsupportsera","title":"CalendarSupportsEra ( calendar )","titleHTML":"CalendarSupportsEra ( <var>calendar</var> )","number":"4.1","referencingIds":["_ref_22","_ref_24","_ref_28","_ref_30"]},{"type":"op","aoid":"CanonicalizeEraInCalendar","refId":"sec-temporal-canonicalizeeraincalendar"},{"type":"clause","id":"sec-temporal-canonicalizeeraincalendar","title":"CanonicalizeEraInCalendar ( calendar, era )","titleHTML":"CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )","number":"4.2","referencingIds":["_ref_15","_ref_23"]},{"type":"table","id":"table-additional-month-codes","number":3,"caption":"Table 3: Additional Month Codes in Calendars","referencingIds":["_ref_5","_ref_6"]},{"type":"op","aoid":"IsValidMonthCodeForCalendar","refId":"sec-temporal-isvalidmonthecodeforcalendar"},{"type":"clause","id":"sec-temporal-isvalidmonthecodeforcalendar","title":"IsValidMonthCodeForCalendar ( calendar, monthCode )","titleHTML":"IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )","number":"4.3"},{"type":"op","aoid":"IsValidEraYearForCalendar","refId":"sec-temporal-isvaliderayearforcalendar"},{"type":"clause","id":"sec-temporal-isvaliderayearforcalendar","title":"IsValidEraYearForCalendar ( calendar, era, eraYear )","titleHTML":"IsValidEraYearForCalendar ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )","number":"4.4"},{"type":"term","term":"Calendar Date Record","refId":"sup-temporal-calendar-date-records"},{"type":"table","id":"table-temporal-calendar-date-record-fields","number":4,"caption":"Table 4: Calendar Date Record Fields","referencingIds":["_ref_8"]},{"type":"clause","id":"sup-temporal-calendar-date-records","titleHTML":"Calendar Date Records","number":"4.5","referencingIds":["_ref_16","_ref_20","_ref_21"]},{"type":"op","aoid":"CalendarDateEra","refId":"sec-temporal-calendardateera"},{"type":"clause","id":"sec-temporal-calendardateera","title":"CalendarDateEra ( calendar, date )","titleHTML":"CalendarDateEra ( <var>calendar</var>, <var>date</var> )","number":"4.6","referencingIds":["_ref_17"]},{"type":"op","aoid":"CalendarDateEraYear","refId":"sec-temporal-calendardateerayear"},{"type":"clause","id":"sec-temporal-calendardateerayear","title":"CalendarDateEraYear ( calendar, date )","titleHTML":"CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )","number":"4.7","referencingIds":["_ref_18"]},{"type":"table","id":"table-epoch-years","number":5,"caption":"Table 5: epoch years","referencingIds":["_ref_9"]},{"type":"op","aoid":"CalendarDateArithmeticYear","refId":"sec-temporal-calendardatearithmeticyear"},{"type":"clause","id":"sec-temporal-calendardatearithmeticyear","title":"CalendarDateArithmeticYear ( calendar, date )","titleHTML":"CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )","number":"4.8","referencingIds":["_ref_19"]},{"type":"op","aoid":"CalendarDateUntil","refId":"sup-temporal-calendardateuntil"},{"type":"clause","id":"sup-temporal-calendardateuntil","title":"CalendarDateUntil ( calendar, one, two, largestUnit )","titleHTML":"CalendarDateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )","number":"4.9"},{"type":"op","aoid":"CalendarExtraFields","refId":"sup-temporal-calendarextrafields"},{"type":"clause","id":"sup-temporal-calendarextrafields","title":"CalendarExtraFields ( calendar, fields )","titleHTML":"CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )","number":"4.10"},{"type":"op","aoid":"CalendarFieldKeysToIgnore","refId":"sup-temporal-calendarfieldkeystoignore"},{"type":"clause","id":"sup-temporal-calendarfieldkeystoignore","title":"CalendarFieldKeysToIgnore ( calendar, keys )","titleHTML":"CalendarFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )","number":"4.11"},{"type":"clause","id":"sup-temporal-calendar-abstract-ops","titleHTML":"Abstract Operations","number":"4"},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
 ;let usesMultipage = false</script><style>:root {
   --foreground-color: #111;
   --background-color: #fff;
@@ -1910,23 +1910,6 @@ h1.shortname { display: none; }
 
 body.oldtoc {
   margin: 0 auto;
-}
-
-#metadata-block {
-  margin: 4em 0;
-  padding: 10px;
-  border: 1px solid #ee8421;
-}
-
-#metadata-block h1 {
-  font-size: 1.5em;
-  margin-top: 0;
-}
-
-#metadata-block > ul {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
 }
 
 span[aria-hidden='true'] {
@@ -3267,7 +3250,6 @@ emu-normative-optional,
 
 #ecma-logo {
   background: var(--figure-background);
-  width: 500px;
 }
 </style><style>@media print {
 @font-face {
@@ -3341,7 +3323,6 @@ emu-normative-optional,
 
 :root {
   --page-number-style: decimal;
-  -prince-change-line-breaks-for-pagination: yes; /* see https://www.princexml.com/doc/prince-for-books/#pagination-fine-tuning */
 }
 
 @page {
@@ -3350,16 +3331,16 @@ emu-normative-optional,
   margin-bottom: 20mm;
   margin-inside: 19mm;
   margin-outside: 13mm;
-  -prince-page-fill: prefer-balance; /* see https://www.princexml.com/doc/prince-for-books/#the-property--prince-page-fill */
+  -prince-page-fill: prefer-fill;
 
-  /* Uncomment when producing WIP versions of final standards, see https://www.princexml.com/doc/paged/#page-regions */
+  /* Uncomment when producing WIP versions of final standards */
   /*
   @prince-overlay {
     color: rgba(0,0,0,0.15);
-    content: "DRAFT";
+    content: "WORK IN PROGRESS";
     font-family: Arial;
     font-weight: bolder;
-    font-size: 200pt;
+    font-size: 100pt;
     transform: rotate(-60deg);
   }
   */
@@ -3469,7 +3450,7 @@ body {
   line-height: 1.15;
 }
 
-h1, h2, h3, h4, h5, h6 { -prince-bookmark-level: none } /* see https://www.princexml.com/doc/prince-output/#pdf-bookmarks */
+h1, h2, h3, h4, h5, h6 { -prince-bookmark-level: none }
 
 .copyright-notice + h1.title {
   break-before: recto;
@@ -3489,22 +3470,13 @@ p {
   text-wrap: pretty;
   overflow-wrap: break-word;
   hyphens: auto;
-  orphans: 2, -prince-prefer 3; /* see https://www.princexml.com/doc/prince-for-books/#pagination-goals */
-  widows: 2, -prince-prefer 3;
+  orphans: 2;
+  widows: 2;
 }
 
 h1 {
   text-wrap: balance;
   line-height: 1.4;
-}
-
-pre:has(> code) {
-  margin: 0;
-}
-
-p + pre:has(+ p) {
-  padding-top: 0;
-  padding-bottom: 0;
 }
 
 emu-alg {
@@ -3545,10 +3517,6 @@ emu-alg ol li:last-child {
   break-after: initial; /* it's okay to break after the last item in a list, even if it's also the first item in the list */
 }
 
-emu-normative-optional {
-  break-inside: avoid;
-}
-
 emu-normative-optional emu-clause[id] {
   margin-top: 0;
 }
@@ -3565,10 +3533,6 @@ emu-note {
 emu-note .note {
   font-size: 9pt;
   min-width: 4.5em;
-}
-
-emu-note table td {
-  background-color: white;
 }
 
 emu-note p,
@@ -3599,6 +3563,7 @@ emu-intro, emu-clause, emu-annex {
 }
 
 emu-clause p:first-of-type {
+  margin-bottom: 0;
   orphans: 3;
 }
 
@@ -3718,7 +3683,7 @@ caption, table > figcaption {
 }
 
 caption {
-  -prince-caption-page: first; /* see https://www.princexml.com/doc/css-props/#prop-prince-caption-page */
+  -prince-caption-page: first;
 }
 
 /* do not break inside of small tables */
@@ -3757,11 +3722,6 @@ emu-figure img {
   margin-top: 1ex;
   max-width: 100%;
   height: auto;
-}
-
-.attributes-tag {
-  break-before: avoid-page;
-  break-after: avoid-page;
 }
 
 #spec-container {
@@ -3859,8 +3819,8 @@ emu-annex > h1 .secnum {
   border: 1px solid black;
   padding: 1em;
   page: copyright;
-  break-before: page;
-  break-after: page;
+  page-break-before: always;
+  page-break-after: always;
 }
 
 .secnum {
@@ -3988,7 +3948,7 @@ p.ECMAaddress {
 </ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
-    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-ecma402-calendar-types" title="Calendar Types"><span class="secnum">1</span> Calendar Types</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sup-availablecalendars" title="AvailableCalendars ( )"><span class="secnum">1.1</span> AvailableCalendars ( )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sup-temporal-calendar-abstract-ops" title="Abstract Operations"><span class="secnum">2</span> Abstract Operations</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendarsupportsera" title="CalendarSupportsEra ( calendar )"><span class="secnum">2.1</span> CalendarSupportsEra ( <var>calendar</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-canonicalizeeraincalendar" title="CanonicalizeEraInCalendar ( calendar, era )"><span class="secnum">2.2</span> CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-isvalidmonthecodeforcalendar" title="IsValidMonthCodeForCalendar ( calendar, monthCode )"><span class="secnum">2.3</span> IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-isvaliderayearforcalendar" title="IsValidEraYearForCalendar ( calendar, era, eraYear )"><span class="secnum">2.4</span> IsValidEraYearForCalendar ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendar-date-records" title="Calendar Date Records"><span class="secnum">2.5</span> Calendar Date Records</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardateera" title="CalendarDateEra ( calendar, date )"><span class="secnum">2.6</span> CalendarDateEra ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardateerayear" title="CalendarDateEraYear ( calendar, date )"><span class="secnum">2.7</span> CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardatearithmeticyear" title="CalendarDateArithmeticYear ( calendar, date )"><span class="secnum">2.8</span> CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendardateuntil" title="CalendarDateUntil ( calendar, one, two, largestUnit )"><span class="secnum">2.9</span> CalendarDateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendarextrafields" title="CalendarExtraFields ( calendar, fields )"><span class="secnum">2.10</span> CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendarfieldkeystoignore" title="CalendarFieldKeysToIgnore ( calendar, keys )"><span class="secnum">2.11</span> CalendarFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License">Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 2 Draft / July 18, 2025</h1><h1 class="title">Intl era and monthCode Proposal</h1>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-ecma402-calendar-types" title="Calendar Types"><span class="secnum">1</span> Calendar Types</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sup-availablecalendars" title="AvailableCalendars ( )"><span class="secnum">1.1</span> AvailableCalendars ( )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#locale-and-parameter-negotiation" title="Locale and Parameter Negotiation"><span class="secnum">2</span> Locale and Parameter Negotiation</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-internal-slots" title="Internal slots of Service Constructors"><span class="secnum">2.1</span> Internal slots of Service Constructors</a></li></ol></li><li><span class="item-toggle">+</span><a href="#ecma402-datetimeformat-objects" title="DateTimeFormat Objects"><span class="secnum">3</span> DateTimeFormat Objects</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-ecma402-intl-datetimeformat-constructor" title="The Intl.DateTimeFormat Constructor"><span class="secnum">3.1</span> The Intl.DateTimeFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-createdatetimeformat" title="CreateDateTimeFormat ( newTarget, locales, options, required, defaults )"><span class="secnum">3.1.1</span> CreateDateTimeFormat ( <var>newTarget</var>, <var>locales</var>, <var>options</var>, <var>required</var>, <var>defaults</var> )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-ecma402-properties-of-intl-datetimeformat-constructor" title="Properties of the Intl.DateTimeFormat Constructor"><span class="secnum">3.2</span> Properties of the Intl.DateTimeFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-ecma402-intl.datetimeformat-internal-slots" title="Internal slots"><span class="secnum">3.2.1</span> Internal slots</a></li></ol></li></ol></li><li><span class="item-toggle">+</span><a href="#sup-temporal-calendar-abstract-ops" title="Abstract Operations"><span class="secnum">4</span> Abstract Operations</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendarsupportsera" title="CalendarSupportsEra ( calendar )"><span class="secnum">4.1</span> CalendarSupportsEra ( <var>calendar</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-canonicalizeeraincalendar" title="CanonicalizeEraInCalendar ( calendar, era )"><span class="secnum">4.2</span> CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-isvalidmonthecodeforcalendar" title="IsValidMonthCodeForCalendar ( calendar, monthCode )"><span class="secnum">4.3</span> IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-isvaliderayearforcalendar" title="IsValidEraYearForCalendar ( calendar, era, eraYear )"><span class="secnum">4.4</span> IsValidEraYearForCalendar ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendar-date-records" title="Calendar Date Records"><span class="secnum">4.5</span> Calendar Date Records</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardateera" title="CalendarDateEra ( calendar, date )"><span class="secnum">4.6</span> CalendarDateEra ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardateerayear" title="CalendarDateEraYear ( calendar, date )"><span class="secnum">4.7</span> CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardatearithmeticyear" title="CalendarDateArithmeticYear ( calendar, date )"><span class="secnum">4.8</span> CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendardateuntil" title="CalendarDateUntil ( calendar, one, two, largestUnit )"><span class="secnum">4.9</span> CalendarDateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendarextrafields" title="CalendarExtraFields ( calendar, fields )"><span class="secnum">4.10</span> CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendarfieldkeystoignore" title="CalendarFieldKeysToIgnore ( calendar, keys )"><span class="secnum">4.11</span> CalendarFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License">Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 2 Draft / July 18, 2025</h1><h1 class="title">Intl era and monthCode Proposal</h1>
 
 
 <emu-clause id="sec-ecma402-calendar-types" oldids="sec-calendar-types"><span id="sec-calendar-types"></span>
@@ -3997,7 +3957,7 @@ p.ECMAaddress {
   <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">
     <p>
       This section, Calendar Types, is <a href="https://tc39.es/ecma402/#sec-calendar-types">present in ECMA-402</a> but is slated to <a href="https://tc39.es/proposal-temporal/#sec-calendar-types">move to ECMA-262 as part of the Temporal proposal</a>.
-      This proposal re-adds the section to ECMA-402, but with additional requirements for Intl-supporting implementations, beyond those specified in ECMA-262.
+      This proposal re-adds the section to ECMA-402, but with additional requirements for Intl-supporting implementations, beyond those specified in <emu-xref href="#ecma262"><a href="https://tc39.es/ecma402/#ecma262">ECMA-262</a></emu-xref>.
     </p>
   </div></emu-note>
 
@@ -4007,19 +3967,19 @@ p.ECMAaddress {
 
   <ins class="block">
     <p>
-      ECMA-262 describes calendar types, of which <emu-val>"iso8601"</emu-val> is required to be supported.
+      <emu-xref href="#ecma262"><a href="https://tc39.es/ecma402/#ecma262">ECMA-262</a></emu-xref> describes calendar types, of which <emu-val>"iso8601"</emu-val> is required to be supported.
       This specification additionally requires ECMAScript implementations to support calendar types corresponding with those of the <a href="https://cldr.unicode.org/">Unicode Common Locale Data Repository (CLDR)</a>.
     </p>
   </ins>
 
   <emu-clause id="sup-availablecalendars" oldids="sec-availablecalendars sec-availablecanonicalcalendars" type="implementation-defined abstract operation" aoid="AvailableCalendars"><span id="sec-availablecalendars sec-availablecanonicalcalendars"></span>
     <h1><span class="secnum">1.1</span> AvailableCalendars ( )</h1>
-    <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation AvailableCalendars takes no arguments and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#sec-ecma402-calendar-types" id="_ref_8"><a href="#sec-ecma402-calendar-types">calendar types</a></emu-xref>. The returned <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is sorted according to lexicographic code unit order, and contains unique <emu-xref href="#sec-ecma402-calendar-types" id="_ref_9"><a href="#sec-ecma402-calendar-types">calendar types</a></emu-xref> in canonical form (<emu-xref href="#sec-calendar-types"><a href="https://tc39.es/proposal-temporal/#sec-calendar-types">calendar types</a></emu-xref>) identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects, including their aliases (e.g., <del>either</del> both <del>or neither of</del> <emu-val>"islamicc"</emu-val> and <emu-val>"islamic-civil"</emu-val>). The <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> must include <del><emu-val>"iso8601"</emu-val></del><ins>the Calendar Type value of every row of <emu-xref href="#table-calendar-types" id="_ref_0"><a href="#table-calendar-types">Table 1</a></emu-xref>, except the header row</ins>.</p>
-    <p><ins>This definition supersedes the definition provided in <emu-xref href="#sec-availablecalendars"><a href="https://tc39.es/proposal-temporal/#sec-availablecalendars">Temporal, 12.1</a></emu-xref>.</ins></p>
+    <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation AvailableCalendars takes no arguments and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#sec-ecma402-calendar-types" id="_ref_10"><a href="#sec-ecma402-calendar-types">calendar types</a></emu-xref>. The returned <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is sorted according to lexicographic code unit order, and contains unique <emu-xref href="#sec-ecma402-calendar-types" id="_ref_11"><a href="#sec-ecma402-calendar-types">calendar types</a></emu-xref> in canonical form (<emu-xref href="#sec-calendar-types"><a href="https://tc39.es/ecma402/#sec-calendar-types">6.9</a></emu-xref>) identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects, including their aliases (e.g., <del>either</del> both <del>or neither of</del> <emu-val>"islamicc"</emu-val> and <emu-val>"islamic-civil"</emu-val>). The <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> must include <del><emu-val>"iso8601"</emu-val></del><ins>the Calendar Type value of every row of <emu-xref href="#table-calendar-types" id="_ref_0"><a href="#table-calendar-types">Table 1</a></emu-xref>, except the header row</ins>.</p>
+    <p><ins>This definition supersedes the definition provided in <emu-xref href="#sec-availablecalendars"><a href="https://tc39.es/ecma402/#sec-availablecalendars">6.9.1</a></emu-xref>.</ins></p>
   </emu-clause>
 
   <ins class="block">
-    <emu-table id="table-calendar-types"><figure><figcaption>Table 1: <emu-xref href="#sec-ecma402-calendar-types" id="_ref_10"><a href="#sec-ecma402-calendar-types">Calendar types</a></emu-xref> described in CLDR</figcaption>
+    <emu-table id="table-calendar-types"><figure><figcaption>Table 1: <emu-xref href="#sec-ecma402-calendar-types" id="_ref_12"><a href="#sec-ecma402-calendar-types">Calendar types</a></emu-xref> described in CLDR</figcaption>
       
       <table class="real-table">
         <thead>
@@ -4069,24 +4029,8 @@ p.ECMAaddress {
           <td>Indian national (or Śaka) calendar, proleptic. Solar calendar with one era.</td>
         </tr>
         <tr>
-          <td><emu-val>"islamic"</emu-val></td>
-          <td>Hijri calendar, proleptic, unspecified algorithm. Historically in browsers, this was an astronomical simulation whose parameters are undocumented and that is not known to match a specific Hijri calendar variant in use outside of software.
-            <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">
-              See <a href="https://github.com/tc39/proposal-intl-era-monthcode/issues/29">issue #29</a>.
-            </div></emu-note>
-          </td>
-        </tr>
-        <tr>
           <td><emu-val>"islamic-civil"</emu-val></td>
           <td>Hijri calendar, proleptic, tabular/rule-based with leap years 2, 5, 7, 10, 13, 16, 18, 21, 24, 26, 29 in the 30-year cycle, and civil epoch (Friday July 16, 622 Julian / 0622-07-19 ISO)</td>
-        </tr>
-        <tr>
-          <td><emu-val>"islamic-rgsa"</emu-val></td>
-          <td>Hijri calendar, proleptic, Saudi Arabia sighting. Browsers do not have historical astronomical sighting data and future sightings have not occurred yet. Historically in browsers, this calendar has had identical behaviour to <emu-val>"islamic"</emu-val>.
-            <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">
-              See <a href="https://github.com/tc39/proposal-intl-era-monthcode/issues/29">issue #29</a>.
-            </div></emu-note>
-          </td>
         </tr>
         <tr>
           <td><emu-val>"islamic-tbla"</emu-val></td>
@@ -4102,7 +4046,7 @@ p.ECMAaddress {
         </tr>
         <tr>
           <td><emu-val>"iso8601"</emu-val></td>
-          <td>ISO 8601 calendar. Fully specified in ECMA-262.</td>
+          <td>ISO 8601 calendar. Fully specified in <emu-xref href="#ecma262"><a href="https://tc39.es/ecma402/#ecma262">ECMA-262</a></emu-xref>.</td>
         </tr>
         <tr>
           <td><emu-val>"japanese"</emu-val></td>
@@ -4121,15 +4065,70 @@ p.ECMAaddress {
   </ins>
 </emu-clause>
 
+<emu-clause id="locale-and-parameter-negotiation">
+  <h1><span class="secnum">2</span> Locale and Parameter Negotiation</h1>
+
+  <emu-clause id="sec-internal-slots">
+    <h1><span class="secnum">2.1</span> Internal slots of Service Constructors</h1>
+
+    <p>[...]</p>
+
+    <emu-note><span class="note">Note</span><div class="note-contents">
+      For example, an implementation of DateTimeFormat might include the <emu-xref href="#sec-language-tags"><a href="https://tc39.es/ecma402/#sec-language-tags">language tag</a></emu-xref> <emu-val>"fa-IR"</emu-val> in its <var class="field">[[AvailableLocales]]</var> internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"><a href="https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots">11.2.3</a></emu-xref>) include the keys <emu-val>"ca"</emu-val>, <emu-val>"hc"</emu-val>, and <emu-val>"nu"</emu-val> in its <var class="field">[[RelevantExtensionKeys]]</var> internal slot.
+      The default calendar for that locale is usually <emu-val>"persian"</emu-val>, but an implementation might also support <emu-val>"gregory"</emu-val><del>, <emu-val>"islamic"</emu-val>,</del> and <emu-val>"islamic-civil"</emu-val>.
+      The <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> in the DateTimeFormat <var class="field">[[LocaleData]]</var> internal slot would therefore include a [[fa-IR]] field whose value is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> like { <var class="field">[[ca]]</var>: « <emu-val>"persian"</emu-val>, <emu-val>"gregory"</emu-val>, <del><emu-val>"islamic"</emu-val>,</del> <emu-val>"islamic-civil"</emu-val> », <var class="field">[[hc]]</var>: « … », <var class="field">[[nu]]</var>: « … » }, along with other locale-named fields having the same value shape but different elements in their <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref>.
+    </div></emu-note>
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="ecma402-datetimeformat-objects">
+  <h1><span class="secnum">3</span> DateTimeFormat Objects</h1>
+
+  <emu-clause id="sec-ecma402-intl-datetimeformat-constructor">
+    <h1><span class="secnum">3.1</span> The Intl.DateTimeFormat Constructor</h1>
+
+    <emu-clause id="sec-createdatetimeformat" type="abstract operation" oldids="sec-initializedatetimeformat,sec-todatetimeoptions" aoid="CreateDateTimeFormat"><span id="sec-todatetimeoptions"></span><span id="sec-initializedatetimeformat"></span>
+      <h1><span class="secnum">3.1.1</span> CreateDateTimeFormat ( <var>newTarget</var>, <var>locales</var>, <var>options</var>, <var>required</var>, <var>defaults</var> )</h1>
+
+      <p>The abstract operation CreateDateTimeFormat takes arguments <var>newTarget</var> (a <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>), <var>locales</var> (an <emu-xref href="#sec-ecmascript-language-types"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types">ECMAScript language value</a></emu-xref>), <var>options</var> (an <emu-xref href="#sec-ecmascript-language-types"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types">ECMAScript language value</a></emu-xref>), <var>required</var> (<emu-const>date</emu-const>, <emu-const>time</emu-const>, or <emu-const>any</emu-const>), and <var>defaults</var> (<emu-const>date</emu-const>, <emu-const>time</emu-const>, or <emu-const>all</emu-const>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a DateTimeFormat object or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It performs the following steps when called:</p>
+
+      <emu-alg><ol><li>Let <var>dateTimeFormat</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor"><a href="https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(<var>newTarget</var>, <emu-val>"%Intl.DateTimeFormat.prototype%"</emu-val>, « <var class="field">[[InitializedDateTimeFormat]]</var>, <var class="field">[[Locale]]</var>, <var class="field">[[Calendar]]</var>, <var class="field">[[NumberingSystem]]</var>, <var class="field">[[TimeZone]]</var>, <var class="field">[[HourCycle]]</var>, <var class="field">[[DateStyle]]</var>, <var class="field">[[TimeStyle]]</var>, <var class="field">[[DateTimeFormat]]</var>, <var class="field">[[BoundFormat]]</var>&nbsp;»).</li><li>Let <var>hour12</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>modifyResolutionOptions</var> be a new <emu-xref href="#sec-abstract-closure"><a href="https://tc39.es/ecma262/#sec-abstract-closure">Abstract Closure</a></emu-xref> with parameters (<var>options</var>) that captures <var>hour12</var> and performs the following steps when called:<ol><li>Set <var>hour12</var> to <var>options</var>.<var class="field">[[hour12]]</var>.</li><li>Remove field <var class="field">[[hour12]]</var> from <var>options</var>.</li><li>If <var>hour12</var> is not <emu-val>undefined</emu-val>, set <var>options</var>.<var class="field">[[hc]]</var> to <emu-val>null</emu-val>.</li></ol></li><li>Let <var>optionsResolution</var> be ?&nbsp;<emu-xref aoid="ResolveOptions"><a href="https://tc39.es/ecma402/#sec-resolveoptions">ResolveOptions</a></emu-xref>(<emu-xref href="#sec-intl-datetimeformat-constructor"><a href="https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor">%Intl.DateTimeFormat%</a></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"><a href="https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor">%Intl.DateTimeFormat%</a></emu-xref>.<var class="field">[[LocaleData]]</var>, <var>locales</var>, <var>options</var>, « <emu-const>coerce-options</emu-const>&nbsp;», <var>modifyResolutionOptions</var>).</li><li>Set <var>options</var> to <var>optionsResolution</var>.<var class="field">[[Options]]</var>.</li><li>Let <var>r</var> be <var>optionsResolution</var>.<var class="field">[[ResolvedLocale]]</var>.</li><li>Set <var>dateTimeFormat</var>.<var class="field">[[Locale]]</var> to <var>r</var>.<var class="field">[[Locale]]</var>.</li><li>Let <var>resolvedCalendar</var> be <var>r</var>.<var class="field">[[ca]]</var>.</li><li><ins>If <var>resolvedCalendar</var> is <emu-val>"islamic"</emu-val> or <emu-val>"islamic-rgsa"</emu-val>, then</ins><ol><li><ins>Let <var>fallbackCalendar</var> be an implementation- and locale-defined <emu-xref href="#sec-ecma402-calendar-types" id="_ref_13"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is one of the values returned from <emu-xref aoid="AvailableCalendars" id="_ref_14"><a href="#sup-availablecalendars">AvailableCalendars</a></emu-xref>.</ins></li><li><ins>Set <var>fallbackCalendar</var> to <emu-xref aoid="CanonicalizeUValue"><a href="https://tc39.es/ecma402/#sec-canonicalizeuvalue">CanonicalizeUValue</a></emu-xref>(<emu-val>"ca"</emu-val>, <var>fallbackCalendar</var>).</ins></li><li><ins>Set <var>resolvedCalendar</var> to <var>fallbackCalendar</var>.</ins></li></ol></li><li>Set <var>dateTimeFormat</var>.<var class="field">[[Calendar]]</var> to <var>resolvedCalendar</var>.</li><li>NOTE: Rest of algorithm unchanged.</li></ol></emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-ecma402-properties-of-intl-datetimeformat-constructor">
+    <h1><span class="secnum">3.2</span> Properties of the Intl.DateTimeFormat Constructor</h1>
+
+    <emu-clause id="sec-ecma402-intl.datetimeformat-internal-slots">
+      <h1><span class="secnum">3.2.1</span> Internal slots</h1>
+
+      <p>[...]</p>
+
+      <p>The value of the <var class="field">[[LocaleData]]</var> internal slot is <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> within the constraints described in <emu-xref href="#sec-internal-slots" id="_ref_1"><a href="#sec-internal-slots">2.1</a></emu-xref> and the following additional constraints, for all locale values <var>locale</var>:</p>
+
+      <ul>
+        <li><ins><var class="field">[[LocaleData]]</var>.[[&lt;<var>locale</var>&gt;]].<var class="field">[[ca]]</var> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> consisting of values from the Calendar Type column of <emu-xref href="#table-calendar-types" id="_ref_2"><a href="#table-calendar-types">Table 1</a></emu-xref>. The list may also include <emu-val>"islamic"</emu-val> and <emu-val>"islamic-rgsa"</emu-val>.</ins></li>
+        <li>
+          <var class="field">[[LocaleData]]</var>.[[&lt;<var>locale</var>&gt;]].<var class="field">[[nu]]</var> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> that does not include the values <emu-val>"native"</emu-val>, <emu-val>"traditio"</emu-val>, or <emu-val>"finance"</emu-val>.
+        </li>
+        <li>
+          <var class="field">[[LocaleData]]</var>.[[&lt;<var>locale</var>&gt;]].<var class="field">[[hc]]</var> must be « <emu-val>null</emu-val>, <emu-val>"h11"</emu-val>, <emu-val>"h12"</emu-val>, <emu-val>"h23"</emu-val>, <emu-val>"h24"</emu-val> ».
+        </li>
+        <li>[...]</li>
+      </ul>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>
+
 <emu-clause id="sup-temporal-calendar-abstract-ops">
-  <h1><span class="secnum">2</span> Abstract Operations</h1>
+  <h1><span class="secnum">4</span> Abstract Operations</h1>
 
   <emu-clause id="sec-temporal-calendarsupportsera" type="abstract operation" aoid="CalendarSupportsEra">
-    <h1><span class="secnum">2.1</span> CalendarSupportsEra ( <var>calendar</var> )</h1>
+    <h1><span class="secnum">4.1</span> CalendarSupportsEra ( <var>calendar</var> )</h1>
     <p>The abstract operation CalendarSupportsEra takes argument <var>calendar</var> (a String) and returns a Boolean. 
         The following algorithm refers to the era data from <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Data">UTS 35's Supplemental Calendar Data</a>.
        It performs the following steps when called:</p>
-    <emu-alg><ol><li>If <var>calendar</var> is listed in the Calendar column of <emu-xref href="#table-eras" id="_ref_1"><a href="#table-eras">Table 2</a></emu-xref>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <var>calendar</var> is listed in the Calendar column of <emu-xref href="#table-eras" id="_ref_3"><a href="#table-eras">Table 2</a></emu-xref>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-table id="table-eras"><figure><figcaption>Table 2: era aliases and range of eraYear</figcaption>
       
       <table class="real-table">
@@ -4206,20 +4205,6 @@ p.ECMAaddress {
           <td><emu-val>+∞</emu-val><sub>𝔽</sub></td>
         </tr>
         <tr>
-          <td><emu-val>"islamic"</emu-val></td>
-          <td><emu-val>"ah"</emu-val></td>
-          <td></td>
-          <td><emu-val>1</emu-val><sub>𝔽</sub></td>
-          <td><emu-val>+∞</emu-val><sub>𝔽</sub></td>
-        </tr>
-        <tr>
-          <td><emu-val>"islamic"</emu-val></td>
-          <td><emu-val>"bh"</emu-val></td>
-          <td></td>
-          <td><emu-val>1</emu-val><sub>𝔽</sub></td>
-          <td><emu-val>+∞</emu-val><sub>𝔽</sub></td>
-        </tr>
-        <tr>
           <td><emu-val>"islamic-civil"</emu-val></td>
           <td><emu-val>"ah"</emu-val></td>
           <td></td>
@@ -4228,20 +4213,6 @@ p.ECMAaddress {
         </tr>
         <tr>
           <td><emu-val>"islamic-civil"</emu-val></td>
-          <td><emu-val>"bh"</emu-val></td>
-          <td></td>
-          <td><emu-val>1</emu-val><sub>𝔽</sub></td>
-          <td><emu-val>+∞</emu-val><sub>𝔽</sub></td>
-        </tr>
-        <tr>
-          <td><emu-val>"islamic-rgsa"</emu-val></td>
-          <td><emu-val>"ah"</emu-val></td>
-          <td></td>
-          <td><emu-val>1</emu-val><sub>𝔽</sub></td>
-          <td><emu-val>+∞</emu-val><sub>𝔽</sub></td>
-        </tr>
-        <tr>
-          <td><emu-val>"islamic-rgsa"</emu-val></td>
           <td><emu-val>"bh"</emu-val></td>
           <td></td>
           <td><emu-val>1</emu-val><sub>𝔽</sub></td>
@@ -4353,17 +4324,17 @@ p.ECMAaddress {
   </emu-clause>
 
   <emu-clause id="sec-temporal-canonicalizeeraincalendar" type="abstract operation" aoid="CanonicalizeEraInCalendar">
-    <h1><span class="secnum">2.2</span> CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )</h1>
+    <h1><span class="secnum">4.2</span> CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )</h1>
     <p>The abstract operation CanonicalizeEraInCalendar takes arguments <var>calendar</var> (a String) and <var>era</var> (a String) and returns a String or <emu-val>undefined</emu-val>. 
         The following algorithm refers to the era data from <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Data">UTS 35's Supplemental Calendar Data</a>.
        It performs the following steps when called:</p>
-    <emu-alg><ol><li>For each row of <emu-xref href="#table-eras" id="_ref_2"><a href="#table-eras">Table 2</a></emu-xref>, do<ol><li>Let <var>cal</var> be the Calendar value of the current row.</li><li>If <var>cal</var> is equal to <var>calendar</var>, then<ol><li>Let <var>e</var> be the Era value of the current row.</li><li>If <var>e</var> is equal to <var>era</var>, return <var>era</var>.</li><li>Let <var>aliases</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the strings given in the Aliases column of the row.</li><li>If <var>aliases</var> contains <var>era</var>, return <var>era</var>.</li></ol></li></ol></li><li>Return <emu-val>undefined</emu-val>.</li></ol></emu-alg>
+    <emu-alg><ol><li>For each row of <emu-xref href="#table-eras" id="_ref_4"><a href="#table-eras">Table 2</a></emu-xref>, do<ol><li>Let <var>cal</var> be the Calendar value of the current row.</li><li>If <var>cal</var> is equal to <var>calendar</var>, then<ol><li>Let <var>e</var> be the Era value of the current row.</li><li>If <var>e</var> is equal to <var>era</var>, return <var>era</var>.</li><li>Let <var>aliases</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the strings given in the Aliases column of the row.</li><li>If <var>aliases</var> contains <var>era</var>, return <var>era</var>.</li></ol></li></ol></li><li>Return <emu-val>undefined</emu-val>.</li></ol></emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-isvalidmonthecodeforcalendar" type="abstract operation" aoid="IsValidMonthCodeForCalendar">
-    <h1><span class="secnum">2.3</span> IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )</h1>
+    <h1><span class="secnum">4.3</span> IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )</h1>
     <p>The abstract operation IsValidMonthCodeForCalendar takes arguments <var>calendar</var> (a String) and <var>monthCode</var> (a String) and returns a Boolean. It performs the following steps when called:</p>
-    <emu-alg><ol><li>Let <var>commonMonthCodes</var> be « <emu-val>"M01"</emu-val>, <emu-val>"M02"</emu-val>, <emu-val>"M03"</emu-val>, <emu-val>"M04"</emu-val>, <emu-val>"M05"</emu-val>, <emu-val>"M06"</emu-val>, <emu-val>"M07"</emu-val>, <emu-val>"M08"</emu-val>, <emu-val>"M09"</emu-val>, <emu-val>"M10"</emu-val>, <emu-val>"M11"</emu-val>, <emu-val>"M12"</emu-val>&nbsp;».</li><li>If <var>commonMonthCodes</var> contains <var>monthCode</var>, return <emu-val>true</emu-val>.</li><li>If <var>calendar</var> is not listed in the Calendar column of <emu-xref href="#table-additional-month-codes" id="_ref_3"><a href="#table-additional-month-codes">Table 3</a></emu-xref>, return <emu-val>false</emu-val>.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-additional-month-codes" id="_ref_4"><a href="#table-additional-month-codes">Table 3</a></emu-xref> which the <var>calendar</var> is in the Calendar column.</li><li>Let <var>specialMonthCodes</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the strings given in the <emu-val>"Additional Month Codes"</emu-val> column of <var>r</var>.</li><li>If <var>specialMonthCodes</var> contains <var>monthCode</var>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Let <var>commonMonthCodes</var> be « <emu-val>"M01"</emu-val>, <emu-val>"M02"</emu-val>, <emu-val>"M03"</emu-val>, <emu-val>"M04"</emu-val>, <emu-val>"M05"</emu-val>, <emu-val>"M06"</emu-val>, <emu-val>"M07"</emu-val>, <emu-val>"M08"</emu-val>, <emu-val>"M09"</emu-val>, <emu-val>"M10"</emu-val>, <emu-val>"M11"</emu-val>, <emu-val>"M12"</emu-val>&nbsp;».</li><li>If <var>commonMonthCodes</var> contains <var>monthCode</var>, return <emu-val>true</emu-val>.</li><li>If <var>calendar</var> is not listed in the Calendar column of <emu-xref href="#table-additional-month-codes" id="_ref_5"><a href="#table-additional-month-codes">Table 3</a></emu-xref>, return <emu-val>false</emu-val>.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-additional-month-codes" id="_ref_6"><a href="#table-additional-month-codes">Table 3</a></emu-xref> which the <var>calendar</var> is in the Calendar column.</li><li>Let <var>specialMonthCodes</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the strings given in the <emu-val>"Additional Month Codes"</emu-val> column of <var>r</var>.</li><li>If <var>specialMonthCodes</var> contains <var>monthCode</var>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
 
     <emu-table id="table-additional-month-codes"><figure><figcaption>Table 3: Additional Month Codes in Calendars</figcaption>
       
@@ -4403,22 +4374,22 @@ p.ECMAaddress {
   </emu-clause>
 
   <emu-clause id="sec-temporal-isvaliderayearforcalendar" type="abstract operation" aoid="IsValidEraYearForCalendar">
-    <h1><span class="secnum">2.4</span> IsValidEraYearForCalendar ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )</h1>
+    <h1><span class="secnum">4.4</span> IsValidEraYearForCalendar ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )</h1>
     <p>The abstract operation IsValidEraYearForCalendar takes arguments <var>calendar</var> (a String), <var>era</var> (a String), and <var>eraYear</var> (a <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns a Boolean. 
         The following algorithm refers to the era data from <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Data">UTS 35's Supplemental Calendar Data</a>.
        It performs the following steps when called:</p>
-    <emu-alg><ol><li>Let <var>era</var> be <emu-xref aoid="CanonicalizeEraInCalendar" id="_ref_11"><a href="#sec-temporal-canonicalizeeraincalendar">CanonicalizeEraInCalendar</a></emu-xref>(<var>calendar</var>, <var>era</var>).</li><li>If <var>era</var> is <emu-val>undefined</emu-val>, return <emu-val>false</emu-val>.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-eras" id="_ref_5"><a href="#table-eras">Table 2</a></emu-xref> which the <var>calendar</var> is in the Calendar column and the <var>era</var> is in the Era column.</li><li>Let <var>min</var> be the value given in the <emu-val>"Minimum eraYear"</emu-val> column of <var>r</var>.</li><li>Let <var>max</var> be the value given in the <emu-val>"Maximum eraYear"</emu-val> column of <var>r</var>.</li><li>If <var>eraYear</var> &lt; <var>min</var>, return <emu-val>false</emu-val>.</li><li>If <var>eraYear</var> &gt; <var>max</var>, return <emu-val>false</emu-val>.</li><li>Return <emu-val>true</emu-val>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Let <var>era</var> be <emu-xref aoid="CanonicalizeEraInCalendar" id="_ref_15"><a href="#sec-temporal-canonicalizeeraincalendar">CanonicalizeEraInCalendar</a></emu-xref>(<var>calendar</var>, <var>era</var>).</li><li>If <var>era</var> is <emu-val>undefined</emu-val>, return <emu-val>false</emu-val>.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-eras" id="_ref_7"><a href="#table-eras">Table 2</a></emu-xref> which the <var>calendar</var> is in the Calendar column and the <var>era</var> is in the Era column.</li><li>Let <var>min</var> be the value given in the <emu-val>"Minimum eraYear"</emu-val> column of <var>r</var>.</li><li>Let <var>max</var> be the value given in the <emu-val>"Maximum eraYear"</emu-val> column of <var>r</var>.</li><li>If <var>eraYear</var> &lt; <var>min</var>, return <emu-val>false</emu-val>.</li><li>If <var>eraYear</var> &gt; <var>max</var>, return <emu-val>false</emu-val>.</li><li>Return <emu-val>true</emu-val>.</li></ol></emu-alg>
   </emu-clause>
 
   <emu-clause id="sup-temporal-calendar-date-records">
-    <h1><span class="secnum">2.5</span> Calendar Date Records</h1>
+    <h1><span class="secnum">4.5</span> Calendar Date Records</h1>
     <p>
       A <dfn variants="Calendar Date Records" tabindex="-1">Calendar Date Record</dfn> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> value used to represent a valid calendar date in a non-ISO 8601 calendar.
       Calendar Date Records are produced by the abstract operation CalendarISOToDate.
     </p>
-    <p>Calendar Date Records have the fields listed in <emu-xref href="#table-temporal-calendar-date-record-fields" id="_ref_6"><a href="#table-temporal-calendar-date-record-fields">Table 4</a></emu-xref>.</p>
+    <p>Calendar Date Records have the fields listed in <emu-xref href="#table-temporal-calendar-date-record-fields" id="_ref_8"><a href="#table-temporal-calendar-date-record-fields">Table 4</a></emu-xref>.</p>
     <p>This definition supersedes the one in <emu-xref href="#sec-temporal-calendar-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendar-date-records">Calendar Date Records</a></emu-xref>.</p>
-    <emu-table id="table-temporal-calendar-date-record-fields" caption="Calendar Date Record Fields"><figure><figcaption>Table 4: <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_12"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref> Fields</figcaption>
+    <emu-table id="table-temporal-calendar-date-record-fields" caption="Calendar Date Record Fields"><figure><figcaption>Table 4: <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_16"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref> Fields</figcaption>
       <table class="real-table">
         <tbody><tr>
           <th>Field Name</th>
@@ -4430,7 +4401,7 @@ p.ECMAaddress {
           <td>a String or <emu-val>undefined</emu-val></td>
           <td>
             A lowercase String value representing the date's era, or <emu-val>undefined</emu-val> for calendars that do not have eras.<br>
-            The value of this field for a calendar with the identifier <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateEra" id="_ref_13"><a href="#sec-temporal-calendardateera">CalendarDateEra</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
+            The value of this field for a calendar with the identifier <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateEra" id="_ref_17"><a href="#sec-temporal-calendardateera">CalendarDateEra</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
           </td>
         </tr>
         <tr>
@@ -4438,7 +4409,7 @@ p.ECMAaddress {
           <td>an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> or <emu-val>undefined</emu-val></td>
           <td>
             The ordinal position of the date's year within its era, or <emu-val>undefined</emu-val> for calendars that do not have eras.<br>
-            The value of this field for a calendar with the identifier <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateEraYear" id="_ref_14"><a href="#sec-temporal-calendardateerayear">CalendarDateEraYear</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
+            The value of this field for a calendar with the identifier <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateEraYear" id="_ref_18"><a href="#sec-temporal-calendardateerayear">CalendarDateEraYear</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
             <emu-note><span class="note">Note 1</span><div class="note-contents">
               Era years are 1-indexed for many calendars, but not all (e.g., the eras of the Burmese calendar each start with a year 0). Years can also advance opposite the flow of time (as for BCE years in the Gregorian calendar).
             </div></emu-note>
@@ -4449,7 +4420,7 @@ p.ECMAaddress {
           <td>an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
           <td>
             The date's year relative to the first day of a calendar-specific "epoch year".<br>
-            The value of this field for a calendar with the identifier <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateArithmeticYear" id="_ref_15"><a href="#sec-temporal-calendardatearithmeticyear">CalendarDateArithmeticYear</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
+            The value of this field for a calendar with the identifier <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateArithmeticYear" id="_ref_19"><a href="#sec-temporal-calendardatearithmeticyear">CalendarDateArithmeticYear</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
             <emu-note><span class="note">Note 2</span><div class="note-contents">The year is relative to the first day of the calendar's epoch year, so if the epoch era starts in the middle of the year, the year will be the same value before and after the start date of the era.</div></emu-note>
           </td>
         </tr>
@@ -4500,9 +4471,9 @@ p.ECMAaddress {
           <td>
             <p>The date's <em>calendar week of year</em>, and the corresponding <em>week calendar year</em>.</p>
             <p>The <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Week]]</var> field should be 1-based.</p>
-            <p>The <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Year]]</var> field is relative to the first day of a calendar-specific "epoch year", as in the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_16"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref>'s <var class="field">[[Year]]</var> field, not relative to an era as in <var class="field">[[EraYear]]</var>.</p>
+            <p>The <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Year]]</var> field is relative to the first day of a calendar-specific "epoch year", as in the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_20"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref>'s <var class="field">[[Year]]</var> field, not relative to an era as in <var class="field">[[EraYear]]</var>.</p>
             <p>
-              Usually the <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Year]]</var> field will contain the same value as the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_17"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref>'s <var class="field">[[Year]]</var> field, but may contain the previous or next year if the week number in the <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Week]]</var> field overlaps two different years.
+              Usually the <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Year]]</var> field will contain the same value as the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_21"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref>'s <var class="field">[[Year]]</var> field, but may contain the previous or next year if the week number in the <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Week]]</var> field overlaps two different years.
               See also ISOWeekOfYear.
             </p>
             <p>The <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref> contains <emu-val>undefined</emu-val> in <var class="field">[[Week]]</var> and <var class="field">[[Year]]</var> field for calendars that do not have a well-defined week numbering system.</p>
@@ -4548,25 +4519,25 @@ p.ECMAaddress {
   </emu-clause>
 
   <emu-clause id="sec-temporal-calendardateera" type="abstract operation" aoid="CalendarDateEra">
-    <h1><span class="secnum">2.6</span> CalendarDateEra ( <var>calendar</var>, <var>date</var> )</h1>
+    <h1><span class="secnum">4.6</span> CalendarDateEra ( <var>calendar</var>, <var>date</var> )</h1>
     <p>The abstract operation CalendarDateEra takes arguments <var>calendar</var> (a String) and <var>date</var> (a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth) and returns a String or <emu-val>undefined</emu-val>. It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to find the era for the date corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> and returns a lowercase String value representing that era, or <emu-val>undefined</emu-val> for calendars that do not have eras. It performs the following steps when called:</p>
-    <emu-alg><ol><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_18"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>false</emu-val>, return <emu-val>undefined</emu-val>.</li><li>Let <var>era</var> be the String to indicate the era corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> from an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li>Return <emu-xref aoid="CanonicalizeEraInCalendar" id="_ref_19"><a href="#sec-temporal-canonicalizeeraincalendar">CanonicalizeEraInCalendar</a></emu-xref>(<var>calendar</var>, <var>era</var>).</li></ol></emu-alg>
+    <emu-alg><ol><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_22"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>false</emu-val>, return <emu-val>undefined</emu-val>.</li><li>Let <var>era</var> be the String to indicate the era corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> from an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li>Return <emu-xref aoid="CanonicalizeEraInCalendar" id="_ref_23"><a href="#sec-temporal-canonicalizeeraincalendar">CanonicalizeEraInCalendar</a></emu-xref>(<var>calendar</var>, <var>era</var>).</li></ol></emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-calendardateerayear" type="abstract operation" aoid="CalendarDateEraYear">
-    <h1><span class="secnum">2.7</span> CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )</h1>
+    <h1><span class="secnum">4.7</span> CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )</h1>
     <p>The abstract operation CalendarDateEraYear takes arguments <var>calendar</var> (a String) and <var>date</var> (a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth) and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> or <emu-val>undefined</emu-val>. It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to find the era for the date corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> representing the ordinal position of the year of <var>date</var> in that era, or <emu-val>undefined</emu-val> for calendars that do not have eras. It performs the following steps when called:</p>
     
-    <emu-alg><ol><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_20"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>false</emu-val>, return <emu-val>undefined</emu-val>.</li><li>Let <var>eraYear</var> be the <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> to indicate the era year corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> from an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>eraYear</var> is an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>.</li><li>Return <var>eraYear</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_24"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>false</emu-val>, return <emu-val>undefined</emu-val>.</li><li>Let <var>eraYear</var> be the <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> to indicate the era year corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> from an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>eraYear</var> is an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>.</li><li>Return <var>eraYear</var>.</li></ol></emu-alg>
     <emu-note><span class="note">Note</span><div class="note-contents">
       Era years are 1-indexed for many calendars, but not all (e.g., the eras of the Burmese calendar each start with a year 0). Years can also advance opposite the flow of time (as for BCE years in the Gregorian calendar).
     </div></emu-note>
   </emu-clause>
 
   <emu-clause id="sec-temporal-calendardatearithmeticyear" type="abstract operation" aoid="CalendarDateArithmeticYear">
-    <h1><span class="secnum">2.8</span> CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )</h1>
-    <p>The abstract operation CalendarDateArithmeticYear takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_21"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>date</var> (a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth) and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>. It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to find the year for the date corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> relative to a well-defined epoch year for that calendar. It performs the following steps when called:</p>
-    <emu-alg><ol><li>Let <var>year</var> be <var>date</var>.<var class="field">[[ISOYear]]</var>.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-epoch-years" id="_ref_7"><a href="#table-epoch-years">Table 5</a></emu-xref> which the value of the Calendar column is <var>calendar</var>.</li><li>Let <var>epochYear</var> be the value given in the <emu-val>"Epoch ISO Year"</emu-val> column of <var>r</var>.</li><li>Let <var>arithmeticYear</var> be the number of whole years in the calendar represented by <var>calendar</var> elapsed until the ISO year <var>year</var> since the calendar year that started during ISO year <var>epochYear</var>, according to <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li>Return <var>arithmeticYear</var>.</li></ol></emu-alg>
+    <h1><span class="secnum">4.8</span> CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )</h1>
+    <p>The abstract operation CalendarDateArithmeticYear takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_25"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>date</var> (a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth) and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>. It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to find the year for the date corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> relative to a well-defined epoch year for that calendar. It performs the following steps when called:</p>
+    <emu-alg><ol><li>Let <var>year</var> be <var>date</var>.<var class="field">[[ISOYear]]</var>.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-epoch-years" id="_ref_9"><a href="#table-epoch-years">Table 5</a></emu-xref> which the value of the Calendar column is <var>calendar</var>.</li><li>Let <var>epochYear</var> be the value given in the <emu-val>"Epoch ISO Year"</emu-val> column of <var>r</var>.</li><li>Let <var>arithmeticYear</var> be the number of whole years in the calendar represented by <var>calendar</var> elapsed until the ISO year <var>year</var> since the calendar year that started during ISO year <var>epochYear</var>, according to <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li>Return <var>arithmeticYear</var>.</li></ol></emu-alg>
 
     <emu-table id="table-epoch-years"><figure><figcaption>Table 5: epoch years</figcaption>
       
@@ -4614,15 +4585,7 @@ p.ECMAaddress {
           <td>78</td>
         </tr>
         <tr>
-          <td><emu-val>"islamic"</emu-val></td>
-          <td>621</td>
-        </tr>
-        <tr>
           <td><emu-val>"islamic-civil"</emu-val></td>
-          <td>621</td>
-        </tr>
-        <tr>
-          <td><emu-val>"islamic-rgsa"</emu-val></td>
           <td>621</td>
         </tr>
         <tr>
@@ -4650,8 +4613,8 @@ p.ECMAaddress {
   </emu-clause>
 
   <emu-clause id="sup-temporal-calendardateuntil" type="implementation-defined abstract operation" aoid="CalendarDateUntil">
-    <h1><span class="secnum">2.9</span> CalendarDateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )</h1>
-    <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation CalendarDateUntil takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_22"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref>), <var>one</var> (an ISO Date <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>), <var>two</var> (an ISO Date <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>), and <var>largestUnit</var> (a date unit) and returns a <emu-xref href="#sec-temporal-date-duration-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-date-duration-records">Date Duration Record</a></emu-xref>. 
+    <h1><span class="secnum">4.9</span> CalendarDateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )</h1>
+    <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation CalendarDateUntil takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_26"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref>), <var>one</var> (an ISO Date <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>), <var>two</var> (an ISO Date <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>), and <var>largestUnit</var> (a date unit) and returns a <emu-xref href="#sec-temporal-date-duration-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-date-duration-records">Date Duration Record</a></emu-xref>. 
         It determines the difference between the dates <var>one</var> and <var>two</var> using the years, months, and weeks reckoning of <var>calendar</var>.
         No fields larger than <var>largestUnit</var> will be non-zero in the resulting <emu-xref href="#sec-temporal-date-duration-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-date-duration-records">Date Duration Record</a></emu-xref>.
       </p>
@@ -4661,20 +4624,20 @@ p.ECMAaddress {
   </emu-clause>
 
   <emu-clause id="sup-temporal-calendarextrafields" type="implementation-defined abstract operation" aoid="CalendarExtraFields">
-    <h1><span class="secnum">2.10</span> CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )</h1>
-    <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation CalendarExtraFields takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_23"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref>) and <var>fields</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>) and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>. It characterizes calendar-specific fields that are relevant for the provided <var>fields</var> in the built-in calendar identified by <var>calendar</var>.</p>
+    <h1><span class="secnum">4.10</span> CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )</h1>
+    <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation CalendarExtraFields takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_27"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref>) and <var>fields</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>) and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>. It characterizes calendar-specific fields that are relevant for the provided <var>fields</var> in the built-in calendar identified by <var>calendar</var>.</p>
     <p>This definition supersedes the definition provided in <emu-xref aoid="TemporalCalendarExtraFields"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarextrafields">TemporalCalendarExtraFields</a></emu-xref>.</p>
-    <emu-alg><ol><li>If <var>fields</var> contains an element equal to <emu-const>year</emu-const> and <emu-xref aoid="CalendarSupportsEra" id="_ref_24"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val>, then<ol><li>Append <emu-const>era</emu-const> and <emu-const>era-year</emu-const> to <var>fields</var>.</li></ol></li><li>Return <var>fields</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <var>fields</var> contains an element equal to <emu-const>year</emu-const> and <emu-xref aoid="CalendarSupportsEra" id="_ref_28"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val>, then<ol><li>Append <emu-const>era</emu-const> and <emu-const>era-year</emu-const> to <var>fields</var>.</li></ol></li><li>Return <var>fields</var>.</li></ol></emu-alg>
   </emu-clause>
 
   <emu-clause id="sup-temporal-calendarfieldkeystoignore" type="implementation-defined abstract operation" aoid="CalendarFieldKeysToIgnore">
-    <h1><span class="secnum">2.11</span> CalendarFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )</h1>
-    <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation CalendarFieldKeysToIgnore takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_25"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref>) and <var>keys</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>) and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>. 
+    <h1><span class="secnum">4.11</span> CalendarFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )</h1>
+    <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation CalendarFieldKeysToIgnore takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_29"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref>) and <var>keys</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>) and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>. 
         It determines which calendar date fields changing any of the fields named in <var>keys</var> can potentially conflict with or invalidate, for the given <var>calendar</var>.
         A field always invalidates at least itself.
       </p>
     <p>This definition supersedes the definition provided in <emu-xref aoid="TemporalCalendarFieldKeysToIgnore"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarfieldkeystoignore">TemporalCalendarFieldKeysToIgnore</a></emu-xref>.</p>
-    <emu-alg><ol><li>Let <var>ignoredKeys</var> be an empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>For each element <var>key</var> of <var>keys</var>, do<ol><li>If <var>key</var> is <emu-const>month</emu-const>, append <emu-const>month-code</emu-const> to <var>ignoredKeys</var>.</li><li>Else if <var>key</var> is <emu-const>month-code</emu-const>, append <emu-const>month</emu-const> to <var>ignoredKeys</var>.</li><li>If <var>key</var> is one of <emu-const>era</emu-const>, <emu-const>era-year</emu-const>, or <emu-const>year</emu-const> and <emu-xref aoid="CalendarSupportsEra" id="_ref_26"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val>, then<ol><li>Append <emu-const>era</emu-const>, <emu-const>era-year</emu-const>, and <emu-const>year</emu-const> to <var>ignoredKeys</var>.</li></ol></li><li>Else,<ol><li>Append <var>key</var> to <var>ignoredKeys</var>.</li></ol></li></ol></li><li>NOTE: While <var>ignoredKeys</var> can have duplicate elements, this is not intended to be meaningful. This specification only checks whether particular keys are or are not members of the list.</li><li>Return <var>ignoredKeys</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Let <var>ignoredKeys</var> be an empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>For each element <var>key</var> of <var>keys</var>, do<ol><li>If <var>key</var> is <emu-const>month</emu-const>, append <emu-const>month-code</emu-const> to <var>ignoredKeys</var>.</li><li>Else if <var>key</var> is <emu-const>month-code</emu-const>, append <emu-const>month</emu-const> to <var>ignoredKeys</var>.</li><li>If <var>key</var> is one of <emu-const>era</emu-const>, <emu-const>era-year</emu-const>, or <emu-const>year</emu-const> and <emu-xref aoid="CalendarSupportsEra" id="_ref_30"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val>, then<ol><li>Append <emu-const>era</emu-const>, <emu-const>era-year</emu-const>, and <emu-const>year</emu-const> to <var>ignoredKeys</var>.</li></ol></li><li>Else,<ol><li>Append <var>key</var> to <var>ignoredKeys</var>.</li></ol></li></ol></li><li>NOTE: While <var>ignoredKeys</var> can have duplicate elements, this is not intended to be meaningful. This specification only checks whether particular keys are or are not members of the list.</li><li>Return <var>ignoredKeys</var>.</li></ol></emu-alg>
   </emu-clause>
 </emu-clause><emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "npm run build-loose -- --watch",
     "build": "npm run build-loose -- --strict",
-    "build-loose": "ecmarkup --load-biblio @tc39/ecma262-biblio --verbose spec.emu index.html --lint-spec",
+    "build-loose": "ecmarkup --load-biblio @tc39/ecma262-biblio --load-biblio @tc39/ecma402-biblio --verbose spec.emu index.html --lint-spec",
     "format": "emu-format --write spec.emu"
   },
   "homepage": "https://tc39.es/proposal-intl-era-monthcode/",
@@ -16,6 +16,7 @@
   "license": "MIT",
   "devDependencies": {
     "@tc39/ecma262-biblio": "2.0.2331",
+    "@tc39/ecma402-biblio": "=2.1.1191",
     "ecmarkup": "^21.3.0"
   }
 }

--- a/spec.emu
+++ b/spec.emu
@@ -90,24 +90,8 @@ contributors: Google, Ecma International
           <td>Indian national (or Śaka) calendar, proleptic. Solar calendar with one era.</td>
         </tr>
         <tr>
-          <td>*"islamic"*</td>
-          <td>Hijri calendar, proleptic, unspecified algorithm. Historically in browsers, this was an astronomical simulation whose parameters are undocumented and that is not known to match a specific Hijri calendar variant in use outside of software.
-            <emu-note type="editor">
-              See <a href="https://github.com/tc39/proposal-intl-era-monthcode/issues/29">issue #29</a>.
-            </emu-note>
-          </td>
-        </tr>
-        <tr>
           <td>*"islamic-civil"*</td>
           <td>Hijri calendar, proleptic, tabular/rule-based with leap years 2, 5, 7, 10, 13, 16, 18, 21, 24, 26, 29 in the 30-year cycle, and civil epoch (Friday July 16, 622 Julian / 0622-07-19 ISO)</td>
-        </tr>
-        <tr>
-          <td>*"islamic-rgsa"*</td>
-          <td>Hijri calendar, proleptic, Saudi Arabia sighting. Browsers do not have historical astronomical sighting data and future sightings have not occurred yet. Historically in browsers, this calendar has had identical behaviour to *"islamic"*.
-            <emu-note type="editor">
-              See <a href="https://github.com/tc39/proposal-intl-era-monthcode/issues/29">issue #29</a>.
-            </emu-note>
-          </td>
         </tr>
         <tr>
           <td>*"islamic-tbla"*</td>
@@ -140,6 +124,88 @@ contributors: Google, Ecma International
       </table>
     </emu-table>
   </ins>
+</emu-clause>
+
+<emu-clause id="locale-and-parameter-negotiation">
+  <h1>Locale and Parameter Negotiation</h1>
+
+  <emu-clause id="sec-internal-slots">
+    <h1>Internal slots of Service Constructors</h1>
+
+    <p>[...]</p>
+
+    <emu-note>
+      For example, an implementation of DateTimeFormat might include the language tag *"fa-IR"* in its [[AvailableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the keys *"ca"*, *"hc"*, and *"nu"* in its [[RelevantExtensionKeys]] internal slot.
+      The default calendar for that locale is usually *"persian"*, but an implementation might also support *"gregory"*<del>, *"islamic"*,</del> and *"islamic-civil"*.
+      The Record in the DateTimeFormat [[LocaleData]] internal slot would therefore include a [[fa-IR]] field whose value is a Record like { [[ca]]: « *"persian"*, *"gregory"*, <del>*"islamic"*,</del> *"islamic-civil"* », [[hc]]: « … », [[nu]]: « … » }, along with other locale-named fields having the same value shape but different elements in their Lists.
+    </emu-note>
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="ecma402-datetimeformat-objects">
+  <h1>DateTimeFormat Objects</h1>
+
+  <emu-clause id="sec-ecma402-intl-datetimeformat-constructor">
+    <h1>The Intl.DateTimeFormat Constructor</h1>
+
+    <emu-clause id="sec-createdatetimeformat" type="abstract operation" oldids="sec-initializedatetimeformat,sec-todatetimeoptions">
+      <h1>
+        CreateDateTimeFormat (
+          _newTarget_: a constructor,
+          _locales_: an ECMAScript language value,
+          _options_: an ECMAScript language value,
+          _required_: ~date~, ~time~, or ~any~,
+          _defaults_: ~date~, ~time~, or ~all~,
+        ): either a normal completion containing a DateTimeFormat object or a throw completion
+      </h1>
+
+      <dl class="header">
+      </dl>
+
+      <emu-alg>
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.DateTimeFormat.prototype%"*, « [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] »).
+        1. Let _hour12_ be *undefined*.
+        1. Let _modifyResolutionOptions_ be a new Abstract Closure with parameters (_options_) that captures _hour12_ and performs the following steps when called:
+          1. Set _hour12_ to _options_.[[hour12]].
+          1. Remove field [[hour12]] from _options_.
+          1. If _hour12_ is not *undefined*, set _options_.[[hc]] to *null*.
+        1. Let _optionsResolution_ be ? ResolveOptions(%Intl.DateTimeFormat%, %Intl.DateTimeFormat%.[[LocaleData]], _locales_, _options_, « ~coerce-options~ », _modifyResolutionOptions_).
+        1. Set _options_ to _optionsResolution_.[[Options]].
+        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Set _dateTimeFormat_.[[Locale]] to _r_.[[Locale]].
+        1. Let _resolvedCalendar_ be _r_.[[ca]].
+        1. <ins>If _resolvedCalendar_ is *"islamic"* or *"islamic-rgsa"*, then</ins>
+          1. <ins>Let _fallbackCalendar_ be an implementation- and locale-defined calendar type that is one of the values returned from AvailableCalendars.</ins>
+          1. <ins>Set _fallbackCalendar_ to CanonicalizeUValue(*"ca"*, _fallbackCalendar_).</ins>
+          1. <ins>Set _resolvedCalendar_ to _fallbackCalendar_.</ins>
+        1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
+        1. NOTE: Rest of algorithm unchanged.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-ecma402-properties-of-intl-datetimeformat-constructor">
+    <h1>Properties of the Intl.DateTimeFormat Constructor</h1>
+
+    <emu-clause id="sec-ecma402-intl.datetimeformat-internal-slots">
+      <h1>Internal slots</h1>
+
+      <p>[...]</p>
+
+      <p>The value of the [[LocaleData]] internal slot is implementation-defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints, for all locale values _locale_:</p>
+
+      <ul>
+        <li><ins>[[LocaleData]].[[&lt;_locale_>]].[[ca]] must be a List consisting of values from the Calendar Type column of <emu-xref href="#table-calendar-types"></emu-xref>. The list may also include *"islamic"* and *"islamic-rgsa"*.</ins></li>
+        <li>
+          [[LocaleData]].[[&lt;_locale_>]].[[nu]] must be a List that does not include the values *"native"*, *"traditio"*, or *"finance"*.
+        </li>
+        <li>
+          [[LocaleData]].[[&lt;_locale_>]].[[hc]] must be « *null*, *"h11"*, *"h12"*, *"h23"*, *"h24"* ».
+        </li>
+        <li>[...]</li>
+      </ul>
+    </emu-clause>
+  </emu-clause>
 </emu-clause>
 
 <emu-clause id="sup-temporal-calendar-abstract-ops">
@@ -237,20 +303,6 @@ contributors: Google, Ecma International
           <td>*+∞*<sub>𝔽</sub></td>
         </tr>
         <tr>
-          <td>*"islamic"*</td>
-          <td>*"ah"*</td>
-          <td></td>
-          <td>*1*<sub>𝔽</sub></td>
-          <td>*+∞*<sub>𝔽</sub></td>
-        </tr>
-        <tr>
-          <td>*"islamic"*</td>
-          <td>*"bh"*</td>
-          <td></td>
-          <td>*1*<sub>𝔽</sub></td>
-          <td>*+∞*<sub>𝔽</sub></td>
-        </tr>
-        <tr>
           <td>*"islamic-civil"*</td>
           <td>*"ah"*</td>
           <td></td>
@@ -259,20 +311,6 @@ contributors: Google, Ecma International
         </tr>
         <tr>
           <td>*"islamic-civil"*</td>
-          <td>*"bh"*</td>
-          <td></td>
-          <td>*1*<sub>𝔽</sub></td>
-          <td>*+∞*<sub>𝔽</sub></td>
-        </tr>
-        <tr>
-          <td>*"islamic-rgsa"*</td>
-          <td>*"ah"*</td>
-          <td></td>
-          <td>*1*<sub>𝔽</sub></td>
-          <td>*+∞*<sub>𝔽</sub></td>
-        </tr>
-        <tr>
-          <td>*"islamic-rgsa"*</td>
           <td>*"bh"*</td>
           <td></td>
           <td>*1*<sub>𝔽</sub></td>
@@ -733,15 +771,7 @@ contributors: Google, Ecma International
           <td>78</td>
         </tr>
         <tr>
-          <td>*"islamic"*</td>
-          <td>621</td>
-        </tr>
-        <tr>
           <td>*"islamic-civil"*</td>
-          <td>621</td>
-        </tr>
-        <tr>
-          <td>*"islamic-rgsa"*</td>
           <td>621</td>
         </tr>
         <tr>


### PR DESCRIPTION
These two calendars have been present on the web for a long time, but their behaviour does not match any Hijri calendar algorithm in use in the real world outside of software. So anyone using these calendar IDs is probably not getting what they expect to get.

When creating a DateTimeFormat with one of these calendar IDs, we specify a fallback, which is implementation- and locale-defined, but must be one of the available non-alias calendar IDs. This way, implementations could choose to fall back to one of the other Hijri calendars depending on the locale. resolvedOptions().calendar will show which fallback was chosen.

They are removed from AvailableCalendars, which removes them from supportedValuesOf("calendar") and from Temporal APIs. Note that the result of resolvedOptions().calendar can still be passed to any Temporal API.

Closes: #29