### PR TITLE
Bug fix:  remove spurious normative change introduced in conversion from prose algorithm descriptions

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -59,6 +59,11 @@
             },
             {
                 "type": "op",
+                "aoid": "CompareSurpasses",
+                "id": "sec-temporal-comparesurpasses"
+            },
+            {
+                "type": "op",
                 "aoid": "CreateDateDurationRecord",
                 "id": "sec-temporal-createdatedurationrecord"
             },

--- a/spec.emu
+++ b/spec.emu
@@ -1116,32 +1116,22 @@ contributors: Google, Ecma International
       <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _parts_ be CalendarISOToDate(_calendar_, _fromIsoDate_).
-        1. Let _y0_ be _parts_.[[Year]] + _years_.
-        1. Let _m0_ be MonthCodeToOrdinal(_calendar_, _y0_, ! ConstrainMonthCode(_calendar_, _y0_, _parts_.[[MonthCode]], ~constrain~)).
-        1. Let _endOfMonth_ be BalanceNonISODate(_calendar_, _y0_, _m0_ + _months_ + 1, 0).
-        1. Let _baseDay_ be _parts_.[[Day]].
-        1. If _weeks_ is not 0 or _days_ is not 0, then
-          1. If _baseDay_ &le; _endOfMonth_.[[Day]], then
-            1. Let _regulatedDay_ be _baseDay_.
-          1. Else,
-            1. Let _regulatedDay_ be _endOfMonth_.[[Day]].
-          1. Let _daysInWeek_ be 7 (the number of days in a week for all supported calendars).
-          1. Let _balancedDate_ be BalanceNonISODate(_calendar_, _endOfMonth_.[[Year]], _endOfMonth_.[[Month]], _regulatedDay_ + _daysInWeek_ * _weeks_ + _days_).
-          1. Let _y1_ be _balancedDate_.[[Year]].
-          1. Let _m1_ be _balancedDate_.[[Month]].
-          1. Let _d1_ be _balancedDate_.[[Day]].
-        1. Else,
-          1. Let _y1_ be _endOfMonth_.[[Year]].
-          1. Let _m1_ be _endOfMonth_.[[Month]].
-          1. Let _d1_ be _baseDay_.
         1. Let _calDate2_ be CalendarISOToDate(_calendar_, _toIsoDate_).
-        1. If _y1_ ≠ _calDate2_.[[Year]], then
-          1. If _sign_ × (_y1_ - _calDate2_.[[Year]]) > 0, return *true*.
-        1. Else if _m1_ ≠ _calDate2_.[[Month]], then
-          1. If _sign_ × (_m1_ - _calDate2_.[[Month]]) > 0, return *true*.
-        1. Else if _d1_ ≠ _calDate2_.[[Day]], then
-          1. If _sign_ × (_d1_ - _calDate2_.[[Day]]) > 0, return *true*.
-        1. Return *false*.
+        1. Let _y0_ be _parts_.[[Year]] + _years_.
+        1. If CompareSurpasses(_sign_, _y0_, _parts_.[[MonthCode]], _parts_.[[Day]], _calDate2_) is *true*, return *true*.
+        1. Let _m0_ be MonthCodeToOrdinal(_calendar_, _y0_, ! ConstrainMonthCode(_calendar_, _y0_, _parts_.[[MonthCode]], ~constrain~)).
+        1. Let _monthsAdded_ be BalanceNonISODate(_calendar_, _y0_, _m0_ + _months_, 1).
+        1. If CompareSurpasses(_sign_, _monthsAdded_.[[Year]], _monthsAdded_.[[Month]], _parts_.[[Day]], _calDate2_) is *true*, return *true*.
+        1. If _weeks_ = 0 and _days_ = 0, return *false*.
+        1. Let _endOfMonth_ be BalanceNonISODate(_calendar_, _monthsAdded_.[[Year]], _monthsAdded_.[[Month]] + 1, 0).
+        1. Let _baseDay_ be _parts_.[[Day]].
+        1. If _baseDay_ &le; _endOfMonth_.[[Day]], then
+          1. Let _regulatedDay_ be _baseDay_.
+        1. Else,
+          1. Let _regulatedDay_ be _endOfMonth_.[[Day]].
+        1. Let _daysInWeek_ be 7 (the number of days in a week for all supported calendars).
+        1. Let _balancedDate_ be BalanceNonISODate(_calendar_, _endOfMonth_.[[Year]], _endOfMonth_.[[Month]], _regulatedDay_ + _daysInWeek_ * _weeks_ + _days_).
+        1. Return CompareSurpasses(_sign_, _balancedDate_.[[Year]], _balancedDate_.[[Month]], _balancedDate_.[[Day]], _calDate2_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Fix https://github.com/tc39/proposal-intl-era-monthcode/issues/96

The replacement of the prose algorithm for `NonISODateUntil` carried out by 0a7577f386d6f919a371a9037727c53e7c8b8597 introduced an unwanted normative change: whereas the prose algorithm lexicographically compared the month codes in the candidate date and the target date when determining whether the candidate date "surpasses" the target date, _without constraining_ the month given in the candidate date to one that exists in the year in the candidate date, the new algorithm steps constrains the month code of the candidate date, converts it to an ordinal month, and then compares that ordinal month to the month of the target date.

The accidental normative change is only visible when
1. The requested calendar is a lunisolar calendar that uses the ~skip-forward~ leap to common month transformation (in practice, only the hebrew calendar)
2. The date given by the `_two_` parameter of `NonISODateUntil` is before the date given in the `_one_` parameter

This PR introduces a new AO,
`NonISODateUnconstrainedMonthSurpasses`, which is called when determining the number of years required to "surpass" the target date, restoring the original behavior.