### PR TITLE
Editorial: Address high-priority points from TG2 editor review

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -244,7 +244,7 @@ contributors: Google, Ecma International
       from the epoch, so 1 Era is an arithmetic year of 0, and larger [[EraYear]] values produce smaller, negative arithmetic years. An *Era kind* of
       ~offset~ means that the era is "offset" by a given number (in the *Offset* column), so 1 Era has an arithmetic year of *Offset*.</p>
       <emu-table id="table-eras">
-        <emu-caption>era aliases, range of eraYear, and era kinds</emu-caption>
+        <emu-caption>Eras</emu-caption>
         <table class="real-table">
           <thead>
             <tr>


### PR DESCRIPTION
Addresses the following points from #51:

-  "arithmetic year" and "epoch year" should be defined terms.
- But also [CalendarSupportsEra](https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-calendarsupportsera) does not actually refer to era data from [UTS #35 Part 4: Dates](https://unicode.org/reports/tr35/tr35-dates.html), and I'm particularly concerned about the hard-coding—for example, conformance requires that eras for the Japanese calendar forever end with "reiwa", which does not match my expectations for that calendar type. I think the algorithms that claim to refer to that link are in fact missing such reference.
- In a similar vein, [AvailableCalendars](https://tc39.es/proposal-intl-era-monthcode/#sup-availablecalendars) requires the returned list to include calendar types from the table, but does not constrain implementations to those calendar types—which is good IMO, but the later algorithms seems to assume that implementations are so constrained (e.g., [CalendarSupportsEra](https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-calendarsupportsera) and [CanonicalizeEraInCalendar](https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-canonicalizeeraincalendar) require negative responses for any calendar type not in the eras table and [CanonicalizeEraInCalendar](https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-canonicalizeeraincalendar) requires returning false for any calendar type that is not "japanese"). I suggest rewording the algorithms to include implementation-defined behavior for calendar types that are not explicitly described (and note that some of those tables are incomplete because their data is not applicable to a given calendar type, so a step like e.g. «If calendar is not listed in the Calendar column of Table 3, return false.» would need explicit constraint to calendar values that do exist in the first new table).