### PR TITLE
Normative: Add calendar authority for Japanese Imperial era names

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -114,7 +114,7 @@ contributors: Google, Ecma International
           </tr>
           <tr>
             <td>*"japanese"*</td>
-            <td>Japanese Imperial calendar, era system hybridised with *"gregory"*. Month numbers, month codes, and days are the same as in the ISO 8601 calendar, extended proleptically before their introduction in ISO year 1873. Imperial era names only extend as far back as the Meiji period (starting in ISO year 1868) during which calendar reforms took place. The arithmetic year, and the years and eras before ISO year 1868, are identical to *"gregory"*.</td>
+            <td>Japanese Imperial calendar, era system hybridised with *"gregory"*. Month numbers, month codes, and days are the same as in the ISO 8601 calendar, extended proleptically before their introduction in ISO year 1873. Imperial era names only extend as far back as the Meiji period (starting in ISO year 1868) during which calendar reforms took place. All era names are defined by the Japanese government. The arithmetic year, and the years and eras before ISO year 1868, are identical to *"gregory"*.</td>
           </tr>
           <tr>
             <td>*"persian"*</td>


### PR DESCRIPTION
Added wording specifying that Japanese Imperial era names are defined by the Japanese government. 

See [The Historical Background of How Japan Chooses Its Era Names](https://www.nippon.com/en/in-depth/a05403/). Key quote:

> The Era Name Law is Japan’s shortest law, consisting of just two sentences: “1. The era name shall be determined by cabinet ordinance. 2. The era name shall be changed only in the case of a succession to the imperial throne.”

Also see description of the Japanese Imperial calendar system used in [documentation for Java's JapaneseEra class](https://docs.oracle.com/javase/8/docs/api/java/time/chrono/JapaneseEra.html):

> The Japanese government defines the official name and start date of each era.
