### PR TITLE
Normative: Indicate ISO date 1868-10-23 as start of Meiji era

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,5069 @@
+<!doctype html>
+<head><meta name="viewport" content="width=device-width, initial-scale=1"><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="Intl era and monthCode Proposal"><meta property="og:description" content="Identification of Locales, Currencies, Time Zones, Measurement Units, Numbering Systems, Collations, and Calendars
+
+  
+    Calendar Types
+
+    
+      
+        This section, Calendar Types, is present in ECMA-402 but is slated to move to ECMA-262 as part of the Temporal proposal.
+        This prop">
+<title>Intl era and monthCode Proposal</title><script>'use strict';
+let sdoBox = {
+  init() {
+    this.$alternativeId = null;
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$displayLink = document.createElement('a');
+    this.$displayLink.setAttribute('href', '#');
+    this.$displayLink.textContent = 'Syntax-Directed Operations';
+    this.$displayLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showSDOs(sdoMap[this.$alternativeId] || {}, this.$alternativeId);
+    });
+    this.$container.appendChild(this.$displayLink);
+    this.$outer.appendChild(this.$container);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el) {
+    clearTimeout(this.deactiveTimeout);
+    Toolbox.deactivate();
+    this.$alternativeId = el.id;
+    let numSdos = Object.keys(sdoMap[this.$alternativeId] || {}).length;
+    this.$displayLink.textContent = 'Syntax-Directed Operations (' + numSdos + ')';
+    this.$outer.classList.add('active');
+    let top = el.offsetTop - this.$outer.offsetHeight;
+    let left = el.offsetLeft + 50 - 10; // 50px = padding-left(=75px) + text-indent(=-25px)
+    this.$outer.setAttribute('style', 'left: ' + left + 'px; top: ' + top + 'px');
+    if (top < document.body.scrollTop) {
+      this.$container.scrollIntoView();
+    }
+  },
+
+  deactivate() {
+    clearTimeout(this.deactiveTimeout);
+    this.$outer.classList.remove('active');
+  },
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof sdoMap == 'undefined') {
+    console.error('could not find sdo map');
+    return;
+  }
+  sdoBox.init();
+
+  let insideTooltip = false;
+  sdoBox.$outer.addEventListener('pointerenter', () => {
+    insideTooltip = true;
+  });
+  sdoBox.$outer.addEventListener('pointerleave', () => {
+    insideTooltip = false;
+    sdoBox.deactivate();
+  });
+
+  sdoBox.deactiveTimeout = null;
+  [].forEach.call(document.querySelectorAll('emu-grammar[type=definition] emu-rhs'), node => {
+    node.addEventListener('pointerenter', function () {
+      sdoBox.activate(this);
+    });
+
+    node.addEventListener('pointerleave', () => {
+      sdoBox.deactiveTimeout = setTimeout(() => {
+        if (!insideTooltip) {
+          sdoBox.deactivate();
+        }
+      }, 500);
+    });
+  });
+
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        sdoBox.deactivate();
+      }
+    }),
+  );
+});
+
+'use strict';
+function Search(menu) {
+  this.menu = menu;
+  this.$search = document.getElementById('menu-search');
+  this.$searchBox = document.getElementById('menu-search-box');
+  this.$searchResults = document.getElementById('menu-search-results');
+
+  this.loadBiblio();
+
+  document.addEventListener('keydown', this.documentKeydown.bind(this));
+
+  this.$searchBox.addEventListener(
+    'keydown',
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }),
+  );
+  this.$searchBox.addEventListener(
+    'keyup',
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }),
+  );
+
+  // Perform an initial search if the box is not empty.
+  if (this.$searchBox.value) {
+    this.search(this.$searchBox.value);
+  }
+}
+
+Search.prototype.loadBiblio = function () {
+  if (typeof biblio === 'undefined') {
+    console.error('could not find biblio');
+    this.biblio = { refToClause: {}, entries: [] };
+  } else {
+    this.biblio = biblio;
+    this.biblio.clauses = this.biblio.entries.filter(e => e.type === 'clause');
+    this.biblio.byId = this.biblio.entries.reduce((map, entry) => {
+      map[entry.id] = entry;
+      return map;
+    }, {});
+    let refParentClause = Object.create(null);
+    this.biblio.refParentClause = refParentClause;
+    let refsByClause = this.biblio.refsByClause;
+    Object.keys(refsByClause).forEach(clause => {
+      refsByClause[clause].forEach(ref => {
+        refParentClause[ref] = clause;
+      });
+    });
+  }
+};
+
+Search.prototype.documentKeydown = function (e) {
+  if (e.key === '/') {
+    e.preventDefault();
+    e.stopPropagation();
+    this.triggerSearch();
+  }
+};
+
+Search.prototype.searchBoxKeydown = function (e) {
+  e.stopPropagation();
+  e.preventDefault();
+  if (e.keyCode === 191 && e.target.value.length === 0) {
+    e.preventDefault();
+  } else if (e.keyCode === 13) {
+    e.preventDefault();
+    this.selectResult();
+  }
+};
+
+Search.prototype.searchBoxKeyup = function (e) {
+  if (e.keyCode === 13 || e.keyCode === 9) {
+    return;
+  }
+
+  this.search(e.target.value);
+};
+
+Search.prototype.triggerSearch = function () {
+  if (this.menu.isVisible()) {
+    this._closeAfterSearch = false;
+  } else {
+    this._closeAfterSearch = true;
+    this.menu.show();
+  }
+
+  this.$searchBox.focus();
+  this.$searchBox.select();
+};
+// bit 12 - Set if the result starts with searchString
+// bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
+// bits 1-7: 127 - length of the entry
+// General scheme: prefer case sensitive matches with fewer chunks, and otherwise
+// prefer shorter matches.
+function relevance(result) {
+  let relevance = 0;
+
+  relevance = Math.max(0, 8 - result.match.chunks) << 7;
+
+  if (result.match.caseMatch) {
+    relevance *= 2;
+  }
+
+  if (result.match.prefix) {
+    relevance += 2048;
+  }
+
+  relevance += Math.max(0, 255 - result.key.length);
+
+  return relevance;
+}
+
+Search.prototype.search = function (searchString) {
+  if (searchString === '') {
+    this.displayResults([]);
+    this.hideSearch();
+    return;
+  } else {
+    this.showSearch();
+  }
+
+  if (searchString.length === 1) {
+    this.displayResults([]);
+    return;
+  }
+
+  let results;
+
+  if (/^[\d.]*$/.test(searchString)) {
+    results = this.biblio.clauses
+      .filter(clause => clause.number.substring(0, searchString.length) === searchString)
+      .map(clause => ({ key: getKey(clause), entry: clause }));
+  } else {
+    results = [];
+
+    for (let i = 0; i < this.biblio.entries.length; i++) {
+      let entry = this.biblio.entries[i];
+      let key = getKey(entry);
+      if (!key) {
+        // biblio entries without a key aren't searchable
+        continue;
+      }
+
+      let match = fuzzysearch(searchString, key);
+      if (match) {
+        results.push({ key, entry, match });
+      }
+    }
+
+    results.forEach(result => {
+      result.relevance = relevance(result, searchString);
+    });
+
+    results = results.sort((a, b) => b.relevance - a.relevance);
+  }
+
+  if (results.length > 50) {
+    results = results.slice(0, 50);
+  }
+
+  this.displayResults(results);
+};
+Search.prototype.hideSearch = function () {
+  this.$search.classList.remove('active');
+};
+
+Search.prototype.showSearch = function () {
+  this.$search.classList.add('active');
+};
+
+Search.prototype.selectResult = function () {
+  let $first = this.$searchResults.querySelector('li:first-child a');
+
+  if ($first) {
+    document.location = $first.getAttribute('href');
+  }
+
+  this.$searchBox.value = '';
+  this.$searchBox.blur();
+  this.displayResults([]);
+  this.hideSearch();
+
+  if (this._closeAfterSearch) {
+    this.menu.hide();
+  }
+};
+
+Search.prototype.displayResults = function (results) {
+  if (results.length > 0) {
+    this.$searchResults.classList.remove('no-results');
+
+    let html = '<ul>';
+
+    results.forEach(result => {
+      let key = result.key;
+      let entry = result.entry;
+      let id = entry.id;
+      let cssClass = '';
+      let text = '';
+
+      if (entry.type === 'clause') {
+        let number = entry.number ? entry.number + ' ' : '';
+        text = number + key;
+        cssClass = 'clause';
+        id = entry.id;
+      } else if (entry.type === 'production') {
+        text = key;
+        cssClass = 'prod';
+        id = entry.id;
+      } else if (entry.type === 'op') {
+        text = key;
+        cssClass = 'op';
+        id = entry.id || entry.refId;
+      } else if (entry.type === 'term') {
+        text = key;
+        cssClass = 'term';
+        id = entry.id || entry.refId;
+      }
+
+      if (text) {
+        html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
+      }
+    });
+
+    html += '</ul>';
+
+    this.$searchResults.innerHTML = html;
+  } else {
+    this.$searchResults.innerHTML = '';
+    this.$searchResults.classList.add('no-results');
+  }
+};
+
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
+
+function Menu() {
+  this.$toggle = document.getElementById('menu-toggle');
+  this.$menu = document.getElementById('menu');
+  this.$toc = document.querySelector('menu-toc > ol');
+  this.$pins = document.querySelector('#menu-pins');
+  this.$pinList = document.getElementById('menu-pins-list');
+  this.$toc = document.querySelector('#menu-toc > ol');
+  this.$specContainer = document.getElementById('spec-container');
+  this.search = new Search(this);
+
+  this._pinnedIds = {};
+  this.loadPinEntries();
+
+  // unpin all button
+  document
+    .querySelector('#menu-pins .unpin-all')
+    .addEventListener('click', this.unpinAll.bind(this));
+
+  // individual unpinning buttons
+  this.$pinList.addEventListener('click', this.pinListClick.bind(this));
+
+  // toggle menu
+  this.$toggle.addEventListener('click', this.toggle.bind(this));
+
+  // keydown events for pinned clauses
+  document.addEventListener('keydown', this.documentKeydown.bind(this));
+
+  // toc expansion
+  let tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (let i = 0; i < tocItems.length; i++) {
+    let $item = tocItems[i];
+    $item.addEventListener('click', event => {
+      $item.classList.toggle('active');
+      event.stopPropagation();
+    });
+  }
+
+  // close toc on toc item selection
+  let tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (let i = 0; i < tocLinks.length; i++) {
+    let $link = tocLinks[i];
+    $link.addEventListener('click', event => {
+      this.toggle();
+      event.stopPropagation();
+    });
+  }
+
+  // update active clause on scroll
+  window.addEventListener('scroll', debounce(this.updateActiveClause.bind(this)));
+  this.updateActiveClause();
+
+  // prevent menu scrolling from scrolling the body
+  this.$toc.addEventListener('wheel', e => {
+    let target = e.currentTarget;
+    let offTop = e.deltaY < 0 && target.scrollTop === 0;
+    if (offTop) {
+      e.preventDefault();
+    }
+    let offBottom = e.deltaY > 0 && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+
+    if (offBottom) {
+      e.preventDefault();
+    }
+  });
+}
+
+Menu.prototype.documentKeydown = function (e) {
+  e.stopPropagation();
+  if (e.key === 'p') {
+    this.togglePinEntry();
+  } else if ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9].includes(parseInt(e.key))) {
+    this.selectPin((e.keyCode - 9) % 10);
+  } else if (e.key === '`') {
+    const hash = document.location.hash;
+    const id = decodeURIComponent(hash.slice(1));
+    const target = document.getElementById(id);
+    target?.scrollIntoView(true);
+  }
+};
+
+Menu.prototype.updateActiveClause = function () {
+  this.setActiveClause(findActiveClause(this.$specContainer));
+};
+
+Menu.prototype.setActiveClause = function (clause) {
+  this.$activeClause = clause;
+  this.revealInToc(this.$activeClause);
+};
+
+Menu.prototype.revealInToc = function (path) {
+  let current = this.$toc.querySelectorAll('li.revealed');
+  for (let i = 0; i < current.length; i++) {
+    current[i].classList.remove('revealed');
+    current[i].classList.remove('revealed-leaf');
+  }
+
+  current = this.$toc;
+  let index = 0;
+  outer: while (index < path.length) {
+    let children = current.children;
+    for (let i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].hash) {
+        children[i].classList.add('revealed');
+        if (index === path.length - 1) {
+          children[i].classList.add('revealed-leaf');
+          let rect = children[i].getBoundingClientRect();
+          // this.$toc.getBoundingClientRect().top;
+          let tocRect = this.$toc.getBoundingClientRect();
+          if (rect.top + 10 > tocRect.bottom) {
+            this.$toc.scrollTop =
+              this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+          } else if (rect.top < tocRect.top) {
+            this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
+          }
+        }
+        current = children[i].querySelector('ol');
+        index++;
+        continue outer;
+      }
+    }
+    console.log('could not find location in table of contents', path);
+    break;
+  }
+};
+
+function findActiveClause(root, path) {
+  path = path || [];
+
+  let visibleClauses = getVisibleClauses(root, path);
+  let midpoint = Math.floor(window.innerHeight / 2);
+
+  for (let [$clause, path] of visibleClauses) {
+    let { top: clauseTop, bottom: clauseBottom } = $clause.getBoundingClientRect();
+    let isFullyVisibleAboveTheFold =
+      clauseTop > 0 && clauseTop < midpoint && clauseBottom < window.innerHeight;
+    if (isFullyVisibleAboveTheFold) {
+      return path;
+    }
+  }
+
+  visibleClauses.sort(([, pathA], [, pathB]) => pathB.length - pathA.length);
+  for (let [$clause, path] of visibleClauses) {
+    let { top: clauseTop, bottom: clauseBottom } = $clause.getBoundingClientRect();
+    let $header = $clause.querySelector('h1');
+    let clauseStyles = getComputedStyle($clause);
+    let marginTop = Math.max(
+      0,
+      parseInt(clauseStyles['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top']),
+    );
+    let marginBottom = Math.max(0, parseInt(clauseStyles['margin-bottom']));
+    let crossesMidpoint =
+      clauseTop - marginTop <= midpoint && clauseBottom + marginBottom >= midpoint;
+    if (crossesMidpoint) {
+      return path;
+    }
+  }
+
+  return path;
+}
+
+function getVisibleClauses(root, path) {
+  let childClauses = getChildClauses(root);
+  path = path || [];
+
+  let result = [];
+
+  let seenVisibleClause = false;
+  for (let $clause of childClauses) {
+    let { top: clauseTop, bottom: clauseBottom } = $clause.getBoundingClientRect();
+    let isPartiallyVisible =
+      (clauseTop > 0 && clauseTop < window.innerHeight) ||
+      (clauseBottom > 0 && clauseBottom < window.innerHeight) ||
+      (clauseTop < 0 && clauseBottom > window.innerHeight);
+
+    if (isPartiallyVisible) {
+      seenVisibleClause = true;
+      let innerPath = path.concat($clause);
+      result.push([$clause, innerPath]);
+      result.push(...getVisibleClauses($clause, innerPath));
+    } else if (seenVisibleClause) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+function* getChildClauses(root) {
+  for (let el of root.children) {
+    switch (el.nodeName) {
+      // descend into <emu-import>
+      case 'EMU-IMPORT':
+        yield* getChildClauses(el);
+        break;
+
+      // accept <emu-clause>, <emu-intro>, and <emu-annex>
+      case 'EMU-CLAUSE':
+      case 'EMU-INTRO':
+      case 'EMU-ANNEX':
+        yield el;
+    }
+  }
+}
+
+Menu.prototype.toggle = function () {
+  this.$menu.classList.toggle('active');
+};
+
+Menu.prototype.show = function () {
+  this.$menu.classList.add('active');
+};
+
+Menu.prototype.hide = function () {
+  this.$menu.classList.remove('active');
+};
+
+Menu.prototype.isVisible = function () {
+  return this.$menu.classList.contains('active');
+};
+
+Menu.prototype.showPins = function () {
+  this.$pins.classList.add('active');
+};
+
+Menu.prototype.hidePins = function () {
+  this.$pins.classList.remove('active');
+};
+
+Menu.prototype.addPinEntry = function (id) {
+  let entry = this.search.biblio.byId[id];
+  if (!entry) {
+    // id was deleted after pin (or something) so remove it
+    delete this._pinnedIds[id];
+    this.persistPinEntries();
+    return;
+  }
+
+  let text;
+  if (entry.type === 'clause') {
+    let prefix;
+    if (entry.number) {
+      prefix = entry.number + ' ';
+    } else {
+      prefix = '';
+    }
+    text = `${prefix}${entry.titleHTML}`;
+  } else {
+    text = getKey(entry);
+  }
+
+  let link = `<a href="${makeLinkToId(entry.id)}">${text}</a>`;
+  this.$pinList.innerHTML += `<li data-section-id="${id}">${link}<button class="unpin">\u{2716}</button></li>`;
+
+  if (Object.keys(this._pinnedIds).length === 0) {
+    this.showPins();
+  }
+  this._pinnedIds[id] = true;
+  this.persistPinEntries();
+};
+
+Menu.prototype.removePinEntry = function (id) {
+  let item = this.$pinList.querySelector(`li[data-section-id="${id}"]`);
+  this.$pinList.removeChild(item);
+  delete this._pinnedIds[id];
+  if (Object.keys(this._pinnedIds).length === 0) {
+    this.hidePins();
+  }
+
+  this.persistPinEntries();
+};
+
+Menu.prototype.unpinAll = function () {
+  for (let id of Object.keys(this._pinnedIds)) {
+    this.removePinEntry(id);
+  }
+};
+
+Menu.prototype.pinListClick = function (event) {
+  if (event?.target?.classList.contains('unpin')) {
+    let id = event.target.parentNode.dataset.sectionId;
+    if (id) {
+      this.removePinEntry(id);
+    }
+  }
+};
+
+Menu.prototype.persistPinEntries = function () {
+  try {
+    if (!window.localStorage) return;
+  } catch (e) {
+    return;
+  }
+
+  localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
+};
+
+Menu.prototype.loadPinEntries = function () {
+  try {
+    if (!window.localStorage) return;
+  } catch (e) {
+    return;
+  }
+
+  let pinsString = window.localStorage.pinEntries;
+  if (!pinsString) return;
+  let pins = JSON.parse(pinsString);
+  for (let i = 0; i < pins.length; i++) {
+    this.addPinEntry(pins[i]);
+  }
+};
+
+Menu.prototype.togglePinEntry = function (id) {
+  if (!id) {
+    id = this.$activeClause[this.$activeClause.length - 1].id;
+  }
+
+  if (this._pinnedIds[id]) {
+    this.removePinEntry(id);
+  } else {
+    this.addPinEntry(id);
+  }
+};
+
+Menu.prototype.selectPin = function (num) {
+  if (num >= this.$pinList.children.length) return;
+  document.location = this.$pinList.children[num].children[0].href;
+};
+
+let menu;
+
+document.addEventListener('DOMContentLoaded', init);
+
+function debounce(fn, opts) {
+  opts = opts || {};
+  let timeout;
+  return function (e) {
+    if (opts.stopPropagation) {
+      e.stopPropagation();
+    }
+    let args = arguments;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      timeout = null;
+      fn.apply(this, args);
+    }, 150);
+  };
+}
+
+let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findContainer($elem) {
+  let parentClause = $elem.parentNode;
+  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
+    parentClause = parentClause.parentNode;
+  }
+  return parentClause;
+}
+
+function findLocalReferences(parentClause, name) {
+  let vars = parentClause.querySelectorAll('var');
+  let references = [];
+
+  for (let i = 0; i < vars.length; i++) {
+    let $var = vars[i];
+
+    if ($var.innerHTML === name) {
+      references.push($var);
+    }
+  }
+
+  return references;
+}
+
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
+function toggleFindLocalReferences($elem) {
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
+  if ($elem.classList.contains('referenced')) {
+    references.forEach($reference => {
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
+    });
+  } else {
+    let index = chooseHighlightIndex(parentClause);
+    references.forEach($reference => {
+      $reference.classList.add('referenced', `referenced${index}`);
+    });
+  }
+}
+
+function installFindLocalReferences() {
+  document.addEventListener('click', e => {
+    if (e.target.nodeName === 'VAR') {
+      toggleFindLocalReferences(e.target);
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', installFindLocalReferences);
+
+// The following license applies to the fuzzysearch function
+// The MIT License (MIT)
+// Copyright © 2015 Nicolas Bevacqua
+// Copyright © 2016 Brian Terlson
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+function fuzzysearch(searchString, haystack, caseInsensitive) {
+  let tlen = haystack.length;
+  let qlen = searchString.length;
+  let chunks = 1;
+  let finding = false;
+
+  if (qlen > tlen) {
+    return false;
+  }
+
+  if (qlen === tlen) {
+    if (searchString === haystack) {
+      return { caseMatch: true, chunks: 1, prefix: true };
+    } else if (searchString.toLowerCase() === haystack.toLowerCase()) {
+      return { caseMatch: false, chunks: 1, prefix: true };
+    } else {
+      return false;
+    }
+  }
+
+  let j = 0;
+  outer: for (let i = 0; i < qlen; i++) {
+    let nch = searchString[i];
+    while (j < tlen) {
+      let targetChar = haystack[j++];
+      if (targetChar === nch) {
+        finding = true;
+        continue outer;
+      }
+      if (finding) {
+        chunks++;
+        finding = false;
+      }
+    }
+
+    if (caseInsensitive) {
+      return false;
+    }
+
+    return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
+  }
+
+  return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
+}
+
+let referencePane = {
+  init() {
+    this.$container = document.createElement('div');
+    this.$container.setAttribute('id', 'references-pane-container');
+
+    let $spacer = document.createElement('div');
+    $spacer.setAttribute('id', 'references-pane-spacer');
+    $spacer.classList.add('menu-spacer');
+
+    this.$pane = document.createElement('div');
+    this.$pane.setAttribute('id', 'references-pane');
+
+    this.$container.appendChild($spacer);
+    this.$container.appendChild(this.$pane);
+
+    this.$header = document.createElement('div');
+    this.$header.classList.add('menu-pane-header');
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
+    this.$headerRefId = document.createElement('a');
+    this.$header.appendChild(this.$headerRefId);
+    this.$header.addEventListener('pointerdown', e => {
+      this.dragStart(e);
+    });
+
+    this.$closeButton = document.createElement('span');
+    this.$closeButton.setAttribute('id', 'references-pane-close');
+    this.$closeButton.addEventListener('click', () => {
+      this.deactivate();
+    });
+    this.$header.appendChild(this.$closeButton);
+
+    this.$pane.appendChild(this.$header);
+    this.$tableContainer = document.createElement('div');
+    this.$tableContainer.setAttribute('id', 'references-pane-table-container');
+
+    this.$table = document.createElement('table');
+    this.$table.setAttribute('id', 'references-pane-table');
+
+    this.$tableBody = this.$table.createTBody();
+
+    this.$tableContainer.appendChild(this.$table);
+    this.$pane.appendChild(this.$tableContainer);
+
+    if (menu != null) {
+      menu.$specContainer.appendChild(this.$container);
+    }
+  },
+
+  activate() {
+    this.$container.classList.add('active');
+  },
+
+  deactivate() {
+    this.$container.classList.remove('active');
+    this.state = null;
+  },
+
+  showReferencesFor(entry) {
+    this.activate();
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
+    this.$headerRefId.innerHTML = getKey(entry);
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+    this.autoSize();
+  },
+
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
+
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+    this.autoSize();
+  },
+
+  autoSize() {
+    this.$tableContainer.style.height =
+      Math.min(250, this.$table.getBoundingClientRect().height) + 'px';
+  },
+
+  dragStart(pointerDownEvent) {
+    let startingMousePos = pointerDownEvent.clientY;
+    let startingHeight = this.$tableContainer.getBoundingClientRect().height;
+    let moveListener = pointerMoveEvent => {
+      if (pointerMoveEvent.buttons === 0) {
+        removeListeners();
+        return;
+      }
+      let desiredHeight = startingHeight - (pointerMoveEvent.clientY - startingMousePos);
+      this.$tableContainer.style.height = Math.max(0, desiredHeight) + 'px';
+    };
+    let listenerOptions = { capture: true, passive: true };
+    let removeListeners = () => {
+      document.removeEventListener('pointermove', moveListener, listenerOptions);
+      this.$header.removeEventListener('pointerup', removeListeners, listenerOptions);
+      this.$header.removeEventListener('pointercancel', removeListeners, listenerOptions);
+    };
+    document.addEventListener('pointermove', moveListener, listenerOptions);
+    this.$header.addEventListener('pointerup', removeListeners, listenerOptions);
+    this.$header.addEventListener('pointercancel', removeListeners, listenerOptions);
+  },
+};
+
+let Toolbox = {
+  init() {
+    this.$outer = document.createElement('div');
+    this.$outer.classList.add('toolbox-container');
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$outer.appendChild(this.$container);
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
+    });
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    });
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(document.createTextNode(' '));
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(document.createTextNode(' '));
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$outer);
+  },
+
+  activate(el, entry, target) {
+    if (el === this._activeEl) return;
+    sdoBox.deactivate();
+    this.active = true;
+    this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
+    this.$outer.classList.add('active');
+    this.top = el.offsetTop - this.$outer.offsetHeight;
+    this.left = el.offsetLeft - 10;
+    this.$outer.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$outer.scrollIntoView();
+    }
+  },
+
+  updatePermalink() {
+    this.$permalink.setAttribute('href', makeLinkToId(this.entry.id));
+  },
+
+  updateReferences() {
+    this.$refsLink.textContent = `References (${(this.entry.referencingIds || []).length})`;
+  },
+
+  activateIfMouseOver(e) {
+    let ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      let entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (
+      this.active &&
+      (e.pageY < this.top || e.pageY > this._activeEl.offsetTop + this._activeEl.offsetHeight)
+    ) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder(el) {
+    while (el) {
+      let parent = el.parentNode;
+      if (el.nodeName === 'EMU-RHS' || el.nodeName === 'EMU-PRODUCTION') {
+        return null;
+      }
+      if (
+        el.nodeName === 'H1' &&
+        parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) &&
+        parent.id
+      ) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName === 'EMU-NT') {
+        if (
+          parent.nodeName === 'EMU-PRODUCTION' &&
+          parent.id &&
+          parent.id[0] !== '_' &&
+          parent.firstElementChild === el
+        ) {
+          // return the LHS non-terminal element
+          return { element: el, id: parent.id };
+        }
+        return null;
+      } else if (
+        el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+        el.id &&
+        el.id[0] !== '_'
+      ) {
+        if (
+          el.nodeName === 'EMU-FIGURE' ||
+          el.nodeName === 'EMU-TABLE' ||
+          el.nodeName === 'EMU-EXAMPLE'
+        ) {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate() {
+    this.$outer.classList.remove('active');
+    this._activeEl = null;
+    this.active = false;
+  },
+};
+
+function sortByClauseNumber(clause1, clause2) {
+  let c1c = clause1.number.split('.');
+  let c2c = clause2.number.split('.');
+
+  for (let i = 0; i < c1c.length; i++) {
+    if (i >= c2c.length) {
+      return 1;
+    }
+
+    let c1 = c1c[i];
+    let c2 = c2c[i];
+    let c1cn = Number(c1);
+    let c2cn = Number(c2);
+
+    if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
+      if (c1 > c2) {
+        return 1;
+      } else if (c1 < c2) {
+        return -1;
+      }
+    } else if (!Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
+      return -1;
+    } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
+      return 1;
+    } else if (c1cn > c2cn) {
+      return 1;
+    } else if (c1cn < c2cn) {
+      return -1;
+    }
+  }
+
+  if (c1c.length === c2c.length) {
+    return 0;
+  }
+  return -1;
+}
+
+function makeLinkToId(id) {
+  let hash = '#' + id;
+  if (typeof idToSection === 'undefined' || !idToSection[id]) {
+    return hash;
+  }
+  let targetSec = idToSection[id];
+  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+}
+
+function doShortcut(e) {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
+    let pathParts = location.pathname.split('/');
+    let hash = location.hash;
+    if (pathParts[pathParts.length - 2] === 'multipage') {
+      if (hash === '') {
+        let sectionName = pathParts[pathParts.length - 1];
+        if (sectionName.endsWith('.html')) {
+          sectionName = sectionName.slice(0, -5);
+        }
+        if (idToSection['sec-' + sectionName] !== undefined) {
+          hash = '#sec-' + sectionName;
+        }
+      }
+      location = pathParts.slice(0, -2).join('/') + '/' + hash;
+    } else {
+      location = 'multipage/' + hash;
+    }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
+  } else if (e.key === '?') {
+    document.getElementById('shortcuts-help').classList.toggle('active');
+  }
+}
+
+function init() {
+  if (document.getElementById('menu') == null) {
+    return;
+  }
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    }),
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape') {
+        if (Toolbox.active) {
+          Toolbox.deactivate();
+        }
+        document.getElementById('shortcuts-help').classList.remove('active');
+      }
+    }),
+  );
+}
+
+document.addEventListener('keypress', doShortcut);
+
+document.addEventListener('DOMContentLoaded', () => {
+  Toolbox.init();
+  referencePane.init();
+});
+
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
+  }
+  return path;
+}
+
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
+
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
+
+function initTOCExpansion(visibleItemLimit) {
+  // Initialize to a reasonable amount of TOC expansion:
+  // * Expand any full-breadth nesting level up to visibleItemLimit.
+  // * Expand any *single-item* level while under visibleItemLimit (even if that pushes over it).
+
+  // Limit to initialization by bailing out if any parent item is already expanded.
+  const tocItems = Array.from(document.querySelectorAll('#menu-toc li'));
+  if (tocItems.some(li => li.classList.contains('active') && li.querySelector('li'))) {
+    return;
+  }
+
+  const selfAndSiblings = maybe => Array.from(maybe?.parentNode.children ?? []);
+  let currentLevelItems = selfAndSiblings(tocItems[0]);
+  let availableCount = visibleItemLimit - currentLevelItems.length;
+  while (availableCount > 0 && currentLevelItems.length) {
+    const nextLevelItems = currentLevelItems.flatMap(li => selfAndSiblings(li.querySelector('li')));
+    availableCount -= nextLevelItems.length;
+    if (availableCount > 0 || currentLevelItems.length === 1) {
+      // Expand parent items of the next level down (i.e., current-level items with children).
+      for (const ol of new Set(nextLevelItems.map(li => li.parentNode))) {
+        ol.closest('li').classList.add('active');
+      }
+    }
+    currentLevelItems = nextLevelItems;
+  }
+}
+
+function initState() {
+  if (typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  const storage = typeof sessionStorage !== 'undefined' ? sessionStorage : Object.create(null);
+  if (storage.referencePaneState != null) {
+    let state = JSON.parse(storage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete storage.referencePaneState;
+    }
+  }
+
+  if (storage.activeTocPaths != null) {
+    document.querySelectorAll('#menu-toc li.active').forEach(li => li.classList.remove('active'));
+    let active = JSON.parse(storage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete storage.activeTocPaths;
+  } else {
+    initTOCExpansion(20);
+  }
+
+  if (storage.searchValue != null) {
+    let value = JSON.parse(storage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete storage.searchValue;
+  }
+
+  if (storage.tocScroll != null) {
+    let tocScroll = JSON.parse(storage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete storage.tocScroll;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initState);
+
+window.addEventListener('pageshow', initState);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
+});
+
+'use strict';
+
+// Manually prefix algorithm step list items with hidden counter representations
+// corresponding with their markers so they get selected and copied with content.
+// We read list-style-type to avoid divergence with the style sheet, but
+// for efficiency assume that all lists at the same nesting depth use the same
+// style (except for those associated with replacement steps).
+// We also precompute some initial items for each supported style type.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/
+
+const lowerLetters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i),
+);
+// Implement the lower-alpha 'alphabetic' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-alphabetic
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#alphabetic-system
+const lowerAlphaTextForIndex = i => {
+  let S = '';
+  for (const N = lowerLetters.length; i >= 0; i--) {
+    S = lowerLetters[i % N] + S;
+    i = Math.floor(i / N);
+  }
+  return S;
+};
+
+const weightedLowerRomanSymbols = Object.entries({
+  m: 1000,
+  cm: 900,
+  d: 500,
+  cd: 400,
+  c: 100,
+  xc: 90,
+  l: 50,
+  xl: 40,
+  x: 10,
+  ix: 9,
+  v: 5,
+  iv: 4,
+  i: 1,
+});
+// Implement the lower-roman 'additive' algorithm,
+// adjusting for indexing from 0 rather than 1.
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#simple-numeric
+// https://w3c.github.io/csswg-drafts/css-counter-styles/#additive-system
+const lowerRomanTextForIndex = i => {
+  let value = i + 1;
+  let S = '';
+  for (const [symbol, weight] of weightedLowerRomanSymbols) {
+    if (!value) break;
+    if (weight > value) continue;
+    const reps = Math.floor(value / weight);
+    S += symbol.repeat(reps);
+    value -= weight * reps;
+  }
+  return S;
+};
+
+// Memoize pure index-to-text functions with an exposed cache for fast retrieval.
+const makeCounter = (pureGetTextForIndex, precomputeCount = 30) => {
+  const cache = Array.from({ length: precomputeCount }, (_, i) => pureGetTextForIndex(i));
+  const getTextForIndex = i => {
+    if (i >= cache.length) cache[i] = pureGetTextForIndex(i);
+    return cache[i];
+  };
+  return { getTextForIndex, cache };
+};
+
+const counterByStyle = {
+  __proto__: null,
+  decimal: makeCounter(i => String(i + 1)),
+  'lower-alpha': makeCounter(lowerAlphaTextForIndex),
+  'upper-alpha': makeCounter(i => lowerAlphaTextForIndex(i).toUpperCase()),
+  'lower-roman': makeCounter(lowerRomanTextForIndex),
+  'upper-roman': makeCounter(i => lowerRomanTextForIndex(i).toUpperCase()),
+};
+const fallbackCounter = makeCounter(() => '?');
+const counterByDepth = [];
+
+function addStepNumberText(
+  ol,
+  depth = 0,
+  indent = '',
+  special = [...ol.classList].some(c => c.startsWith('nested-')),
+) {
+  let counter = !special && counterByDepth[depth];
+  if (!counter) {
+    const counterStyle = getComputedStyle(ol)['list-style-type'];
+    counter = counterByStyle[counterStyle];
+    if (!counter) {
+      console.warn('unsupported list-style-type', {
+        ol,
+        counterStyle,
+        id: ol.closest('[id]')?.getAttribute('id'),
+      });
+      counterByStyle[counterStyle] = fallbackCounter;
+      counter = fallbackCounter;
+    }
+    if (!special) {
+      counterByDepth[depth] = counter;
+    }
+  }
+  const { cache, getTextForIndex } = counter;
+  let i = (Number(ol.getAttribute('start')) || 1) - 1;
+  for (const li of ol.children) {
+    const marker = document.createElement('span');
+    const markerText = i < cache.length ? cache[i] : getTextForIndex(i);
+    const extraIndent = ' '.repeat(markerText.length + 2);
+    marker.textContent = `${indent}${markerText}. `;
+    marker.setAttribute('aria-hidden', 'true');
+    marker.setAttribute('class', 'list-marker');
+    const attributesContainer = li.querySelector('.attributes-tag');
+    if (attributesContainer == null) {
+      li.prepend(marker);
+    } else {
+      attributesContainer.insertAdjacentElement('afterend', marker);
+    }
+    for (const sublist of li.querySelectorAll(':scope > ol')) {
+      addStepNumberText(sublist, depth + 1, indent + extraIndent, special);
+    }
+    i++;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('emu-alg > ol').forEach(ol => {
+    addStepNumberText(ol);
+  });
+});
+
+// Omit indendation when copying a single algorithm step.
+document.addEventListener('copy', evt => {
+  // Construct a DOM from the selection.
+  const doc = document.implementation.createHTMLDocument('');
+  const domRoot = doc.createElement('div');
+  const html = evt.clipboardData.getData('text/html');
+  if (html) {
+    domRoot.innerHTML = html;
+  } else {
+    const selection = getSelection();
+    const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
+    const container = singleRange?.commonAncestorContainer;
+    if (!container?.querySelector?.('.list-marker')) {
+      return;
+    }
+    domRoot.append(singleRange.cloneContents());
+  }
+
+  // Preserve the indentation if there is no hidden list marker, or if selection
+  // of more than one step is indicated by either multiple such markers or by
+  // visible text before the first one.
+  const listMarkers = domRoot.querySelectorAll('.list-marker');
+  if (listMarkers.length !== 1) {
+    return;
+  }
+  const treeWalker = document.createTreeWalker(domRoot, undefined, {
+    acceptNode(node) {
+      return node.nodeType === Node.TEXT_NODE || node === listMarkers[0]
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_SKIP;
+    },
+  });
+  while (treeWalker.nextNode()) {
+    const node = treeWalker.currentNode;
+    if (node.nodeType === Node.ELEMENT_NODE) break;
+    if (/\S/u.test(node.data)) return;
+  }
+
+  // Strip leading indentation from the plain text representation.
+  evt.clipboardData.setData('text/plain', domRoot.textContent.trimStart());
+  if (!html) {
+    evt.clipboardData.setData('text/html', domRoot.innerHTML);
+  }
+  evt.preventDefault();
+});
+
+'use strict';
+
+// Update superscripts to not suffer misinterpretation when copied and pasted as plain text.
+// For example,
+// * Replace `10<sup>3</sup>` with
+//   `10<span aria-hidden="true">**</span><sup>3</sup>`
+//   so it gets pasted as `10**3` rather than `103`.
+// * Replace `10<sup>-<var>x</var></sup>` with
+//   `10<span aria-hidden="true">**</span><sup>-<var>x</var></sup>`
+//   so it gets pasted as `10**-x` rather than `10-x`.
+// * Replace `2<sup><var>a</var> + 1</sup>` with
+//   `2<span …>**(</span><sup><var>a</var> + 1</sup><span …>)</span>`
+//   so it gets pasted as `2**(a + 1)` rather than `2a + 1`.
+
+function makeExponentPlainTextSafe(sup) {
+  // Change a <sup> only if it appears to be an exponent:
+  // * text-only and contains only mathematical content (not e.g. `1<sup>st</sup>`)
+  // * contains only <var>s and internal links (e.g.
+  //   `2<sup><emu-xref><a href="#ℝ">ℝ</a></emu-xref>(_y_)</sup>`)
+  const isText = [...sup.childNodes].every(node => node.nodeType === 3);
+  const text = sup.textContent;
+  if (isText) {
+    if (!/^[0-9. 𝔽ℝℤ()=*×/÷±+\u2212-]+$/u.test(text)) {
+      return;
+    }
+  } else {
+    if (sup.querySelector('*:not(var, emu-xref, :scope emu-xref a)')) {
+      return;
+    }
+  }
+
+  let prefix = '**';
+  let suffix = '';
+
+  // Add wrapping parentheses unless they are already present
+  // or this is a simple (possibly signed) integer or single-variable exponent.
+  const skipParens =
+    /^[±+\u2212-]?(?:[0-9]+|\p{ID_Start}\p{ID_Continue}*)$/u.test(text) ||
+    // Split on parentheses and remember them; the resulting parts must
+    // start and end empty (i.e., with open/close parentheses)
+    // and increase depth to 1 only at the first parenthesis
+    // to e.g. wrap `(a+1)*(b+1)` but not `((a+1)*(b+1))`.
+    text
+      .trim()
+      .split(/([()])/g)
+      .reduce((depth, s, i, parts) => {
+        if (s === '(') {
+          return depth > 0 || i === 1 ? depth + 1 : NaN;
+        } else if (s === ')') {
+          return depth > 0 ? depth - 1 : NaN;
+        } else if (s === '' || (i > 0 && i < parts.length - 1)) {
+          return depth;
+        }
+        return NaN;
+      }, 0) === 0;
+  if (!skipParens) {
+    prefix += '(';
+    suffix += ')';
+  }
+
+  sup.insertAdjacentHTML('beforebegin', `<span aria-hidden="true">${prefix}</span>`);
+  if (suffix) {
+    sup.insertAdjacentHTML('afterend', `<span aria-hidden="true">${suffix}</span>`);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('sup:not(.text)').forEach(sup => {
+    makeExponentPlainTextSafe(sup);
+  });
+});
+
+let sdoMap = JSON.parse(`{}`);
+let biblio = JSON.parse(`{"refsByClause":{"sup-availablecalendars":["_ref_0","_ref_31","_ref_32"],"sec-ecma402-intl.datetimeformat-internal-slots":["_ref_1","_ref_2","_ref_52"],"sec-temporal-calendarsupportsera":["_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_53","_ref_54","_ref_55","_ref_56","_ref_57"],"sec-temporal-canonicalizeeraincalendar":["_ref_8","_ref_9","_ref_58"],"sec-temporal-calendarhasmidyeareras":["_ref_10","_ref_59"],"sec-temporal-isvalidmonthcodeforcalendar":["_ref_11","_ref_12","_ref_13","_ref_60"],"sec-temporal-constrainmonthcode":["_ref_14","_ref_15","_ref_16","_ref_63","_ref_64","_ref_65"],"sec-temporal-monthcodetoordinal":["_ref_17","_ref_18","_ref_66","_ref_67","_ref_68","_ref_69"],"sec-temporal-calendardatearithmeticyear":["_ref_19","_ref_20","_ref_76","_ref_77"],"sec-temporal-calendardatearithmeticyearforerayear":["_ref_21","_ref_22","_ref_78","_ref_79","_ref_80"],"sup-temporal-calendar-date-records":["_ref_23","_ref_24","_ref_83","_ref_84","_ref_85","_ref_86","_ref_87","_ref_88","_ref_89","_ref_90","_ref_91","_ref_92","_ref_93","_ref_94"],"sup-temporal-nonisomonthdaytoisoreferencedate":["_ref_25","_ref_26","_ref_126","_ref_127","_ref_128","_ref_129","_ref_130","_ref_131"],"sup-temporal-calendarextrafields":["_ref_27","_ref_132","_ref_133"],"sup-temporal-nonisofieldkeystoignore":["_ref_28","_ref_134","_ref_135","_ref_136"],"sec-ecma402-calendar-types":["_ref_29","_ref_30","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49"],"sec-createdatetimeformat":["_ref_50","_ref_51"],"sec-temporal-yearcontainsmonthcode":["_ref_61","_ref_62"],"sec-temporal-calendardaysinmonth":["_ref_70"],"sec-temporal-calendardateera":["_ref_71","_ref_72","_ref_73"],"sec-temporal-calendardateerayear":["_ref_74","_ref_75"],"sec-temporal-calendarintegerstoiso":["_ref_81","_ref_82"],"sec-temporal-calendarmonthsinyear":["_ref_95","_ref_96"],"sec-temporal-balancenonisodate":["_ref_97","_ref_98","_ref_99","_ref_100","_ref_101","_ref_102","_ref_103","_ref_104","_ref_105"],"sec-temporal-nonisodatesurpasses":["_ref_106","_ref_107","_ref_108","_ref_109","_ref_110"],"sup-temporal-nonisodateadd":["_ref_111","_ref_112","_ref_113","_ref_114","_ref_115","_ref_116"],"sup-temporal-nonisodateuntil":["_ref_117","_ref_118","_ref_119","_ref_120","_ref_121"],"sup-temporal-nonisocalendardatetoiso":["_ref_122","_ref_123","_ref_124","_ref_125"],"sup-temporal-nonisoresolvefields":["_ref_137","_ref_138","_ref_139","_ref_140","_ref_141","_ref_142","_ref_143","_ref_144","_ref_145","_ref_146"]},"entries":[{"type":"term","term":"calendar type","refId":"sec-ecma402-calendar-types"},{"type":"op","aoid":"AvailableCalendars","refId":"sup-availablecalendars"},{"type":"clause","id":"sup-availablecalendars","titleHTML":"AvailableCalendars ( )","number":"1.1.1","referencingIds":["_ref_51"]},{"type":"table","id":"table-calendar-types","number":1,"caption":"Table 1: Calendar types described in CLDR","referencingIds":["_ref_0","_ref_2","_ref_5","_ref_9","_ref_10","_ref_13","_ref_14","_ref_17","_ref_19","_ref_21","_ref_27","_ref_28"]},{"type":"clause","id":"sec-ecma402-calendar-types","titleHTML":"Calendar Types","number":"1.1","referencingIds":["_ref_31","_ref_32","_ref_33","_ref_50","_ref_52","_ref_53","_ref_58","_ref_59","_ref_60","_ref_61","_ref_63","_ref_66","_ref_70","_ref_71","_ref_74","_ref_76","_ref_78","_ref_81","_ref_84","_ref_86","_ref_88","_ref_95","_ref_97","_ref_106","_ref_111","_ref_117","_ref_122","_ref_126","_ref_132","_ref_134","_ref_137"]},{"type":"clause","id":"ecma402-locales-currencies-tz","titleHTML":"Identification of Locales, Currencies, Time Zones, Measurement Units, Numbering Systems, Collations, and Calendars","number":"1"},{"type":"clause","id":"sec-internal-slots","titleHTML":"Internal slots of Service Constructors","number":"2.1","referencingIds":["_ref_1"]},{"type":"clause","id":"locale-and-parameter-negotiation","titleHTML":"Locale and Parameter Negotiation","number":"2"},{"type":"op","aoid":"CreateDateTimeFormat","refId":"sec-createdatetimeformat"},{"type":"clause","id":"sec-createdatetimeformat","title":"CreateDateTimeFormat ( newTarget, locales, options, required, defaults )","titleHTML":"CreateDateTimeFormat ( <var>newTarget</var>, <var>locales</var>, <var>options</var>, <var>required</var>, <var>defaults</var> )","number":"3.1.1"},{"type":"clause","id":"sec-ecma402-intl-datetimeformat-constructor","titleHTML":"The Intl.DateTimeFormat Constructor","number":"3.1"},{"type":"clause","id":"sec-ecma402-intl.datetimeformat-internal-slots","titleHTML":"Internal slots","number":"3.2.1"},{"type":"clause","id":"sec-ecma402-properties-of-intl-datetimeformat-constructor","titleHTML":"Properties of the Intl.DateTimeFormat Constructor","number":"3.2"},{"type":"clause","id":"ecma402-datetimeformat-objects","titleHTML":"DateTimeFormat Objects","number":"3"},{"type":"table","id":"table-eras","number":2,"caption":"Table 2: Eras","referencingIds":["_ref_3","_ref_4","_ref_6","_ref_8","_ref_22"]},{"type":"op","aoid":"CalendarSupportsEra","refId":"sec-temporal-calendarsupportsera"},{"type":"clause","id":"sec-temporal-calendarsupportsera","title":"CalendarSupportsEra ( calendar )","titleHTML":"CalendarSupportsEra ( <var>calendar</var> )","number":"4.1.1","referencingIds":["_ref_72","_ref_75","_ref_133","_ref_135","_ref_138","_ref_139","_ref_140"]},{"type":"op","aoid":"CanonicalizeEraInCalendar","refId":"sec-temporal-canonicalizeeraincalendar"},{"type":"clause","id":"sec-temporal-canonicalizeeraincalendar","title":"CanonicalizeEraInCalendar ( calendar, era )","titleHTML":"CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )","number":"4.1.2","referencingIds":["_ref_73","_ref_80","_ref_141"]},{"type":"op","aoid":"CalendarHasMidYearEras","refId":"sec-temporal-calendarhasmidyeareras"},{"type":"clause","id":"sec-temporal-calendarhasmidyeareras","title":"CalendarHasMidYearEras ( calendar )","titleHTML":"CalendarHasMidYearEras ( <var>calendar</var> )","number":"4.1.3","referencingIds":["_ref_136"]},{"type":"table","id":"table-additional-month-codes","number":3,"caption":"Table 3: Additional Month Codes in Calendars","referencingIds":["_ref_11","_ref_12","_ref_15","_ref_16","_ref_18"]},{"type":"op","aoid":"IsValidMonthCodeForCalendar","refId":"sec-temporal-isvalidmonthcodeforcalendar"},{"type":"clause","id":"sec-temporal-isvalidmonthcodeforcalendar","title":"IsValidMonthCodeForCalendar ( calendar, monthCode )","titleHTML":"IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )","number":"4.1.4","referencingIds":["_ref_62","_ref_64","_ref_68","_ref_143"]},{"type":"op","aoid":"YearContainsMonthCode","refId":"sec-temporal-yearcontainsmonthcode"},{"type":"clause","id":"sec-temporal-yearcontainsmonthcode","title":"YearContainsMonthCode ( calendar, arithmeticYear, monthCode )","titleHTML":"YearContainsMonthCode ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var> )","number":"4.1.5","referencingIds":["_ref_65","_ref_67","_ref_69","_ref_144"]},{"type":"op","aoid":"ConstrainMonthCode","refId":"sec-temporal-constrainmonthcode"},{"type":"clause","id":"sec-temporal-constrainmonthcode","title":"ConstrainMonthCode ( calendar, arithmeticYear, monthCode, overflow )","titleHTML":"ConstrainMonthCode ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var>, <var>overflow</var> )","number":"4.1.6","referencingIds":["_ref_108","_ref_113","_ref_123","_ref_128","_ref_145"]},{"type":"op","aoid":"MonthCodeToOrdinal","refId":"sec-temporal-monthcodetoordinal"},{"type":"clause","id":"sec-temporal-monthcodetoordinal","title":"MonthCodeToOrdinal ( calendar, arithmeticYear, monthCode )","titleHTML":"MonthCodeToOrdinal ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var> )","number":"4.1.7","referencingIds":["_ref_107","_ref_112","_ref_146"]},{"type":"op","aoid":"CalendarDaysInMonth","refId":"sec-temporal-calendardaysinmonth"},{"type":"clause","id":"sec-temporal-calendardaysinmonth","title":"CalendarDaysInMonth ( calendar, arithmeticYear, ordinalMonth )","titleHTML":"CalendarDaysInMonth ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var> )","number":"4.1.8","referencingIds":["_ref_101","_ref_103","_ref_105","_ref_124","_ref_129"]},{"type":"op","aoid":"CalendarDateEra","refId":"sec-temporal-calendardateera"},{"type":"clause","id":"sec-temporal-calendardateera","title":"CalendarDateEra ( calendar, date )","titleHTML":"CalendarDateEra ( <var>calendar</var>, <var>date</var> )","number":"4.1.9","referencingIds":["_ref_85"]},{"type":"op","aoid":"CalendarDateEraYear","refId":"sec-temporal-calendardateerayear"},{"type":"clause","id":"sec-temporal-calendardateerayear","title":"CalendarDateEraYear ( calendar, date )","titleHTML":"CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )","number":"4.1.10","referencingIds":["_ref_87"]},{"type":"table","id":"table-epoch-years","number":4,"caption":"Table 4: Epoch years","referencingIds":["_ref_20","_ref_24"]},{"type":"op","aoid":"CalendarDateArithmeticYear","refId":"sec-temporal-calendardatearithmeticyear"},{"type":"clause","id":"sec-temporal-calendardatearithmeticyear","title":"CalendarDateArithmeticYear ( calendar, date )","titleHTML":"CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )","number":"4.1.11","referencingIds":["_ref_89","_ref_96"]},{"type":"op","aoid":"CalendarDateArithmeticYearForEraYear","refId":"sec-temporal-calendardatearithmeticyearforerayear"},{"type":"clause","id":"sec-temporal-calendardatearithmeticyearforerayear","title":"CalendarDateArithmeticYearForEraYear ( calendar, era, eraYear )","titleHTML":"CalendarDateArithmeticYearForEraYear ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )","number":"4.1.12","referencingIds":["_ref_7","_ref_142"]},{"type":"op","aoid":"CalendarIntegersToISO","refId":"sec-temporal-calendarintegerstoiso"},{"type":"clause","id":"sec-temporal-calendarintegerstoiso","title":"CalendarIntegersToISO ( calendar, arithmeticYear, ordinalMonth, day )","titleHTML":"CalendarIntegersToISO ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var>, <var>day</var> )","number":"4.1.13","referencingIds":["_ref_116","_ref_125","_ref_127","_ref_130"]},{"type":"term","term":"Calendar Date Record","refId":"sup-temporal-calendar-date-records"},{"type":"table","id":"table-temporal-calendar-date-record-fields","number":5,"caption":"Table 5: Calendar Date Record Fields","referencingIds":["_ref_23"]},{"type":"term","term":"arithmetic year","refId":"sup-temporal-calendar-date-records"},{"type":"term","term":"epoch year","refId":"sup-temporal-calendar-date-records"},{"type":"clause","id":"sup-temporal-calendar-date-records","titleHTML":"Calendar Date Records","number":"4.1.14","referencingIds":["_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_47","_ref_48","_ref_49","_ref_54","_ref_55","_ref_56","_ref_57","_ref_77","_ref_79","_ref_82","_ref_83","_ref_90","_ref_91","_ref_92","_ref_93","_ref_94","_ref_131"]},{"type":"op","aoid":"CalendarMonthsInYear","refId":"sec-temporal-calendarmonthsinyear"},{"type":"clause","id":"sec-temporal-calendarmonthsinyear","title":"CalendarMonthsInYear ( calendar, arithmeticYear )","titleHTML":"CalendarMonthsInYear ( <var>calendar</var>, <var>arithmeticYear</var> )","number":"4.1.15","referencingIds":["_ref_98","_ref_99","_ref_100","_ref_102","_ref_104"]},{"type":"op","aoid":"BalanceNonISODate","refId":"sec-temporal-balancenonisodate"},{"type":"clause","id":"sec-temporal-balancenonisodate","title":"BalanceNonISODate ( calendar, arithmeticYear, ordinalMonth, day )","titleHTML":"BalanceNonISODate ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var>, <var>day</var> )","number":"4.1.16","referencingIds":["_ref_109","_ref_110","_ref_114","_ref_115"]},{"type":"op","aoid":"NonISODateSurpasses","refId":"sec-temporal-nonisodatesurpasses"},{"type":"clause","id":"sec-temporal-nonisodatesurpasses","title":"NonISODateSurpasses ( calendar, sign, fromIsoDate, toIsoDate, years, months, weeks, days )","titleHTML":"NonISODateSurpasses ( <var>calendar</var>, <var>sign</var>, <var>fromIsoDate</var>, <var>toIsoDate</var>, <var>years</var>, <var>months</var>, <var>weeks</var>, <var>days</var> )","number":"4.1.17","referencingIds":["_ref_118","_ref_119","_ref_120","_ref_121"]},{"type":"op","aoid":"NonISODateAdd","refId":"sup-temporal-nonisodateadd"},{"type":"clause","id":"sup-temporal-nonisodateadd","title":"NonISODateAdd ( calendar, isoDate, duration, overflow )","titleHTML":"NonISODateAdd ( <var>calendar</var>, <var>isoDate</var>, <var>duration</var>, <var>overflow</var> )","number":"4.1.18"},{"type":"op","aoid":"NonISODateUntil","refId":"sup-temporal-nonisodateuntil"},{"type":"clause","id":"sup-temporal-nonisodateuntil","title":"NonISODateUntil ( calendar, one, two, largestUnit )","titleHTML":"NonISODateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )","number":"4.1.19"},{"type":"op","aoid":"NonISOCalendarDateToISO","refId":"sup-temporal-nonisocalendardatetoiso"},{"type":"clause","id":"sup-temporal-nonisocalendardatetoiso","title":"NonISOCalendarDateToISO ( calendar, fields, overflow )","titleHTML":"NonISOCalendarDateToISO ( <var>calendar</var>, <var>fields</var>, <var>overflow</var> )","number":"4.1.20"},{"type":"table","id":"chinese-dangi-iso-reference-years","number":6,"caption":"Table 6: *\\"chinese\\"* and *\\"dangi\\"* Calendars ISO Reference Years","referencingIds":["_ref_25","_ref_26"]},{"type":"op","aoid":"NonISOMonthDayToISOReferenceDate","refId":"sup-temporal-nonisomonthdaytoisoreferencedate"},{"type":"clause","id":"sup-temporal-nonisomonthdaytoisoreferencedate","title":"NonISOMonthDayToISOReferenceDate ( calendar, fields, overflow )","titleHTML":"NonISOMonthDayToISOReferenceDate ( <var>calendar</var>, <var>fields</var>, <var>overflow</var> )","number":"4.1.21"},{"type":"op","aoid":"CalendarExtraFields","refId":"sup-temporal-calendarextrafields"},{"type":"clause","id":"sup-temporal-calendarextrafields","title":"CalendarExtraFields ( calendar, fields )","titleHTML":"CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )","number":"4.1.22"},{"type":"op","aoid":"NonISOFieldKeysToIgnore","refId":"sup-temporal-nonisofieldkeystoignore"},{"type":"clause","id":"sup-temporal-nonisofieldkeystoignore","title":"NonISOFieldKeysToIgnore ( calendar, keys )","titleHTML":"NonISOFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )","number":"4.1.23"},{"type":"op","aoid":"NonISOResolveFields","refId":"sup-temporal-nonisoresolvefields"},{"type":"clause","id":"sup-temporal-nonisoresolvefields","title":"NonISOResolveFields ( calendar, fields, type )","titleHTML":"NonISOResolveFields ( <var>calendar</var>, <var>fields</var>, <var>type</var> )","number":"4.1.24"},{"type":"clause","id":"sec-calendar-abstract-ops","titleHTML":"Abstract Operations for Calendar Calculations","number":"4.1"},{"type":"clause","id":"ecma402-locale-sensitive-functions","titleHTML":"Locale Sensitive Functions of the ECMAScript Language Specification","number":"4"},{"type":"term","term":"ECMA-262","id":"ecma262","referencingIds":["_ref_29","_ref_30","_ref_46"]},{"type":"clause","id":"normative-references","titleHTML":"Normative References","number":"5"},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
+;let usesMultipage = false</script><style>:root {
+  --foreground-color: #111;
+  --background-color: #fff;
+
+  --link-foreground-color: #206ca7;
+  --link-hover-foreground-color: #239dee;
+
+  --user-code-foreground-color: brown;
+
+  --var-foreground-color: #218379;
+
+  --referenced0-background-color: #ffff6c;
+  --referenced1-background-color: #ffa4a8;
+  --referenced2-background-color: #96e885;
+  --referenced3-background-color: #3eeed2;
+  --referenced4-background-color: #eacfb6;
+  --referenced5-background-color: #82ddff;
+  --referenced6-background-color: #ffbcf2;
+
+  --note-background-color: #e9fbe9;
+  --note-border-color: #52e052;
+  --note-editor-border-color: #faa;
+
+  --nt-link-foreground-color: #333;
+
+  --production-rhs-background-color: #f0f0f0;
+  --production-rhs-border-color: #888;
+
+  --params-foreground-color: #2aa198;
+  --opt-foreground-color: #b58900;
+
+  --title-foreground-color: #f60;
+
+  --caption-foreground-color: #555555;
+
+  --table-header-background-color: #eeeeee;
+
+  --highlight-background-color-start: rgba(249, 241, 172, 1);
+  --highlight-background-color-end: rgba(249, 241, 172, 0);
+
+  --highlight-background-color: rgba(249, 241, 172, 1);
+
+  --ins-background-color: #e0f8e0;
+  --ins-border-color: #396;
+
+  --del-background-color: #fee;
+
+  --control-foreground-color: #eee;
+  --control-dimmed-foreground-color: #666;
+  --control-background-color: #ddd;
+  --control-dark-background-color: #ccc;
+  --control-border-color: #aaa;
+  --control-light-border-color: #bbb;
+  --control-shortcut-background-color: #eee;
+  --control-shortcut-shadow-color: #ccc;
+  --control-dialog-fade-color: rgba(255, 255, 255, 0.6);
+
+  --control-link-foreground-color: #1567a2;
+
+  --control-input-background-color: #bbb;
+  --control-input-border-color: #999;
+
+  --menu-header-background-color: #bbb;
+  --menu-revealed-link-foreground-color: #206ca7;
+  --menu-unpin-hover-foreground-color: #bb1212;
+
+  --menu-trace-list-foreground-color: #999;
+  --menu-trace-list-background-color: #222;
+
+  --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
+  --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
+
+  --normative-optional-background-color: #ffeedd;
+  --normative-optional-border-color: #ff6600;
+
+  --attributes-tag-foreground-color: #884400;
+
+  --figure-background: #fff;
+}
+
+@supports (color-scheme: dark) {
+  @media only screen and (prefers-color-scheme: dark) {
+    :root {
+      --foreground-color: #fcfcfc;
+      --background-color: #171717;
+
+      --link-foreground-color: #439de2;
+      --link-hover-foreground-color: #80cafb;
+
+      --user-code-foreground-color: brown;
+
+      --var-foreground-color: #4fb6ab;
+
+      --referenced0-background-color: #6d6d1e;
+      --referenced1-background-color: #7e171c;
+      --referenced2-background-color: #1f6211;
+      --referenced3-background-color: #1a7a6b;
+      --referenced4-background-color: #7b4719;
+      --referenced5-background-color: #185870;
+      --referenced6-background-color: #731761;
+
+      --note-background-color: #1b2f1b;
+      --note-border-color: #31a331;
+      --note-editor-border-color: #801e1e;
+
+      --nt-link-foreground-color: #d0d0d0;
+
+      --production-rhs-background-color: #4d4d4d;
+      --production-rhs-border-color: #888;
+
+      --params-foreground-color: #57d0c7;
+      --opt-foreground-color: #d8b750;
+
+      --title-foreground-color: #f60;
+
+      --caption-foreground-color: #b0b0b0;
+
+      --table-header-background-color: #303030;
+
+      --highlight-background-color-start: rgba(114, 105, 24, 1);
+      --highlight-background-color-end: rgba(114, 105, 24, 0);
+
+      --highlight-background-color: rgba(114, 105, 24, 1);
+
+      --ins-background-color: #1e4a1e;
+      --ins-border-color: #61d89b;
+
+      --del-background-color: #4a1f1f;
+
+      --control-foreground-color: #101010;
+      --control-dimmed-foreground-color: #d0d0d0;
+      --control-background-color: #202020;
+      --control-dark-background-color: #303030;
+      --control-border-color: #505050;
+      --control-light-border-color: #606060;
+      --control-shortcut-background-color: #505050;
+      --control-shortcut-shadow-color: #000000;
+      --control-dialog-fade-color: rgba(0, 0, 0, 0.6);
+
+      --control-link-foreground-color: #7ebce9;
+
+      --control-input-background-color: #606060;
+      --control-input-border-color: #a0a0a0;
+
+      --menu-header-background-color: #404040;
+      --menu-revealed-link-foreground-color: #9bd0f7;
+      --menu-unpin-hover-foreground-color: #f29c9c;
+
+      --menu-trace-list-foreground-color: #222;
+      --menu-trace-list-background-color: #999;
+
+      --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
+      --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
+
+      --normative-optional-background-color: #352c24;
+      --normative-optional-border-color: #ff6600;
+
+      --attributes-tag-foreground-color: #e6a96d;
+
+      --figure-background: #fff;
+    }
+  }
+}
+
+/* IBM Plex fonts (Latin subset) have been downloaded from Google Fonts and modified to add support back in for the `zero` substitution (slashed zeroes) */
+
+/* https://fonts.googleapis.com/css2?family=IBM%20Plex%20Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap */
+@font-face {
+  font-family: 'IBM Plex Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local(IBM Plex Serif Regular), local(IBMPlexSerif-Regular), url(data:font/woff2;base64,d09GMgABAAAAADzsABAAAAAAnjgAADyGAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGnQb+CochXQGYD9QZkVkgQQAhCIREAqBmTj6UguEEgABNgIkA4ggBCAFhWgHiBQbq4snZG6fcIvSm1WRGQXXW4uiZNF+jFFItzipBSf///85QQ25+uyqDQNDYUgMI42iXFkW3W5Ws9roauz0THfhZl8G/m6P2+EJCkMRWPqZsgOVKgdcabvfEbf1shSfX5Z12Iv8dT+qzvCHfJAQzpWBBf6tJD2WSJAYnsDEt3iD2+dhzNSXw+c89A/9CmOUbAP/tbt9hr+RulSnPBnlDGwb+ZOcenn+v/363OfW69c9AQRSk6i4uGgCyXbCCwgVwa8DmrMmyQKFYIEQIwlxQkiWiEICxAQIJECQIFbDrKXu12t71KjpidNTav4t155Ur9+j4vSk6v+3n3kDE7iBWXjbdgqvMOYX4fdHFVBGZVMgCazKLk4tCLfK7T+RSPw/dc/Ofcv2wSxIOMmayXSXqfrIC4TqUCyPOmSt8ZxtAAYOlEM51VO3l25jB+wAUYFA0MUl9qvf5jfkIBglWTaLDAkb+CyNX4Mvfr/f+R8WGeQSBrFFNL/8MtmkF0ImhDS+n80s6u4CWF+9dQA3QNNMo8AEJrApFJgDBWT7/YC8fjLIvgb4l3ZYAP8wgDFlKn6x1l4KIYDCCTYw3/xem1VVt+G9X+qZaJFYUtnWcM8CxkD2LkvpHjBmxxlxkt3/mZqV9kepxYEow5J8Nnj7sMbLvHxmjXGpd1f4VehC9WcDQ4DkCOiBHGZuhaWxGnHFkQ4NNN7rJoc8DeU5a4yJznOcvOMaZ7MzxkfOBJHxQaa9MD2fXxAGxoa3/2uq76cMuq5G5orxdYZBskRwtQA04ff8ZnvftA6ykY9cyhjLhPDU/u3uhj3voqzdVeijSJEiIhJckBCCBJH3j3s79lM/hwldS5RzMiNIyLbm9evZMVWGU9T4nFMFMvk3JAL47B+/B+DDz7gPgM+/rAQGWAQ4RyOsaDwGGBYeGLmCMBZYAKNfP4zddsMYNAhjyBCMUy7AuesvWCNGYLzyBi44TCjgEoYJAwwEKCDXu78Qhzq4ffbz+IF49qT2RuBcUt3ZDFIIoL/PCh0Zj7343PZmiP4X6Qdiox8CBQMLZwwiOizQ0OeJVuABAmTbp8IJO64AmNmM+8R9rbbJF+0sdT1p1Fmd/gzwN0iFYolFq911sMU2WtM2W/O0HwYEiUAoQ/rQOPRHmv5tzyKKgYsYdg/PJ42TaZPVk/7JgPvkHpycmLwbkVDOWD6uGS+Mr6biafq0cTptumF6bDoyi5vpZ6WwFla4qXVGSEToPken7wJl7eVHv5of6vUiIXUrJaw8KsZTh87n1ppTIgQZgjsps+w+3813a34QfkJsmjnTiqANnVQ39Ezff3cTGo8clE+srU6xfHHnnrdaut78VOnKYzu4sewHEQ1mw2SUjFeTj0xXs9k8WyTLVId+B0eDq3abvota/YfU+1TjHfGhW6iNOtCFHvWrrkpA0AHBTQDLkJqe7cjYlanOD/nXZUXa6q5ZiO5Mqlu7ZXjLQ38m39kP+Gn+y69m4yM7wD9qUi2iTXQpSrvaFRIUoDjRcnHFIflMkTiF1Ge5Uf9OfhB+1v9TcQxNv8WSg3VlzYwHo9QYTdZNkYwkckhSj3psVjiJNHU/VE2tQH1be1TKlhU7hN2JCXe0o4zziqwTAAe30ttkn80kDUlMUYL6qkMMKCgABBwADAAGB6nDqrxBdrght2UlbjE1mdEh0FOtl41ZUYWYU6JAJSVss9MczYmvPlQ5hP7eyh5r33nFpNWk5STSwLFGd+jRFIqTQCiDgmsQG5itpGL2yX2Rl8VaqTOPN5jGD6SADDCNDMRus2wvCreTMRPKxkvIaS80YWxzZ1VLQJ3eAwgAwOFX9T9qAwg4wAZgIgyIIc2e8As0JWbEkmko7aaV4+QV4A+oaF3cJgE430kgQ9bTZXHCOVDBW80YMkYwTk2KWX3uvBJObkRDzXEnAKRdkMibKxoI1vey3QTbYcV2X5RRq16vbtVnECL5pg2/2/tt+pbKEghmSmwQs1m2bYBqkfzDFHtkvovMXFEzA9BCJxtLKvmGiNuqixTMXmyt8LMOAMt7Kw7TlpWpKmJdlOjcC+eC2KAZhnE3IUzNzK/Oq9SqKl2CCWLzslFGIczFGIQfmIACKA86QD0UB7fBRa5AZaS2ZaBkDsEdicqxOlg0km1jkENUj0l34DqbrJ5UImvApmBpia07n5DsABAshWW8VZt/925RYViFw4vDwcWXLIWEnIKShpZOugx6Jk5+JcrUatWpS5+ZVlntQ2ustU6/9TbYaJPNBmzxiU995pLLfnHFDTPHWFNLW0dXT9/A0MjYxNTM3MJScgPSsPXuLA8B6VvE6BfuGDOOLi1zcrqVOGaHzLhhkpYScsDrJQcyITR8Gb7P9M+TEm95jxCycWNlW0MGCsBBLqobQ/DMuMPKRGkbAIq62L+P2f0G9Kje9Cw7j9QT4SwRJaqp4XogOGvz8kzlVZlBalyhJPoCJeRRY8grgWK4rU7wbdzDut5EOXSHoOpstRUY7XvEJXuSI4ZJOvPd+XDmSfuFFHuLwK8SUjNEeb/FuN2bRJZEo9iVvh9LSaXabUWBrdXNJKWkSuEeLN5tFSS94Pnn7O5ywS7N3dQwVyxTnCFxAZ7YFQ46gQmKIG44pt0+iZZ4mDEFvX7JE5Wb6ceWoXp+o8SgyK0t/m6IoOQ8fkRAXIjHb0WMLzYY2WjmAQhBOVh0NNs+JB5RYtB0K+CxpDHZphSzSxCzLCzBSrPB0Xi7vkKmzdJpAaaG6zbU0QKy3KRYegywnqvUwXMCo8Mg7e4Vz3GRIvF/azrdTCSzsXdI95lpeYdgHJV9OBa8TP4tCzBBtgdtnEMSCNqtNDs2tXx02NIruShuKAZ2wlCtKde+AXeP1BCF9tiOpbDP9fXtUkpYUlHWloqfNmVeyiqg9tpmtdQfD8MBGMgCNWTzRmihnT4JHCNDbKM6IszLmogcBl+6qdDDhHtwQnxQzceKOFGNy8NQiG+hoP3zYZosrzHgjHql441NFYRsTscgX3XlKFaXA0TIRkL2KaWYTmQWWSmlamJJqpV/4brtCXvWjDCfePl4Y9xyaCil9SRt1x+vnB7cOlC9IezAEDpaF0gTNh8g/27LtTVkCSKwRcEBph2Pd4E0sIAq2bqBcK6u3iCRMY1ThPNQeE4Wx1k4nIrLw6RwDAXH0nFEBg+RycOZuEAJT1bGhSr4GLU8SitP1Mn5ujhHHyeZyWkGOM4WHuczHukmJ7jNue5zkQc8xkOe5BFneMzxnnCipzzFM57gOed5wdlGeayXPNrfnOkfTvcvj/Dft4yHEeIODBQCwTsfRoQAB90OuOUsNjq2DinGqZi6Dp0kFgNQOHRRPACGAFR4E+k3T5gxWMgoWFioqGiAKqpE4SIAKUBaVIlWMJegwYuE8Adf8mgOHfQ00MZ44nHYwiR00Gwyev0gW/UifD0SkE4AfXYADuWhEKGQwIOuPKggnInJ26fASDVmZhY6XUEnQybThByv2HEWnofPpl++iV00TvubmBMMir8lZrfhpP7Hl1fUWt1S0lHZmb9JJ1KEU2zQ8mmLoGj8hmF+Q0RyoHZjFOiBTIh7YPvGEHSh/cKrH4y7HElGLDFUGiYWYbq/iQdhxfRDtTQ5nOzrhUXhFYmMHQ1EqZyV5ZVJ+Jh7CFYpBa5wMLtkICbMP5xndlOyDttSwS41QNc+n06UnZkJns6zQXbOJ9d6uUc1ncpOll4mKf+IT6czzzwt629Impcq8wcuRYbJx82SsZAjRFoebU0L0Ttxz4mjdzdWeTKpIGhjQq2jL6ZhZCLXdaa0LsFkO6wGKhs40X+iG1wDcEaDX0jq60GHMdSRbkdV6YyWyffA1myTC0lz1Kq4rnX2DSSKwq7ZFq3VBw3LGXX48OIWgIvZdgsD5jSSY6Ky+dxhMmPA4tCUhjjdQwPIlmV5y2ZRknvDCXmzZOyHQKEuZTbRYxc70KHb/PDs1/PABijvH6vEeQGH6dMH8Khi0+QBmD1orlQVVyCwWVwB5q7iAQCiQFdGgHkHZ7mZgqcYUS91HV+QfGSpTXu+NE4Kd04Y0ylIDDJIr+JI7uiJCUfcAQA4qzJ5qWjC1oBj4mO9+AzWn5sWpTdNd6rVgZRw+MQApma7nkzbwhpWM1eXT2ak542lfVyYgJThTKUS5BF47h7h0lhlwaMcNUY5laF4lW0jpjVbSKT6trm7luGmqc5Syvgv1Fk7NnodCWLKSEzAMQWhsWrZzalBT4ZWSLr9wOuxivdno094rAWlzLulo8OprODi0G02YFhBCXI3u3K3P9301Xsq44XiS0UY1XVQa9S6gSvZlQxPcFVFMFJIbwGdJdViI+IDqdKMPYt003pAi/+S3JmBKa0WAf66PWurq6mImcpat7VfKJtBAohU/dYmxxuPBcFRBw6IwUGhXdyX3BSpwd5xkZjW1nJLGcwYIjJCG7lEtiqfP6rYHKBcbSaEPyi6Y8gOrVmi4s5a9wGRfyC1UNk1OBYUWgWDxNCreCgjE45aPfGYiO3gs6P9+p1BHN4rVJQN20Th6m8ADsc27tTKfk3T4OEApiBykbU2DtyiW2Ka3XFjh1zEomt8sEqHrUkPcikePEcFAgAHnCHOqG8B46NVkrfFtwVhZHYrp01WVMoWmwvh2Fd2Ra4GkZjMoEnGeCv3jG8BycCbVseBhpAU4Kayb2Ab159xveuFsprIg0aYCTSB4jpIZeKgWNtEbFTFpULYiNdQk4G2+2/7Xzk7WF1vrtutBjeKV8XUISXtwc7KQ0eaLQ8RJV66uy8G0lse9REBLd9Bh8mEIE67ejYJtpuPCq0J1inNc/3p8X0dNP2s1Kt1Th6jTWPRfFCt7QnaksQ6EbN1NMZWvHnTVHfVOe+oR5vF5kVXjhgNuqN54hq3Tta7MtsxKtq8Q65IrKm1wAjmB9rOfsSHp0CsaK5Fe4EGzQMy5+YNH50SmBdnVFC2jdPwyKePP1UoZUyq9iu1URLl74F9MX0zbn0iawz35j894DFIr+K6P5zsL0quENNKAfYDkGbd89ZSO/PgbC6VuBR7sES0ArD2wMI7q2TTplq3sTUHGu0123Q0zKQ9eXL2ezX/x17f3m6m/UJuQppN5qY1CmyuG6DJhlu38kdZM7w1s7vrxI1byUvdcFwPihmbDCH25pJRqe13qRHySgoYo1cFYPz7h8SGuL3prgH18QywKjs5Z8dqjYZXhFo1ye0qI9PgV3qX2ZjalxdvZF0ilUPOUT659I+mcWvOmqTFv/UTb/51m3HoejwS9F31HEEnk8T0Fcb8yzWGegNaOliAfPvIL2nkcggciSKDkFJ8qRElpMY2UGLZClpDeCL5h6p6kSiusZYKefLjmTBBs0gap6xoCuPjg/w8pWPnSIBSQWfxZ/GGM0SleECdDXERw27hXRakK42a1LisJGbFkMmpIgFS11TnGMdI14MWNxaCbzq6mqd77AMxYNBbUyXSGqNK6vfZgcSw79RM6Rk2Bu30Wu+aflMxAT0A9LFxACM8wBifQDIhYAFYSgUUf18GBNx+lxAnWoxYBHHixAsXgygBCRlQBzTQuKdgEBAWCeFvfKWZ6Jg2UKcNB9LAmNAT+QZI40XA29EE3oE0UEIW9+dMOKoYTHgO4aFQYUICgq3lO7VUFkHMCOJvZoro50Z/wXcwQi6ExmkOjcF5N1hFsIlkYwsJ71VMXcunwIiCwIqGQwTAF+ATsJMgDPVHjySOkYOdkZGCQhi+UApS8RhijUEQjlzilcDZeYQX4EgtvuHQyBjwNlXEI14PLpKtIzINpEU9cRwbkrSOMNuB+BseDNBj+HI4EUQCIkOd5liGEtGFBE5P+YseBtHHSgDs/793K0mKZExc6TKJabEYCAmocGAxhAgBJEXAiBIFKwYBDgNTKB6eMQSEwomIRJJIE0VGLpaSVpx06cj0DCgsAmhKlUpTLkiqSRO5Fi0UpppKaZalVFZZx6jfZg5bfSrpcn3uGxUGHVHnoqta/OY3Pa65rtddIybDtPJ6B9NqRKrwgyNOueAXf7htxGOjXgWYEROJiQslzPAiijTq6GOKI7nxpzRVaUhj2tObaZmTRVmRNdmQrdmdg/kig/kpx3Im/8vVXM+d3M/T/J03i0/mkuWk0FgCsVybaXF5i8prxjV3Tp7x5fe/Ti2sOVwBZeNV/fz16DfoJPsj2QxIjkOyB5LDEY8+Re6OdmK1jRogoerFDKQ5oPPZVBIA2TxrJS+wP5mOZVK2Z6PMytgsMpHQCQOkva+6k62lO8AcEVpaJ7xhV5iC4WmOYxFsBoO52oO7IO/ewwFNUXi4S1olnEEYhfsEk8AcdzntLlF0zPjywUIM8PIwUQDbMohl4UTl5pEkVwG2QkECs8yXZpGVVD6wjsF6m5lttYvDXgcE98IFDvlRwM+NB2HMBdkPjJZl5N/shKloiKQwTrNOk80wzxIJf3Fvst1en/jKd4accM5lv7nproee+9e7EEwEJjak0MOJMGiUSU92bPGkIIFUpC4T0pruTMmsLMiyrIZJcQ3CBAWWz7JZHnOxYGLhHg50hh5tjbJvaAGwhqj4ztSMy2zR6cXpGbA65mVKPgZLJ4pnBBmtWbNzYO4C7mAmOkZjPpaQCCt56KKpaeyjaDIkoL8qcGuXoO1hR9IWHyvqM3UBfAvaoKLEkfM/x9O5uDHkKZIkICjZAgtI9OuH2m23NIMGSQ0ZIjNihBwWzinngX+8ERocJhTCRQHbAbsAewEHAIcBxwAnAWcA5wGXAFcBNwC3wYBaJbgLnn67FlJh/2cLM1FHJhuxkaMRIQ+rTMIkf+9Dzz67qRUE5zS3NAH6S+ZfCCgvGT+2GvSXdTW1g+mz0GXjVBalAJ/NvB8GVlUhXPDugXmI6HhQaplscpXCAJEb8gKhQ6XVQNQ7Bfvdhez2uJTQ5MktguSme09m+69mqFEYGPGw6PBuuK9Ppy43P87porAw4tCBBkMUUTgHZjAickxfjd7fATNfNxxgf7A99R9QaCKwsHhEH78WG6DBGEPuoSP9BSvPXfL4AScMTorB8d2JRvQG1lmvYZ3yCtZpGBjn6DdxAIrC/PYwPLCwrA6TeudyFsNgUmCQDH/ldRULER+fbyEKq0x3uI1lwBKIBY18hNnbehYORj39OLNjQzAhckKMWB45pM50fleVLh6ptKwQAuqeCgAHh1/UOY04KlBjCC4ECQVsmwHOBzYGwIFPDguTDdZaCsG8+wUMt4W5BmDuA9SAHQTWgIUByHlnN3UCWALGxC/MqH8GXvzqAupnPMfvrIJfjLzxq5uM72is7hhXX/dlmhp+Nlr8gjnyq5lk/1fTna/VYNnk912MoZMVNCn/GlmFfowR8vtX20ZYEBHAoqZ5j5HFV9/VsfqjheO4awhYClY6y8LqZO2vrMX+oLrU+/dgUSwDyVJQh+pY/dYAt/Ya8Sw5S5fOVv4Wmv6y/9mH+sreNqd3AeD/N/j8dXP7zfU3G2PVfrR0Pv2J85mshAlshh/Au7cAL3rJy3jFq4DXvO4Nb8IfGW952zt413veB3wA+NBX+JqMBJBCgVOENkzG6Vdzcb6ui/MVnv5PFoLN4fL4gmRhiihVLEHTpDK5QqlSa7S69Ay9ITMr22gyW6w2u8PpcntycvO8+QU+f2FRcaCktKw8WFFZVQ3kd7/65rvfphZWV9YsZqudcbAc73S5vX5fQAgqciiMAO115174Qe+W1rNfdk8wvx86wPk94JIpHhicWXsBLp36Yc2suWsPf5vLq1oBiX6GG7f+/Q+AG4evgjlLZi9dtHzFymUfroHVGzauH/oh9hosmAyoWzQzC1lCSG9xyAxqCZD1wfIHs8qHtOuoU6Bqx9UrzUST10ETiVYI5bYcITqK4LVIC7DrLk2hitnRe3sFbAE8VKxdtME7oddP53AiSQnrEGPInC20WOsqM7QSikhNfLBk0OUTV1egK63JxE1vwTi1V7CzWXcl26sIgNwc5p4nBCJMf6SbxO75sUYGAkbZ/UoYWw66zJZ9AL9JLwohE6JboIQXOeaWisymIGpsxTYs68QypY0ftf4baEqRHsbaquaZqEYipVxsqmxSHevmNLNhYhtUg2pGbtff5lwH+JpRi00X3YyNAGMQmkeoNlzKJZsmleGBGWIk3q+pT2NEkCmValHRfVYaPDIZEkDETOB5IGFiQylh0EgjTdhjCjIiJkLZPErAxK4eTUaUVEA0h69lS0+5/8rBe7q5GMa4E4EpBFAZZaEGFCxJp9hOQhJqQugP/qk2OykH3E/m7aEcOz9vRhthSH8UgQoenfO4QzyxM5zBe4cIQv+3CFgkm5qGddSz4TuMO3gE+DrX9SyqFQ2mRtGn+ePvySkMFjd9to6e+27hF0Ys5Aa6osn9jtdqgAnhedS5wR6DhBhvH6mg0b80jDt5PGYBrrc1v9M6/B4CWLzPQhaDX6qqOPE6+NAcAWGpwMCB2YSstc4kygfnidc9QFzE/tCjTbbTD+uQK1ch5+N8i+vaT9EjbtA+xyVTRwmB4MSt8IF27LdrjlUaYSzI3dNMchFlymwqnLCRxmMyasjZ11MnHHARtFTtRIUVIaNaqC90eEtH43ZX9/GZq7Eou9+CggU95jm1jdKmI/N2p5qXwBBGkEnVMS5lr5HM/2LZ9QmPDZ+UrGsvM1TkEG5zWmQl2bqzm5XGiPekdedcJ0aUmzk94duNakfM8nKixtgsupkSkdU/uGor4Tge95QlgMuhmMkQuKCwQ36qN5JoYUs87DnPplmKwuAqeHfzgMty141J5heDrgWnxAV2btQ8J9I/aK/JDSOnWGEPV9KvFZy4dUQEs7ZNc0kDNEhakMm5Cy2xIR6kgaA5oORr9KfFdoRVNxcZJLzv+x7G2MOKKsLGJvGYrgZ7LMY3ildsJk6Y0gstWdvFRq06TjeBQt8iKhVWcVmwnBq5L71CYPHGCiFIC4ekCi6Sw1YVzoEbjQglKg7TynrBbljL0WzlxNhGA2umolkkW9mfFamiM5evSvWkbgKbTFIRWVzO1lX2ogmZZJUs9i9GxQuQwSN0UpwlflbkLK8I8dxkqlzhrovAGg+TPV5XjJt7sVyYEC3HF9VFyTYXD9SyQK5TChGZQtAnbjXbGKU46jJ/ulEJZ0peSZk0LXiz3Ai/41KkhLulEAL0HTgfA5LD4Hca/gCf3jJuN5uhkNfVKPdYwnGp7HjEgMNp8Eo6gD1fqQYw/rj2vBgrqnXyF3dqjGV6pbwg7dQBYI7cYYSb3TZhY7c7lLtX0MMJKRbXQ+fw0Gi6nx1oOhjCvLcHKPVWJa/Xf2v6nnKLvmOt/Zxob6NJ7gTWqfAv9m9KsKjfHPMNybZcP5OoCVu/BCf1qlerhhBgc3ULb7j3qatfyUb3bdHqhaJhprNs4EjI40FQ6KEP1+84PG4TthomTpTiluAll5R6GNVuEKh61kzeu89Tfvht+wQWICf6Ke747TDTwhMBryoWQ7Ef6pkzFVUcMwNW1/l71oojy3gbnUxBmcdK1SkFJN/UR3pIF2Aoa80xSTRaSN+K0w2Ln5IIdFI0FmeY01t4woLHKEAFLpHBjReC4xm5heO2lhlhKUbYxmDbSxGY7pYwADzCAV1J1E9uflkBinD0+VFHguya3O2VIKEmp3G8zB6TSNUeY+Td2CrFOrHCj8r90SHCZZrKLPw7kv9Juaf66iRO6WgcJizcy1faaOxYtTJTRc3MO9/7hEOhXeoLBPvqJCPpTumTwCfBP4f6z+xlCZrthOItEnenaePiXCIQpjl/XCFABOeFBIGF4RnR0McSE0wzY9cwZbM1URKUfqIhega953JqZYg6ydDdY2Kxkp2hoYpLQQlAAp0wWSdnyxTy5diHaz7fBWFpKrVhj+R7ydg38NAm7BlFWsBnEfnctJ5efpHQXu37WBdMP7MtkhlYJv8JPe+jayfxs+SwkOn0MZ00zvkMW4zAo0qbZTPggMhxIOgLUBNfbMrzcgtbJKdzlCtDINhO9cQk+2us4Chj/OCrcTz6WhcyCZhiB16JwRTsmGPbM5bzjW8H2CQ4k9YIHNB6MftB4etZZW8QgzMLfkblE82UApNnEWSLFIfO0nKXKFYJwCPTQNdvdDfC3bLLeNUe1Q2sc8ofcxmYrugRuw487g77JJUSPL4knIy1uJow+LmZeWaA0a2SUclQlyYUjWRNFPL6jWEfALC1lxhNCwrNyNLd9etDzl9llM6TKaz5bBO58LD4pqv046gVWmDcrPQ4/IQeU93dPA/6lGK5CL7DmYoZU6zgI3LebFfEVjbGPIoWb4VzjdPu0xnKcwBrDU+OU7qTfGYEOk18brgghCmbmETg4JbpDOpbDFtvZndijxxASY23OepsZsn0GRz9BZkQoyiNGKcKEZZO1qj6RJ4ElhKu/W9NmU1sGAus6U6xpfJ+C1pgC1HVKi0zRf7XC36Xk9AiwE+2KduajvwpIDIpSRgFjQuqIsgisUdcUgRxG+H/VJLHXmANKts7dvIzDatCkbcilc6jk8Vs4hieSUM74rWlyXSbzyi5HasQfPwkMxV7wsFs4+xiV4yHW1Gxw3ELeOR8kAqS834niQleY/mW4V+eTaL7Hdl6jZgqUxSHQuYFc3R2Xnaq4lOdnjyqpWiljjn6iCUPe/bT4SDiXD1gQ8ici+FakyNYH+lovY4atqOb1GUWCS3aBzrDYKrJb+V+eHjmaTfdww0gDM77mpOGMtShN8Pc26uA3oGYyOllscKoBxmmYs2uDFnx9sNOA1zoJBQRDR5Mmh3Es/1aCM2yMaYB2LkiJ0Z9qB613epIN8u42KRd1m5jAL1kcujx8tvigduSHf1k4wcFmRXq3OnwFT1guX3z/Kv2uUPZ/fN6uZ9kwdCwx0ipK6Pt3F24BjCB/i88VBDw2zAf30xaR9XhZqs93GqfeBEPO/DG++FCN/0o9rwCpH+fnaR1iI0t99odm8SiX6Gb7gnTd7WEUNn59V1RckBgHSbRzpELsAmmKDW/KuFxrXUuc3NRYtMrIkzWjjk25Z7izMWXd7XOB2ZeM3ZT17PU4CaLfKRFBFS+D05bMa6PzE5+s4GOKmZYVxrRfWkgsM6xZKvSVIcD9iw8BRcKTYYJXnjSZUFdxZ2wVKOoMutF/lAvPTf7Pqff7pyFJ6HTUt2oIhi2REiaSveOA9GuZKv/BEDnuc2yirbZlQ+n0m6SwzTD+1JaN7p4Hdsk0aq/SReVsqc9AAgPv3RtB5udL8LlMs9NpcPacKMbYNEjq0phMsZAtOlW0qt9pafkH/ussHeOXktjtm+6I0HyV/81SQEYMlVhpQb+MJIZYUsYE7obs0yc+lOZTgxiOcBWshu3YwoK6Kptkxn0X+HGE7lWQua+rVje/dwMNOXmyUXzriV3f363d3ctvbn3IOzVoZQkfnOXN75qBZkrprG5Y/8+dkxJ4slqlN50140FHGgub4Z117y5ay5HB2N61P0X1Y3aPr3bvL26huHlYq35+Z1y3mrffvoOTsj0NX1WpaH0+Z75fyj4rWxhPVByn/alqo90dGz4ZWRqbl6t/RknXs0/cmjfM/rRmweV6t3s3M7BSbqq6v/L5628VftvT1/qTxhvtfx4ZY/hmyvLD9x6u2/7QJ0P8J/cwifGDty7Rjw5Hw8mVEXkKjE3R00GqTxbb4xNazGGZZl1aqPxLVyvLurJ7SlKrRVas6OnMJz+uupqek52oYVW7td28Kj+9rd6EOBVxZQnXKvE7i0xcrDP+DlpztqiYuHokdnMpK+e/icbuoyNL05zomdQr4sxvjehCJeKmpJt428oy5LzthrZWTZRdEq9TO4RRwh+/JjTJXUy9v3+nMl1SQmZxWbwrShzlhG/TQJZ/77CUkuPaIWvQLQS7+fCkn1LlxkLJWPJHYYcPblT0mAsWrYUMFOWGYskDeROfY6B3CEZayxctnRfYcloamWBT7Ti+pbuA9/nV9xZmbyyE/pP3pGsT/yKHsw8uVNOqqLpdwa5zPiWrxyS/OxXPNnhu5pQiCGdU547rT3N/PoB8XyGJLsRS79EDqXF0RkhieGk97wzTw5GX4gtBOYG+/IA/oEuVtGng1SeaCAnNqBZpdnOkTMg4oxa0Tvj608/pdfL/gsYisUHHJ8X3D/dmLN0l2Qv6LNv3yGoavWkLIfDyJWMYI80k2hxNPoLJvWR0UEU1XfWlUqoztTsPZHf7URc1fKDxyAan+ZO8J0hM+NpidhEYssRbPhEQW7AYuJkeW05+TK3021RCnQOjYE/8T/scCWRFpeY+IJJ/o7rSJCg3oTTHKOYM2++6xgy3P/7meQ0rsuoKEuE1gFHuud6zq/12fVbCiJvRvUhEIWXOBMU35GZ8YmJz2lEw0skfKLAn59vJzs9Pqf0eHgpZVqLzxYXK1XkKHRoLm0Xu0Ar5XnNuvIkEOM7elfNrtStq29dYMvBn3g9LsNdLGmp9LZ9vjifI3UzS+hemZxTcN/PYgkColfcOM5rUUBwXvmaE8d99b6DSw3BTvnx0/rIqXZIxesC9MMsh1jw3an1d8K2pU4cy0pJMi7No8hkklu6/SqlsMZOTN0Wdmf9qe8EYpbjcIC+jNdlUzITmEpbF49877jV7JcvHtOiaY9fvGTPtgar6EbumSePy5fndCx22Tw1cC97+0v9+F9C3xejB+Ody6rL2MvKyxBI44s4s/4RAHva87ENDjNZb83S8d+EY7ctI9Fu0+kYFvVNgZ0olLiplQxTioTt+Dwv6VKXJvFq3H29Hen1L9BVT1CtDQbV/TXNiw1FhUu0dWM1y4oVhNJk818SZaUNJ9iMcgaHaQVaLa1geJCDBm/gEi18vSdDIa+sR82ijgJ/jzQnp1uVXy6a6sxwpfblBzpkzltMQVO46anKJF0iNanU8mx13eF84e2K24srby1WoQ/RUsMXsfo+L0VPHYp70RkMhSZ3hRvNDdSUuPklznuzcSu7fr2WIqbZsWaasHFAuj8926wWq3C50/fLNqg3SsXSjeoNUIg3TZS5gylzfcX80LrKxqdlG4tEN5AsxxmHUl6st6s8AqmJFJBN0tCLm/PYCnulM1CzZOphH0vnEjxrm8hbJJ4VCEBY0Z+/lTcgnawo4CxjFqt71cziZVOvYnL1n01kt6MnMfyYV39R7z3G5M9wfBpdaFO+dOIqUQA/3jRB5i5PmesvTpmXU9aMWvOLxT+EZDvOOGTaoC5f4+XkUQOaGWp6IOhmowJj/Mtd/OAUNB7N5rLTqpCOvx8/lz/hIeqOrY1lFcIZtQxdAZn3GtbhrRaViD7KoP5II2q34VZ9TqjpeVmJAup+VFTlb/Bzl4uUj7t4x4teQc1XRp52WtEnqP2kumbCGamTymCG49N7vI0/Of0xbvjjHfqXTEZSq36ctrdeMwlJrt1n69X3dKchWEfsY5aYVwaQ1PPSUC9U5PJUpsQyTbvmIG7iYkYFdwmetU3mDabO8fsprOhnsmJKwXZslXUV5WVjayu2+XbqQOsmtdYsQ2WH81FvAsx+xlroH8oK7g6WV1jK7fNI+yUshz/VUlatOXb2Y56ni8BELwxbltU8KthQXm7P7f7uiOq8qiDww9FsxsTh6i/77nbHu9GHA20b1TqTDJXpzOqNIMBn5QqehugdZx0o9X7azJRijzNTte9mUzm5vtIvSrJs9lJlOgfncajacdiBUv/K2CSyWbOU6odmgriUXF2ZK2F41vqZcEhSWfZJj2O3bbej55OySpQI3XhLFcNgThyfM70PdrxcRciZZaTKavIbxi/3+oei3UNu1trLOOBcrELvo6UNqtz3yDNUK0vR06jql8VF4C5caiYfWecr3OBDZvGrdeZ9sWOxb5Md6bf7gKH/H/+sRo8+Rl2b/kZ2/G1Ch1D9Wdb/9NfWk5VbXiF7Xl2FI/CZpPLBiXYV+gwtHVAh21VKKieanto69ZNVxaYex+7HMnvJ/hmOTwH0/wxJuoXdkiEQHthK9HJsyqwh0BWcb7C8Dz4+ZEa+BoFSj9Vg4YtbHr77kwNwCu/wuoz83vri+CyXx5CenUH75gp2h51E+4NKecggrXt/dk2SX+rzWN3cXW5y8np+WEhViwYNlZqlimpj6gbKn5QEgQa8+Ey3AkEkHvY+ZyR3Pd2EIE6loap90ezZnNKjtXrKc/2585eNlfLW2UD5g9LgfAtkvLZIkGFLqjFkcmqzrAG+Or/ComLhGEmXqKRKLe74fBZ3z6ZpfFdKgmn5Qp7BKneMLowdzSYBghd+Zar0LgWCjLoiuRvoXzsjOesZpbojDk15ys3fx0DCa4oEGdakWoOeU6O3+wRyRR5Xnc0oUZFraYX+anumQ+5APmIRjaSvM6MiuA9ej+FwNKk0Lpx17XDJXPm8vr27uOp7ybRzZNI+IncvtpqAFx1Sl7fKWndUoK8g5JLeR8hqohMJvxYokf9nCSWUkD/VOZrkc247OTXNRKkO38MgnSQl7KXQ/8TJD04XJN9wO8ip9LmrV5CpPkl3wG8zuWYWT/pWM16eLB+vSV+1Sq3Qkpye5vbLRAK1ccPbsyBxTfXzDTIiFdOdMUnBvKpqlgu9i7qoTp0ti7QvxUoze9uE7ZNpB0khpIM02g8y8MMSj+tDP7m3K1wl3SX5aw5pI5k0PiH62CzcbEKml7t4+5Z8dy5Wkddcq73y+BBfcOoiC/oL6lyx5otYHTqMZq/4tah0+rlT0T3FIYbCq/0RoxSpnO58z7yTI/sT1/ZBkM0J5lZXJ5l8shU9pP1j1DQTckg3eQOliYQTVyx3xjKD3uU81YpJ9JKoPP44cSSvkRcpHscXBLJLB7yqYr7Bxq7JNLBrrehJhWWQy/SRvA4kf+QKRkzcsEK9k39VoK+SRmP25U0fVYy0caJ+zSbX8zT5o3Gnl+VGhbTk3VueKHYKmRcpiW/IxDFbsNJPwhNWgzPBFD/vl9eSZhXsQhT69fqE1MJM3YjE5o/7zhnjcpssQU+e9OxaRBR/8gTeVsU8Efd6b58nxuM0seaNmEhwMkQ1WTnZJAtPmHu/SkQKSObNlc3dOpc9Z1eIHBLwQW9VTWSHewtW+o+kSPS8k68oqIaV6C+oY9EkZN4kB/oVqvxiOAsyPljnl2qYi0z53Nr+OTJu7mfrwPti1rC3eTXSu9oLj3Rrzq77VYn+D81o2YaM35aJfonqlp1a98fNupRq3om07fx5B5MvKX7j0n6kkReRCcgq3LYYGl3u+P6+1iOHU22vJSBO8Omfjfr1C7gWXmxzHQwtTJ7IwokXi5VcNo41MblGUkegUC/O9UX45l6kUgh1khqY9I96lhrY5aXprtqI2q6m7S8Rtr3gfcC65mPSWqpmOMRiTldz1fJFYPHK0aDpXAT+A/tSAbwGziNSWhMrdDpGucriTvn/OGWDE+c3KZhYRuJtKrFRg7uyhHFgZrZcPTr/zOpe+VglxhPMLs1y2jODU8Bk2yap1MXkoGVpecfJeRIR096eS5ehznjTOTqLyGTcIYu34kYWsfJsTq2SWvDNN2kHE5OjWcnXTFSkpE6+7xRIu/PcdXWHGhocPp+joeFQXZ07D/3e5UrZyMtbTD/z1kuEnZ0Kn0gqxx1ED05k7sNpaS36Ai0dYCLbmKXoecf/HP2otHhw3KFlzKQ/1GPVs/i7DiB8ZC+USpgYGvUPcoJyGHt5lGAwpslSbk+0xJf2d8k4Cqvbi5hExe4qX7nDXx0s186YWuSu9OHVaw4rBOfWO4hb1bPXXMruBC5MIO8n4oj7yen4ZuRjCUv7fSXjiyVU+20jLTnDqhCSFpKIJfGMt9jtd8lKo1mp1hksKgnht2XV7aIngh5Dg8jlFo416A03cRIX5zBk1nMFlrhu75WVBOVzfT4KK/qz222TMIE/TmBViaJNJLcpi2RS4QQBLwU363+RhFpCXB2RbkazdP8ofpFTOucTdCoEt/OilfUjO1Os3cSKpKXAWdIS5ZFXWli1mfgJMa4hiZ6IrmesJGDj8MT1K1C6ixDnLrHw9m7oY5FYfRv28uZTM1PszCKmWyxmrmjrSRE6kJRIei/tl1Oib0VHRd+MToGBQZKOBCMtvJNnl/F4y86e5MF5yaizfnpNpb7+aRZ1Nh1iGs8pzx3THmOKZ9vHNX+hw506c2IHgYFPamAT6ubgOrdFxNniiMUJLLNEnWVVy+Q6y7hGK/KVRFhNhPVmfXZaErGYSBQQ8CvrcHiOcDszhlEtYPMZPB85iuFJ4ozg/AORBHU8MUBkmCWqbHOqlPBHw7XniNUtUOdpILzI/YmHP3UdjB3aHb0vmSlvwhHhoLYEhB8Jnt7YQ2OOMmgfU8iLrTi8QTBmi7KMYpYmO+SyZKf9OS0jK0NQt6m9vi1+c2qhy1QEW56uyR9b0JzlLdyv7P+OSDmSEDvB91lcpSAmj6OMZa1gJURdGg+alkZiS8qTJVkqV6UgGk71UVnBnSQXaWeQRT0nm9YstaaJNZP37SaSUSjk2Td9y8svCn9/Nerb7J1jxAUwPgvfmQMqddCDOp/r/Lih7i9vl32Rg/54O+7spAio7sgPU5GmS7VKa7lgpncc9rYXu2blsLGrHFCuXLjzNYMldUoIxOqKb8gXlR3hv1P1DoXGNwE/UduCdVaa+Kj+9aqE2XtLkB71rxk1xP+ie4R6mndU1lVVlNVVVu7o9qCPBi5vUmtNMqlMa1Jvgq/w+T6NiLKJlDCZGHt0BxJaSNOdk6QsfLDTEp+ZbTAGXV4cK9/izbZn53gkG9Djsg8GU8rMnZ/HlMtyOX10b1q2wG1ME3ATvltjJ9ites7Ce0byUe4t5xmFfQ3FcXeJ8cqxCAY7P/SG32BQeAQKE7VMRS+MHhYenzQ42rxtvpBrPx9O4R++8KohFK3S2I5/odGiWkk/7i//AwL37A/32RxKIp4LnGB9N+LmClU2ekX6QPf15j8+stZ4/RlPwGuKuBnmpMqMDGaFzpzPlee/k2HV1fyirGP5GbUHz/mvLI4s0N91qt7qXWnV9F73sqkLJ0pNuQWFvsLcAlNmJ5Cqp98ih5Jv0emWiS28Ykj17mHjV2s8Q0lV+iOoQd/3GruIr+4UbJBfIdqHXQPkQNtM/2AMs9/2Iw3RDpSPXNaxQPuDrBjjKHWpFry7S5YfFM3x+yms6F+xW7n+xtoy9d56pchEqOJUHcaLtAU8jYk2uhRYozZdvC5Q8KqiwaBVtGlWgy49tLRWlzH87wqoKA9Y5K8anZIdVA+GDhb3QqfWc5t5+OHlIXheM/d1oqOi8JznB9c/1Un5PiGMxXWeSuYerEs8TUISTkP6g/zsr+mwun7yau37yOnTqqZRkFpHv8mcem/S0/VPqQOPKBj3aIBKXfE293PwdgWMGx/PolLaY2IkHO6yuqSLHx+IylNN7MucwL2WQGxt2gJbD5H1JBdegzdv47zmPMx9dvKz8ZToiwDiZydIxce7ZPKU899oMo3SCOkhr8mcL1R/W1aaxQVuCPrTZ+nTDrZaOqibWOFl1uMh8dvM2+/Pdzi38pDsy7/N/2hlWkfm8t4VPyJgw2c1yOxBwRz/gdWHFko98b6fGCwekzFMS9mKy9grUDhY/1Lcqf+i/034D/0norR+fKGlyOkomJLzQS4L0g+x77BpRd7tudsLaef3L7WNyt6ajAv1rHF+GI6jbmVTa65RhDcNYr7rpYsvNtwUUmfC/MfxY7dO6jtzy/VZ0Q898cDNn6j3pLgCRteKr8Z5y2XUdbe3+X2KFOp1Mnk9kXsKO1ws5C+YkMFL2boBf3sUUt7xaIfNNroIhYRpn5FLkyb/qymIPVXnpEsdJIbJZc60jg3bG219t4AmN7lUWko+NXYxxEXSRfBdYypV5pdRU9Ojdrud1eXl9NzswjBwyP7SSO3hRnADvITPphyPOnVF/fWYmciqjWy1OUNPK2vJhkGz2ZlrVbLyF3g4X55xxDoLpkvX/CRUGrJVWo/5bx6ePYaN5yXXF7AzD2UKu2OVyzNMcMhsc2agAo8NeXmam2pWZGWVqanc0y8Rm0eAhiezCgS4xNhEHDki/yD3eyqB+j13UaipUudm27KviuVdwPqZ7uQN33E6vtp1KN+bYojj5pDz5+wr/V0HQvrCZSFY474Ql5GmK/zkfcQQ4j5yenUX8g9Lu9z7HdzeNTWzT9+p977D9+d/+161jgikD+J2i1fHk585lGO3hQ07S3jfqn94PYf7CLvlH8Ydjl6cRr3a+v405AXOB/6qM175L2e7OpeKfxlqgigaMevTX6iqJYnWfpHN8SxhH8QKIAIMF5b/GBAtIQIsBIjAbOLHSK+BD6PnAOJCIbaN9Dr4kDiXcH2tZLiB+bDE02gWoX+eSYRdUGk1WgwjluJ4tZGNr0mdCO1/NCdXIFRbm9SJyJtjYjN3kToRaXPFsR8sTsqsYT1MXmUnQupEaP/DHNOaOZrUicibA722NwIYCzFfw934OD6JJ8AJcBDzXdyNj8MEbuiXMDC/n4wzfjf/uHBCMt8exoOCI/MTgrvxcXwSJkCAmAF34+MwIVWuIwJ+Wf5OFN4NAyvsFp4UtsGEogAuIfpLMASXhZdhWD8MRxOE6NYTMJGafQKWWkK/E2E+mR/nMgADGAFgIuyF3fvm3Xe/sZididsNAMd0JZ56qOAunFssTe9lL5jH1/H8xVQ0xh4/jQe/TeSDdngNApwLSStXrJ/EPqq6v31j77Rn2FP4GZoHtW/7xt4JU3zI2mUCsC6QsU6KDbKzJazVvTXY5tCftBnkfbT6mxB7p0P4FBL4rAnYOwUGiaDOk/EK8h43huyFfW1f9S4QziUxD7JBsle9FnhBGsgKsjICq0JMatd6jepuDbcK6pS6KllhQUCQYF/lFzCNA0HYq16LTArbxUWUILxb6ovKidvz/gag94rV1wQbd7V31yxLdqh31kTLRl/Y0fNsqYckSMz7LbTPzULTOe6irmmXlclprEEYoLLwxj3jg5Ux+t9neNzIBwS4ml3Xxe3rQQDMYAECJhjoab8mLN05YdzvNDPMBSyA758+CVlBbpv597WM8nKflYw7RuMZf07GnP0kg7gVYCoSJFnI1h01C/eNQsAEBjBCimfPg5X0bcssBWI04pW0uaIl/UXU1vPuoNjaRFMLyWvImpli2rHyInmL70kp7/ikmDpMUwXJNs5EiDkz4rUlMPD+8tDXEty6QVLrJLQTyLVRXE1GrKn0oTOkSYo9NKMC0kuJOvbLccirqKQQkFRVikKSogtmSa1W3GSQJ61fLcdPXYzbvi2p6eSlLNcTjpflOcQrO0Kfaqk1EbNIsC0cxpRMUtKTN5mxdrERmWyHORWQ7X+pe1M3XdWgV0+9Q+bn2f7mEwHaLCHMOzzfyaT8u+S+a0v/k/gtl+KlVFIpEfrHzqSKRV25Ijcbh581RHlH0+bgt/ms5EoC9H1LUmuD8OFgMzXsk1IgD7NriDAUzcEPqGIxHAGCgGHz55H4vlWyomlkMgMFDkmGNJBDzDC11MShaAroG2SlT3SiQoPhRhbl9bQXpA/a5P7FiqQlfQhfp1aAvghuQD10QyccuOVz5cZqMXJTEGASfo6DSbY9oPTwOTyXlS3kUrxxGh9cXfywvYnk9RNuK3cLpM0wKYPjgvar/hXZjJjy0W21QePFSi9xTyllGNps6FFmy7rfDHrLE3YJYwrjBOPe6arqUrDuj5cCBmQGNULUQHYh1LCjl3CsrLqp8nw6ou1OlzDH0w0j+PSAlOL0BD7z0iNivrvkxdAqDHAwQziAk8AsjUG3KI0V7es0TrrzaYQ4KekQpDSnQwmzannRlLnIrEWrSdqNN9Y4nVjkpE/TWZxMcrBqmvZq0PK2jRo1YrWiDsTUW6g33TpSBwXv/hQ//hD+95fGH4Ex+ydBZD7mO34FogLo27FXo3q9WHzqNVUagIDR3sb6Xpavfsl4l3SUemN1aVStHXzSnVMCbAWlliHQyWnBmi5IIue4rTZTZ6jCFKqTc08ivQ0TZ2DJa2pygUXouGamow61aMZKPPgoPq8hOaqGs9a2yl4R9VZbpUuTRrUiqLWvCFUvhNA+3dVYafLYeMB7ocl+O1R+x/jGdzUyMc/mASj3j65/RuzEmQFIJqzqFTYBqqKaInWmPRWK1EucZNVLml41yp1YVSjS6WISqDTSyR1BcU4V9dvOL8cgU5ZsRiZmFlY2dg5OrknoIOdfb/J45Svg41eoSLGAEqXKlAuqUKlKdTjYZo65vrfGiHmWWWyjPbaHwCK/me0Dz72w1FoLHHbdM5vs9dKov211wEnHHVSj1gp1Tqt3winnnXHWOfc0uOSCiz421lMr/eKyYeM88MhCE4w3UZNGzQa0aNOqXYcunbr1uK/XZJP0mWqKb2wx3TQzzPTQj/7YIM0n3DlGf7jm17KmZTuul4dXQNCWL/htm4+J/MIilEKFlqT99sRPfk5EWCyRyvzJFVklZRVVNXUNTS1tHV09fQNDI2MTU9wUXteF8VKp1MLuZZQqrCo3mYCZD1BIpbbMVthKW7ubjuR1jHzPkixW0SiRj0ksz6synYwogWLsCJpQS9neUt25l0bqqYittjW2djfdXlqpLbPltsJW2ipbbWts7evroupO1/8kBSPVtV2d9Ujwh8rYuz7aa/pZnsdFfD/dWFf/jVrouhIoor3K4q2CeMzXaXV+tjSJueHvVkZeepE+lHfxOCM0X1uiYIZ4c5RqnEprHFrd2CmVAQA=) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Serif';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local(IBM Plex Serif Bold), local(IBMPlexSerif-Bold), url(data:font/woff2;base64,d09GMgABAAAAAD14ABAAAAAAnrAAAD0TAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGnQb+wYchXQGYD9QZkVkgQQAhCIREAqBl3j4dwuEEgABNgIkA4ggBCAFhUQHiBQbCIw1TK9i7m4HoAtf7ymjyOMgwXx5o5CEky4w+/8/JtAxRMo0RZXtDzKCzA4nFJYVLpZUFewd1FlylW0S+6Rr6REnCOmBjLg78YPOK+kbZ97XD7s9wUErvvpJScseB7lbSupl6HsHwCTdjZUwS/8uHpIb8OjzZe+uyc4Ad1gRoyvP87/fP/u51r7vvIuoWGMQCpQCo3vFu3uD//38wG+z9xEQRRsLED6RAlKCKCp8EDDBHApoL5w1e9GuQrdz5dq7W9Xtbt5umS7ybnG7XqS7rbVQZ02SNUnyGs5WiPiAmuKKuv6ifvonbrTvx5ZiaBElWTNnev7/29Su4Ruu4SvKDfzAC0yKCcJESlgOUSUrXdoFrJY7Nd0WXaCo1tt0W63nuBLilE59r/Ka8NQLAG0lmuKoDMvU60Rk4ojAIAswYclEqMIFaIJ8wZsV+ocxd5M/eRPs41ICeRnNhEamVmIldPLt/36vQtkJx7q6eoBPjfCaUsybyKCUwR1kcAcppP+ffEghbZfTgYrbe8CsCGtmE4zcvHxw4D1M6BlTX8yVL2WKT0mR0bZm4nazhLd+omtyLSLM/rW6UTGa1O9j7yKjhGj9vWlqu4/LEwEqrjM7YjxwDP2RzrF3m7vFe3/379+Pj7045N4SDHdMEMwI5RM52MWdBgtQHPEock7nHM9yChcU0inFeJKzlDuNK+fachVy6c4uWleV3bpoK48rw/P9tFe6V1fXTW7H7lB2Z3W43DXzmc3NDdiunnZlrSS3tm5t/V1rinZ/egMsMAA2FuQEBadjT1BYEAxAAQzE/NEv34QV/OHJTre5NlJMucidVJR0M33fkJ7HGKO1aBERJVdKKSVKROw5ZuYOR9cmjaWGNqgIFO/p3PJjL7LpTC/GhWJa8NRT9v8iEcBXP+cJgE8f73MAvn75dUCAtYGb1cIJwJUEYZYJkc0DMdtsiJVWQmyyCaJfP8QxxyDOGeDlb//A+de/EB995hUvhAhe8Ua8AYEHCuR50tdkU8Xr5FMz84Fy09imWmDfXd5SD3J4wDwU3ePDyri7bmmqh4D/iXag5OygwRPFCwkFHQ4Y6Gs82nwA4IEctu6n5MiHAVkD/R22C2yz3xn3DfoYElKfljxu4iW3+j+fz6KWtLZNA+8VMspGzZg9ekbvwhefvyhejFzMXJxYvF68z2P3cvX5f7PWmisHuUIkOFYOrTydqBN3Ek/xb7NegFP21Dj1TL3Toen9qni1cXXl6oXVR8vIpXiZvxy+nL38bvnb8iMc855EioV5CSnQYf++EOeFS94X/iH8Kyq16GSbjXvwu7hQSszUgjcnKUYuKYRg+VgxmzqeuSBLzP0wYcXwXemnGfwsfqFIRexoqpari0YPTWiJdip0UHeEnugnMZTjP6PcB4ctB7KR47wocb8Z71LFEglMYAKbufBxv+0z8Av8oRppkCZqk05zAARYsTfoiaHBKDUOTGCan5EWlz/fhWa/5YoQHj8q5PKnLqJyd6VQg3r3BmpyWuWAgA0ACBcB4RoI9AU0p3wv/Szji8zd+OzEErRK1QN9liB1P1DY8buqYqZE+MDQAIFWlb9C5eYQAa/LqPNKAME3BgAo0AMAAuigLSdLn3Yj64QQt6qNiO70F5MmRIuOiO4C9Ap9NCAMxfgOEzHV4qxyJedhWZQEcqSQeYeKPZS+/BYz5yOilLpPDmqWLIQvKuOjBtvifSdGZAmlDAGwlDQYGBgYMBgIEAgQBEhgsoUgwiJYuvgd+SkzqIFAEEip7qzPYiCU1uQM69tULBcPqQLvnemAzApbxW1n+QuZu2xErKy1EFqwhdxlIoMEhyikFQmsKMxFrkySYNDApDKQgGUgC4qgpG6R7fwI3WUDuT4JQZay+qE8g9TZUTMlE+lELgZMDQuj0oOypeMIakxaJTVZfqUfwIBABvlV/lWV5IyiRlH3ZCO7RsnosVmHdLc5ICNCeUy04rqMRCwPTEjJ3wAWSJMFuuzIgtykMAQwMD2YmBTnZx1nGqIFF8yj+2mfmS9Ma6eXf+q8JT3SLwwSQ4XRkR87a8KbkmUJJ1cqkAA2FcQvI2wVt8kMF9SSwqtwBxMWgXj8oF5aF7mBZ+Kc0ZNlEwQqMwRkPq0mVDNvXNEyXYhltIhdRQmMNDLzP5Ul3h4+Y1KilgnLGk/BNUta0l1RArVUssGlQEKr/moUK6WyDIhMgFiTcupiOEXZbTemA2tQwAespNzgqAQQEGBg0MDyaj4PUEqC5AkPFdIgwSH09CgF1VEsSWM00pApj8x4tZhZZ1JRK+PSKWetTfNGLDqELuZh0ss6/KQl5fkineqKFCbZ5QsTvM0gSJYLUias/xRmvLFshZdFABsHj4BIDAkpOSUVNa14OgkS6WHS5CviUqlRi1bjTTTVQoss1qXbUt/oscxyK63Sa7U11lpnvV122+Oa62646RYD8J//bUvtqKlraGpp6+jq6RsYGhmbmJpdt3lYnDrFGcdBoyLPsrJ40ra8N04TbBjc/MSLhY7sKYJgLqUDfOmjTYOa7oJskGiuCS8r5jFniIBn7UAMEyDpIfwNrhlIi2AsNS7MCjeETJxx0o8BLsr46NpG72oSEGV52J5HHkRRm6s/+8sBhXTBFhS0Mzokm/IMtG/JoLsAqD6nxUnoHywTvs3M0gkiNPziKYIC7nrqGZBMqYvF7PO7VedfxLe/uvTneMNYfgBgrVEQVY6LCLKxZ3jOkAjJal9UoTiI6qfAzyOss1YgtyTEBf00WrSxm8eljRYaA9ZrLGwWsZ2JfZ4YJ/BJjOOT3WqdC2duMXD8uhhdLsE5l/kMwnywwZYB0KS5KHwzOB8DUHNxL6fEsq7lkirbL2Pnfl2VdHJKdeCDELecSfFyEjN+SXZF3i1IVTOfx3Mq0dSh6nCK1vX3bnaqXbNjbi+AQn3WsY43WQPZVzz/eUqEIKzj6Cf45kZrCs1PE66qyuI0ZbJNEwb6qsMdct4OZb8rKLiP214t/0GeKpeSlG+1TYoUz1YGBK4v0NXLIYZPQlCNwAfXh7GE4MohKDnoMw0cyu7mLtqN+wimfI3jDOAoLV3MwPRJtVsorANyHDXsVCr7apVUldNvbpJ1jTlp8ft4LRV42SpsYF/h1lcSsTCwwNy6GF/fZNS6EoD7ahpSoRIdATglF3EyzoW1zdMdsjo0EDy+XFn86oAaiw6W3F0dUbJFFVhTuw5et7k9OAxS/cGo0QdgyAzSkHVMBIw3FNMIfDcypOfHfVqLBREXZKaOQBlC8APdhlgSzoqW6PYPCERicAwUsBWXWEx3UY3ZvhPKMj0SOH10TUlYb5Vc+uIGTnqT8O1zeCxtciJwtiFxFwHKnKLx8pZTv8rGwoCBkSWNxTb0KwapEcUHIjKRQmBhQ8XBmwiEChwdeIkQJOPDgC8MgSKEXIiUQFJJgEboWuBrhWM8EaZCsw4v6wm1B38PCfEIrsfEeEKQp6CewfAcPy8I8xKxV4R7Dc8b2AYJ9pZA/8P0jmjvIfuwPAVOJgIIXxD+IALBCyJEcIgXjSFc/PGhE0MnhUYJnRo6DUxaAsQTLYFAeoIkEcwAi5lQFiJZobARKQ1v6ZBkgMokTFY/XDb7cLNDjgi5IFI+FAVEKCTKMHw48VUMmRs/HqjKYKkDp4EQE1f2Ms1s/uasTLfUcnQrV6ZbZY1oawmy/sd422CTUJttF2mH3cJIO0KxFytH2OcnkfpXjvSzQ3wdxs9R/BwjwnHoTqwc6YqrQlyD4DpEN8C7CcEtiG6Ddxe8e+DcT6cf6n17OIQEqWvu3L5dREUnUTIDrDt+bclWTO1+34E9nS7bvIL57onjP4jatnom2n8inPFM+Pnuvrn0hZaSogv/eLJSfwjEtQ7NRcj44NbGff8GeOqqp4RV41Zs7YsYNCSpX4ojQfnTX+ZKgFx9MkPblhshNE7cWHkuKs6m/O9T+HmWsE0F0NGOdQHHbVPA2Upgd5wmLPMP5mCa6D5Gk4GSNEwAePTowy52Uc8sv1SugFlL97uwLrkowu5XX9Nvhm5//0J9vgVATw0VxNhMhjZbyKS5pGwBMPri2Ywt9dAIbO0xp1wmcAqCHBeCGR0YIj3rDWQdEokEGAQaYiZlnSE8gs/GvZG5CJttTc71GBi57WH7Hef3mI/0cNTXN1ZfHaa0yBqcch3kRhTau62PslfkGs+a0tb64yUWxgyj0KFBZ70TmmALlUIPXnpsCrGdDx94D8u7gR4paNAq7UYu2EoZRRlO08Y0ZhhINQQo3U0SbcvMTgGwN4h8eitiTABFVs4uh/+06bXNrGFbkgpw2/AAmDBcnWdX3OuIPyFPNryWt2Ej8ToV17xObPBKbPo+eCml6hlY6fdDHpphfUj+veiZDLCRFwNfzOZvO6w1bQTznamiV2l8xCiTxIRMNapKRpmSGBJkMMnaHbV5NWJAkCakqi6y4TWnpVFwKL31lDQN3tMGh0gTr3alRVWC88o9r9uRvI+tQnSlctWBtO1he6wJr1kz9I4UPHu85FkpRXn1/x0RLRaJKspw5JE/dME4BY2iKJ5t0XWHNz1r6R91XJLvPEh87XwptscJrTa7YOnso522J/SrnCY4x4QqMopZy9kDQKyCF7fGGoasbV+6VJyh9t2JrnMGVXKgAaBVW/nEcoaAwkU4vXrecpiGtNfJXLP2PrdEdTE0wlB/QJEATP8rylmmCkUSJ0AaCJf8CybpGDSzz9aYPZlVIk2nWpVRwKczpNPVHM8ytvf3BrzT4GZaZjQ53OjsWWKM9CaAJ9XlZmMjQMnVx01JHLQqtazKClZsES2BwYdUtPzKi5uNjIuzUYsRoXQYDwQiQqqPOCXd9mx80jl76MhP041dWJcZMNTPHyJo2BAoUABSgOjIVHfvHh6GubFhIU7pxiwVRx4z8WaDYF2zXWxAWsEEUhoIDbUIkDNRRJWUQn5YYav/KJObGGPS0YNbDBUw34ThfVo4JtnpAQGu65WWELFnN2sY6o216VWGj+QsH/VLrDViNvMQXbZr/zVssXd98pxNqZxl6RJySyc34biUsmk8Tu6Cj1U7zoh/v66JUl14tpU/6mZFNwICpG8/pXFye08qWbOtVp+vUq+YY/TH95SzcnNm0O2hPjfCbErEZgP9AxIH1LGNFx4ArtyF3EoHTeK2qta07pbORk8lXUO2XHSqeGOAxGG4lzRw4bTECJqsVipBi9zXEKsbqERv/cAoHEGVq9zpiI5fhKYevWnjIxoAfm+znf8YDXY+OkTAE1biRJNNF5RSH7fGXM36nTOc+Im5Z0VVudNldTZ990POSHyQB2FC5kCalqqfHJ8q2joGj6kCzZRqNjjlzICpNDNqK7wTS4Jt8eJGZ4MqZ5UUvxVhBY64KUmSPuAu5yIwec/mzBoiASFQkm3xY/MtOgmJxQyQMIJThBT73elZ9seAiob01EFHNiaQbHaBp9A4gGIl7tNj+Ew1eM74/tOcdXGPt+5rH8+cvb5IJawKentwUN+ZNtMzGbtyl1Nds9xEeRGAkZRSH5fuAe601c/mJbQpm8kw8uYErPFJigWQ4mVTJid0uCG3WEfN6CdWk0Dt+XgnCoH1E3lMmHLvD6O4QWPs5PXRuSdzxTBebMUc5coigWOcU6BcXSFOL4Szc1gjzg5fMe8LgEzYxKAAY6EoyH2qpKj+sV0T4zh+kswPZbXG0iyAGVrA7uIlbvhOhDV42QYqPLC18cm4tX6xszp/9V3Z1dixjwFEn5h6ZpDlHzqsCU8oKTexl7VZkGI1NxlEJsOqejCdzFJrseyJCpoQzPEWC/HKmp2ycDKYpFbsC59FP3T00c5GsWGcgBCOD6r4c92/g8pleFng8W570mlAkU9spBraAcWA3xUq+csy8YuAnFwKmEeSwxjnPugbxwi/ZggljFx5c5qiepIIBQ3LM+8YzZ/sSEHL8kYVr6sjsJV09cwJhn8CXuLtG4i99sU8oDAd/DEGygCgoqoGqGsAGppa2jqALqCnz9G86hcOISAprhDz+AKh0AuHJxLT0oAMICvHvRGTAFKVgl2+p0sKSg2QRfi2SwMNHaMHje20JMgGlnC2SwMv0jhzTmV5SvXhDICWmCzGW4GMV5aU2nsW8CSQ/ywEBMDnf/J99Q1LrnfHi0XTse8lH6QH18Pjo9SBNnqe8KKEGElKS9GegCvgDMgosMAifd2zbu6ystUXLH2mjp0TyfPYfA4Bqe8XWPGrvlkDlrZHY2piu2U9wAaBuNwJeLSb5KYBV1x7+ykPgcx4y27Jf1ngIsBiTt8x5kzEHcr3lpayqIx3h0rWNtKygwS/1x0w1zAyVNMx03W011R3MXDSllTsYjqze0n2AikxFiZnsbUKZ14vKhxzTcXvbYTTeUk/fpTx0H53ok7MJbbnIZ+Sq1JVov65FojTbTmjlday2WC3bHv9pES/E6pccVvDtFran+2+Dn/71zjIcPcrZFTwy47JoaQfX/+m3zzK058bfM4CyIT4ISGJDCPciCOPJvpgsSU7+SlOWYanNk3pyKR0Zm4Wpye92ZBN2ZF96c+RnMqFXM3t3M+fvela+T+/OBwJF4CjlFq0/EqqbHyTa256HS2suxUd2fq2dFyndGbnt7vLu6Z93dJd3d+DPdYzvdTrvduH/btPIdECiQ1IagovP3DcG0d64AicRmYLkqw92vmaCUpBejVFK3WF56I4CGJWp5f5Xl9VlfuaQAxsj1rUrBuLJ6AO42T6AgOqUaru0ffFglOFjdVuQP7IjmTUDA/rW5HBx/QVRg43o2N42BDN+AV/nQrEpQIOkSSIWZooGTIxZcvFUsCDb5pZYs3VJc4SyyVZZS2TDb5ns8X2B9r35frZYU5HHeWBhGcUASZMdv7O7/MdpAHgR2Wkei3GmWKm+bott0afLXbZ76Bjzrjkurse+ttTr733NXjEFwlKeOhhRxhZ1EmIIZZkJjfOlKQqNWlMWyZkWmZnYZZCUtJ+SGzw2pritfmg47yeSY4EMb12aUkPFdtAJ6jjtROZCrVSt3vT3lOxpiCdaiAQRy+EqNESvhCxcZe6fz4AnKzIR+WoU6M8xj7PQI2KFddA7Wr14L0d5fpr+vRNsn2i73s4/r2fBfpmVJYGje3Z6NJliGZXiMnJQ2B2Q2olMpuI1Y/cMRT+LZRvDjjnctInWonHffi/tMrRcqKcHp4LXBxeCVwf3grcLQ/K42efhfDhlT7dgNe/0ppKbOuBreLxyTo5TPRgDh5B0milJ0rjJ950U10j8G+ub6gD2Yz7HwCo7x41ohz097bWNQHWs588ln1r4kEP8QcjcEy79DotBWugoL/4jq2RzCJbMQSIbG7kIi6pRutK6hw8+G/4ic9bQ1Ta5gg/2WnLk+m7P4gGIRChcOjIHnhsvBatHv4di5wbKwQdGBBiiJC8uITwVRXjS/XjHJC19QAB95320gegqHxd0EPR6fg9sUiFIJH61H7+gWP3t8xkIo3ANki8hgtA8RnORZ+Kcc5HeV6leIkXcHQOIjL3EZkSw92ZewLPKmsgBMN3gZ8ZH33K4+AfdMaL5rA/+xnHHTdw+MEx//4R7rO9ihcMevl3uDGCRwgIERBBMmWRWetyzgwcNL6WHkQAfalO4Cx+hc61kpMAOpG8CHgi4MYUcBuwFwDOOLNQBAU7bohHvv4BFs+GsT0gLwO6Nq4f2B4OApBbb6prAbA+xOhol3y6AjFiExtxBo6tBiO8lw8xZuXm2vLmkdVVsa/KpjcXo5BQhChrQbHbw7/QLDQuy5jsAxUMeth3ka1pR1Hi0/N+Tyg8X2Adkwwh0+T1YE/1t+Hjxdmej6rQBNSMtqDbqmzWklrI0BBYB2pdiuT255hxd8CjQ1ElqtO7fopm/p//6Fhd85j/52sA+N+r4Os77UtXpbVp3AMLwJcfQBy8jS0xgH0Zp4Oz4l3gPeecBz50EYCPXXbFVQD9BhXkDDf9xL771B/A9yATtJpM+yhYLWAMhCcQvYeQYw8rxx5q1v9lWWwOl8cXCEXiGIlUFitXKFXqOI02XpeQqE9KTjEYMZM51WK1paVnZGZl2x05uXn5BYXDnEXFLrenpLSsXCUzZ3359i8QS6f2UQQjKJJmOJbP5IR8QRI1VTdAU9Utd3zSsb5x9LdtNWavBM0At7UD3D3Bpv5PL+sB90z8tGLaDP8RXrl689a16wcc9eCbe/cBPHHjNnTO//zj66/ff356fWBpbzR8+ObsmCiAdy8A4YXEVxDCrPUAWQLQ9UF2A5v+G2x9LsB4HPRqQNHonVVeCLwghw8nQKpxHHCul+qMeS4hU15CBWjAPbuIh9PSgPC8dzV1iHBD4u6sA2vBLK7mA2uXC+88ZEZ0rYeq6xhiZe01Rl1GICc8rCuMOaTMjkPBqEgiZTwLl6XXYRyRMzycXtfKS2wWaGc5zErRnJWZSZsH57bSxKSV7D5Kw4J2WloXtE1k1/mVfcoJuxdwRo8LqlziotZRIMq6Zt/8UpgpaQ4J+3JdHass94pcclqXcassclwQy6qIipzn+lwX/UypzVWq5Njs2rsCN4h+NfNAR0NlFnRkU6QUtY9UbZpclELVuUKvKqdULH5uynntCGbKWFaRRTUcCCcii6NcmkmxTubLKbdI0rLkS0mjWi4OWQ01OzVmzaxk+yhJzMTZEdZEDWWlM0IJIS3X/HMN5RFl00POf0fiAcUqYaE8FCzHm4rZlJCECu8uLnvd+Xz5A818oNUBvIeEK/x/h7erLPSKjxhAgzBcy/UzWhinXpK0vhaXEZKXFtGvFN40eUOkMu4zzpX/WAgahHkttLxJ9bWIFaurisUlUouyHo2tkDv6MrcH+20qXjHCp2sAX/o4zN5w/LEJxd355+Qvkzpj7rbiC0cNr6zfz3bcWb4NX7eTWJdB2fvmnO7zEWsX3209gtKeN3uRefBvZikz8ecsfSfNBAeyyi/V2WaRW6OrbT9X+f6ybq5dbGJda1cZDxYWEgLBPmkOxNcKwV8Vz2uTeBgR7d0a5FdUZGqupZLrCoTEW9D/muzx/ABUWpspKq2EQtUnak4jLxwlL9HhMtcN1Nnjn2UoYqGwLO18vh6qAHHbwjYwLFmzelO+5zQt86MJWB+L00hof3pGWhUh10ggBEIsOTTX5hXSrSFKvZxf2zCyh1OLTlCgqFubdPA2x3Q/IDWfBZepXPqjlhTrbZJOjJpk5I8hgSPahl2yZjszGXUeZyno5LXzYXZ51xqA+MQYRLRo18MMoyQJEt10Hx+KQOCWrvbYS0vnmdxBXdYAXb/xlgwPcwWVUhlpRGGO49AKLucyKvUtXT99xi3e1SOCyykoN+dgXDIAkRoG7yrl/gJL8C8THPM5A9wNF0vp5DH8ODO/jogBYVEOVBLZLhSyuAfoKF5iqLQGRw8F1kmtiB2+PH4NNQUdB1Vs3Ok8uUf03mYd9GgSsx0+ssXu1PUHW0+mkVtNDbV2n9ioPWYtlnQkMKi+qROCOh1k70tCYTeo3i02NOiGY+hXQQCHvXTJ7HwCRTLZyls/FwbK5KxMDxJ2i4SAhswyXY8WvDfYe7MC0SeHVlPYfcXYEHfZkVmVb6sAk4/dh4rIDaokp6GjFeqvXoCKrEjFEgecP+y82jbgnEbMJKjw/DRHxWn66TtY4l4n/5qX2XOCu1RePp9svXmMafaS7C4hPb3PDrkn+2aOnWQfANU0yCSEt16fcfq/11b7xxwYT40ECXv69BN+a7ai8cy1Gkc+wC3tZ2BB9wRpbSVhxYIV9d72bdgRZO27HyN/a/VxcCYdHxkOaRNZjlGFDDI/XtkGOlpqo7VKxqmYyG+wgzFsm9B7KZgYeRuFBWpXgaPJXX70IdjvkZkTOXcYzAXLroS9uJSHGc3MoLXIz9n0y++i9QrWQI6MS84J0I+tUerzmpf8XhPsQ+f2IAPX77U+FkFxpxVkYlBcK1hbLSfDOFggjsI6nUKycVcCiy4YSYrMtu9FK05Q/RjjNh5ssprfX04wdyYXDlNXcyY74hXHXQz/kHqermmAc7rUKdpIhfGzAOFu1n4kbGU8j1YE5N6/doj58tkVaHYGYOmXNhp+QSEV5PGAe0GSGi7WLIn2SHJJkWP1isY4o5v2TeNwEMx7/I/UrPBIxt3EYXL6gVyWaKgzuCH6PncPVKLJULnZXkV3K/KyZnnWsFRHumrUTKIrExtDASjvsdHxOBGnR2vm6uNohPt7zMfxCDi0V/qwsaZrqkNm1VEitkDVjFKAWJsu2NMW2LTBmDMzalis2eDu1M4tnGHFMgKRCg+9CkBYw/OcB9ITv8W8L0RdYxsWy03dvdtAR1P7cvPj7OW186k1xYgqhUGhuQoVJKs6KM0eaOlfmpZGCZEZBrQJibSBFf6P49QJRhWWdQUsGUhZTlqiQFOROnNOOyA/uuRCVbRnn7JFcWLx2ZJXzdvPeykQyuTux6xkoWbuPcACdN80B67fS2vn0whKbl47D6brA/lZ0geX7M8eGArl+JcxfWa3fG8B2AcstkmjmGyFivSmcXp0Vo6p9oPbG8JkchbR6d7uZaaqd6jhAwa/R/VXZg3EwD8zQFugNo89RuYS0YBda1ydgaLmm+oEz49ylA6UQEUcGubu9O66PIUI4cXxHowKP5zK4m2yu2/nfiAAlJdP38XFcTfR/jJVIySANEbDNRLCCp3XW4vm8Ow+/AAm67YYOfU2c9csnzZk9kQjFyyTblqJnXlgnZ2nzvxIpq5B6k68DTkK4AUSmlzERxfv8irGAB2a0nMFmxWf5NbZrDoFXst449vApC1iB+UU6CdIIgp9HMlrtjO3kPnvmrQtegGzaeT7/u8hb8NL0bg0agjsrpeDGqURmEZ4WZpsFmz4GnF5v7NK00gok1ai1ngWXhkoQ908BA1+0EY1od+3/lxLUH+a18/NPejyBzVdO5weC/GUSwmZ0hGwmO57sOEciZbyD4XNBJWA/nIxiQduAXCOMsEAkJ9gH0hJycRLqnrHKg3GpEnFKLevHOjZ8JGOIfvR1tfitH7NHgpWt9XqZmM3OToqVm7z7+z15pEcN90ZDefRVvugRWCLhirP2bi0WrDcJNXKYvdZkXZk+baOcO5akaHe/AKrblvBZzQTIq+iPDbc5uD0Brnsyd7ip9QzdODgPsgE/Melc2Mm99JkiJzUXf8avfTBa30Yxif3xviesc4Es0TPN+YIYg/XxeaeqWRDI/5SaMQfENt5FlE4U8taeEfXm3GYeteoXu6o0Te8S8wlj7TFHL1TvJ7ijRCl61mLADbYzb2sODZHGtjhrn1wo4Xr9nK11r3c2x6Wf9t21h0r//FAoKeFB/FRDBIVO8+ZhoxibReXWC1LqaWLwDArKm28H5+GVBk/rUDsTy7gmqI8dkp2i83Mp2slunZeJhDBNHucHAeGsOthR+rwToy1s1zOnBHJ6hdRsPyDo4ETG/W/RH1PiITpKd/T/vAlkoeyzjd2nqpbaMk0yA7zQKnc6++ELcywXgRqQkGlwg6kuS2qZm549cHW12KNuG63Gj4SCw/FonFTcOEuyu95Ak/aSSJUeDNB7ThXIOhEG7NQXscbH1GIh61baJ1F61Vq6rlwytFz25Yu+YLWpwtzJ7PuBVLlGrqHC2QsIOKBV/WSfIwS/GxXqkDgPSv0H7h5eyhKRILIaoljT9K628r+xTeoe1gNW7flCs4+HZ7WPBI63IfIwB6pM7rj+H4PIQLBZApBz4ezMKGFIPAUwYct3aE9ApJq5KJHeXGtZs3gDlUtVAtrQRXg88zWUNitNTucz6nd5OHzzj6n8Jo+MbE+6D21Jk578+zPeicjCqVJj407RBjOHgPGU7OR0HrOxkeIpr/oFlWXz7v5xcNu3nyImi36V/VI5t+4gfot9stJoiymwCqy5CoXz70q+TqUE5Nm981WDdPDpD01BR20zSML2hh7CnZtnZYf7T2rp3ivo29eBzhcblY4byGNf5AjqEXDSh97FynvV4bXNLpy6kZUkhwmOzs97M1EatyFIL9DwFcZ7hqGh9YML5EwrDPsrFCHiTgg+JsjWDNJN4EoEIYtcpbfhL+bqDdljbKb1O26/6S6l9/rV1BSWVFBVeD01ZHquda2nXTcOeAAJtlYTjMq0VSxYP7Dt2Vjj4rtsVyf5dmU2NiswPJHbPS18NVn7EQfCcOwSxjm75bn6DTXBdgUDm/FhHKG76njBG4w638U/Z8VTGOyV+m+nn26PI0TRc3KwcDS3jKhRXhJDMmrBFUFjjZFj9Mpppg2pCB/YmKeoCK0TpuufZgP8+UTTMwHZHhAZJ5jB57U6vpCd+z06vIXg/yOv5qy7+GOmiaY+LNkec9vjttfXF2Vpom8OX/dRh2ci4cveNX58wH3gc+9geiubs8+HEsqmtDbI5BBvTG5wgXyEZJ6Ccyf6sMNMU/cIXnj3RCTyHKF4+1x3Wq8I9zFcj2GQ90dh7cvj1pnTu/fsYNqpvM/EnAaVxG/1S37q3lCRw92DQR1J4//luCJj044r2J3ED8ew1iThdz7AvqRSjtFNW5apUfMMMcY1Qm7p+O1Ttvdl0Ama/Ip0wfogktcwRp2sP1X4m2e2ag2s5JNSZlJ6Um2x6pIzW1VqFcf8d2Vwl4o4F0S0Ha1OChxQ+fYPi4TLZRkskaMoos8sxtAu45RFvDT1u+rmqrW954OOWPEgx9Zk1f2r7Tj3GCD1ZhGndrGzT1lC6DO6+kuDrxKWLR+biOvuq1xRN3isSAhJ5XyMRtnuLHGsGZMba/eRfx7KnNej3cDmtM9To6WlY+p0bCKjcZSbrI1WsmpQCPRCo4y+vlUgyOCxJFpHx+N/z15NcSQk8ojzQpuuiLmWZQhHEfqnvHuP5FzRlFTUxreKfrv3YxuEs4QHvUsJt6MmLHx6c0Mh6GeEcaoNzgYv+OLzqMPRUlUSJTOf6iweqfQLKaMtWHLEYbdsclD62EpelC48UmNehNJvakGsOdXnVfV77OgyOM1/cz5EKC3M8PLrsFCdP1ynnAqcGK17NtlWnu1U8FLMynd0fn2bMEbYJ3ax9tLlyYOHx3X43ZpV4xoWJLkKepSD6+In1ugCy+XpJoFMl2qaixhTrMitbiuvp6XklTpyjFEjSlOx5CHs2Oc5XyLtMGRVS8ypo5ROIokEzL4mZJxjoIxstTfhVXLrq+nAzo6cndUOcpWCCYJFOBvVN5un7s9hRLjYY7Y7j9vig7s1rmoQx4eHoRGi8aCjUoaFjlvK4c7q2fUScK1dzo/kae9auzEfywNmm8VsYpvNQ2pnhGlktIRHqghZzRp7GXC6ZlO+ayc4lpZIuqn6nARE1rut0hVWJLBlJFXfD42wrh1I8fgxEZOORmLYYo8Wi1DWGzjZEVO5dS8PDHVtP2wWf6xGpWW0HMUi+on1cM5d21XGtPdF9L+lqYrjzr16UfS9Z1wZ2bLpbjQhlcn5F0pZoUasrlJkeOWduY7lTOdrlaZKdUhPd2gky5Rf7G5nO6Kw65st81itMSVVGFaTMXQ6iu9Df+jhvACS2SY5ZnvM4cRBuKL8Bj6PGdgOzkvO0XJnMRHZ0RTfv2WMAYh8TzxD0sxK2bZKo+0dziZkPreo3o3ju9abcEGsbQ9B/4Zr8d0mHGlf6b9UJmrqrAM+aGZLZeo5HY/r7Lju+xQ/5BfiFtdy43LjAldxC8ndTfBAQZEvyRyFuwOltrRnWcmeoX+MOOTmHlzIoyyR7II45w8pms4RpqlPXZYsWLmsGHvTrHVspBWkT9Fp9bXlpWUttbUL35Riln/6ahUTVGqlFNUlUD+UZcWo9bkjnfpjE5Oe3oZd750TmuKs1jnxnII96ODk3Fvm2FVc6mdI8sKncvEYrnjeycRp9xWbEIJWCknof3a2dHXMt5YMNk/HVWjSxNLR1dBMpnhZ55djE9oudASo8mQYKmYVhq+s2cX8awon/0jmhUnZab/4IzWMf1MHT8B3QUoiUuTJJr/FUY8+CdIuywhlz0j2iaP5dgxXSkKe4yl8mlNLf0L+1uapslLsTJYTs5pZFpM6Mj0uh4ftkEVkMb6XuK0lFQ3rU48Zmmc1T4fjO1KjI85igUJN4jJNzwCB3YLU15rnwuGwNHGPMbPlcxaLMGPfnxcbkV77+x3+P0E9UKE0XiafEykxeSYse1H4qQfjdhDzLj/3eUk79Tp54kLzzf9Dl6n/cbPZQVtZZlBOLQEC3YZU/WnP7FjBpCm1sc8bWrpj7To2ISZLZcUYHqHv9j+tR3DA1tXtVKt5A6m4SGm+FxJzT41U7CTRryWATXvY/FH6H4+Ndl6hQDHyAWZ2dZVf1l0Sfd0YTf6CEtF4QwnnzEWjTzUnBumqRvhLuDqdT7F0dpjfByxzO4zpIt468V2jfwfXhDqgXZyQrb2OiHVYZl1UHdNnEC8mqrRyDP5cVZ6VXIyTTXt16cKl3hs/Jz4sWKhUfyD2Ag8ckqJyJCGViZioipbagVH567ISOD38nhtKHW9N7H724gkU6ZtJJZk1sYbVVcbZxMSrTT4QC5zJ3L6JcHkMsLpSt0lH9ssJly1aHCuKrLCCv/lAI+cXCI02FhV+hR2tSG1mBcfX8R6zirSstOEplRTgsYov1o2O7Q4g7Yoe1uA7Y5QeMcGXKO+U2/RizzN1aM4KO1NKKpFWaFUCmE6sSuAH6o3V1mqOh0YF8KupZcHbh9L4xtk7/ATG4SyY5vxHE2GTjx0ICdcyX1y0bfOGV3GjGajPBue8e0T8Vu4cPjD8kJ308MGOS2aTMrbfFbeHM/8mxnuSHfG9vDoClGZztBsZp2M2XL3MVCN+tSObZXifetMSCzLLiun6DEypg2My5QEkzZ8DuNoMTJsdYifCQiCZ+J7564AfXWG43FTjwVB5DX9DjHDykT/oLLoeIM3nnpf82/M4GENDSNwKl4uXtdhf0ncTm0br8f+wKxNjZvCpZg3Ji07kIK173gCd3/ZLVxjRWfYgLiScMuckGzOVAzg//9KTCnJLC0P02MkTB0YJxEHv5/2jMJRY+CeJ+JUiQ4xUr6BrAkpHds8sntldqK7/qd698dQLqvOzcVSOdVGI001rZaOLAJ1hl46FyrOxNtErjOprxKuOjCuPGJO+roZjkBzUlOX+nZIzNJeJ5odlm49xvWLABan/fDj79xWKlpkwtV8biHNb0kFHiUGXRn/e5AQIMfam6xd3oHXVPRWBAneaeS/MKM+pj8tjMh1pNpH5BfEtfsQd3qH8P+Oy9RSX8zZsvLTd4X8vIZCuOSj71SPsFhorKe/iQozupotzdOaE//PIQN0mNxXXcx5Li4Q3t6BPKygPhuLeWPxdRZCtSUe+wmL3Xy2DUwBGnJepCuII5o7WlqIVqURO4TFzjzb0FxLbK1tALJRO2f/4gEpRsf0RVOJ7qk67DSmnbu/56AxNfcE1/GACdf0xgQRdxaX44r2b7OEyb2pP6pW/PJIXt8jR8qIo2SH5coQebu3F575zFpXWNG7D/OZvssZ7gS8njNx7DnJAont/ficGzuxGat8Rot+MysvJG/Wm2jas0qsGea/c08TYxSabq8MqWyPyPVDwcq/eE2wXcmM0JfQo64qXAPAqmrrTcw7mfg3NLsPAnw6h0l11ugSbSLbozcViPjlplKH1zCrhtfO5liYEUtUXvGcefKet2Vt9zcfyh9lQpJSeGZVraJBCqLWDclp0mB3VpnF8FsJX8q2PCqgKjX5lM4BuuAeV1iPhskfEzf2Beu1xiRRgGFir2U+K4SaxLs7kxjvsT14DKmj0xuK3RmZxa53WVnvil0/78jdkO7feZpV+iGuJe6D9Am1wuKc1djqbA7U3BWiHIKVIRNDW1bn6IgV5v/qHu6etv3lDyBrY42hu/VRrOUsdjyVIvyEH/kjVP6ew1ziOe+g5GYkMgxxn34iVcXW2lsLRsmwdAcd7miV4bcE8Ukvzo/JaU0Z3Py7F3CogNuB4tEO7ld8P3EuQ89MZTqqi8qSqlD7N1l0GbfRww+nD/Wj3o8KfX8T15QfKk/X5MQ1S0W3zx9o3tLdJnEmDRem2YTlOrPubn6bLzWTPEOczZykcHlUnfn5NNW0WpnkbxxYZ9YXKmvXq3likiAgNxePHQmmzKGG/RrBz1HaMm0G3YUYwSkrhf+aisOn/z1G/IVKpCeKOP40n4g+2IQf7jzm74bO70PWhVDbGUXR4fPUJdalJByVHj6v8VmgMYjqrkpgVvW0cRictp4q5mWH/4rTGIXMDImETuE1LiZWwG5RadSgzaGCuZexYgweZwkwWgjNJBLSzCEiBZuUWSiimbrxM2QNcnmD7PPp4UvFz86ft7m3tfSXLEn+gMnqrSw55031pd6MJL284t7FoelUyuZwllmsM2VJNBHsp06JK5H0jSBpLA26TclP0PADlIjhFL+JLTjj7ySON0pmPORTZVGco1QS9S8q8aEC9yEOrokI2xzOwsQaW5ZMykk0e+fPEykKdPDRZb0yNXn5Jsj/TgSdypYEHTqyUSH+NnkhBKwtKU/VMiZzWZ2MyBQCcZg6mOBr6FTk0/7gZCoVnKw//pjp9sFSw8ZPmEXPWBbjxKIKYfet5dL5pb4Wm/kLadUDSlgXhVyUZ6SMjA8uVG3I80N3cqNy1f+CvK343TAGYa7ZZMqW+sOdVixrShZ2Wd4ozymrcLmocpwBIPKAdeattuNeGDe+Dx9mE74GolEpi7NgCxcltxtmWfI4u9uCXf4UdarEF5qp/R5x2UQYkWgp4U602UyD7T20K4OxZ3X3/Pwly19m3lu+rHn3flYHFy7ecU85q8gc31OVadK47LP+Qyxucf3DQadvjjTKHkValk36bQqc+9a2qhZhqfkrFgBuEQaverQ+48+TYwyhO4vCWHOYKJ8eEbGUqOVL3/KC243o5o79yWlJvBXfDz8mSBgZp9ZgJvF1DEudNbjGSWM7sRJ2Pz0rRiPXfM8O7sDQTbN/SEpL4k8uyafCaXJRFhZ9Zc90FC3nwBJtgjvE0bemkqnxTtZz1IB7PcxsTrw1CsNwxQjipMt3BnyN1Bk+g7iuVsxUfI/wMxTkSrVWeonGFB1s1pXHhujuBetzlUtOdHNTzOzy5HiqS2G0cCRqm3hO7kG582OJrrlYd/B3VvXcqIYRhtZhakZChtgd0WBK54w2prpYWnY2zG5w7fcCYviCXrYXu1dwXJff5G4J1DP4dtbHpSZY2nHPx8/ZpzLW+IYr+v3n5wd0sWPVw0UfYqurCKEz9P7ofBc0iHbLNWLIPseTLceBFU++Qv/WEp/I07h/6e7r/uIu9Ppkk422r1ech1dPPOLmKND4vil0RbyXRFDIU1qx34wy4iSeGhINP4NBkgmKX2BzYp70i9hpDBwjA9KfzCi4oYa2kTN3ufeZ3XOr215ATHXURZqedjHqa4gZTHNVHpOZW23OW5mrcw9PXpUZ2vIirqanLwkJGp1eMNcmcsHS45JRsEoLgY6Ymq6qefSMvDkB0S8W7IHz7B42/p1t5wKr2O+e+XQG0AEzTzxSHJmOP5rIcpX0b8Ch//GExW44J1xSEpskHHknQNgSNr4rizkz2y2oP2ppn8n53U8YdmDlpFI1sJ9jxw9GlextXVGgdTlmnzkvBvYBh/9+nYAflmywLbrXfF9qk6aXN3U1b/SGXLJttMZaxp6eWRAz0+5ukKfG2ynqRrrgMo+/iBlhf0z4Exdsy/UUBBzBjmQfwQ4T3Tn2FNZf3MVbqad45unZDKg8Sh+gC6cnNic2TxT+mis74KPzxF7F6fPbcS/2Es+j8yvxPPb5WJnWxXZpZbHn2fyVMOEiRb/L/dvjF+c3NW3JpQo4dv+gLgX7gLmBbVtdp2qwmptj1HrouvKSeDWrg8NNjY6IGOO9visA02QWhJyYQr6px/yw+M7tnfFq59gpz91QU+uoWxK9ILmLYfoyEj9KMSNFUWQp6rSBUOJ9Ot47rI53D6UO4lW9tR72d9D4nEkcPu1ruT5HRrnbTeVwrrTQZzJvRcM3h0WlBZMX5eI6o2jRDF9OQBSlfHS9/8CTwpPEBkIicVpMRMIvcczJaxfBHlO63WFScXM/FbJD/jEGmVK+yZkez1ds1iXY020KWggjmBFC25wa8LZylT6pm4pNl7phpynVrlaHB+1PDyY8/NgXECZLizUaZWhZWEDfxwFCcMIpCFdPu8wKqt+NbZ8xajPtUwQp4hNtQMgYXV05LX3k7696A/bLWh4/qII3GisXlzxPCX3vTQP+Ru0jjMRzjdA46nlPeG6xdm9thrH9Ddi3JfvcSO28zSmauEnZrLti/+nrqKBhhRi0vZWSu/fQh6x5+PgFL87yUXU9furv3UyW0e9iyHHSvq/A14J4w2ufoHj+HD95zp70FUP+tqfTk39oDpzHGblm9XdC+z2jfiYqx0tugCA++MIh3vlNXVEAweCLNAURc18fCPRtjUJudtwD+Lp7VXoENpwgCEDvy/0EZPzobvCgebtbG8yTma8bba1VgVrjh8aGwr04IaAsYjAUQ5A4fIl8DRCcCqeBMAZDMQQJ4KsnmYvANzEYiiHIRPh6ZoL/7BQKt2d+McVX7nJgDIZiCBKHL/pV4u9bRQBekANDkMnXRuxrCUBvwnuFmcVMf0bboqejZ6M1ekZtMdPraFv0tNbosZhpWrQtelprNIezQtDcmOl9tC16OnpWa9QZM4VF26KntUbdsTZao+bWIG8wfb0B3NrsrI3Rmh4fru3OvAZP9bpd1xt2owx+GO3jkAlTMjO4ycWv2DxecBMswOTgeVvh/c5xQ2uPS3kQv5vstQkATmtzVvSppHnQq0YSzvVeNxKHMk/ynMLHeDJSPGUB+RMbjH3az+XKlcNB/9EjArb02hiwg9Zji3lKtKVrx4AdvH0xIchlsibkSvHLH52FJJAnG8yzfaf9qiv/OXqo58GeqEE72EEWE8m9GrCDTYRRoC8L64vQIQOfOqWD1VMgHT8PitSgT22hHwZySMp50jht4vxhx01Ybn4LctuTPNCnOohvqg59agfn96lwqa0Bn9rEMvPQvHdVKbT6cGQtlPkAZOVPS2m+4xucy9pmwwZmWwv17ylpTuaOClcG/k1F87zcsIdqHhw830lJcc60HwI0c44r//vXp17/15Ls9e+kCTw1tD9LxttFRTSDuwEB/7/PN500yJ+HOPjOLJEBKMDPx396Dof1kHWThTWPavRS9QlqfMFaJW4q56/NxqqTKRpGFlKESpVtvOvEpqhFKGKhikREksTZ5RSJxLZGfj0USxMf3hsix2yq/iygR6KFFdR9A9FNbXLT8O4TQ5LMlAIO/DokTi1gNI8IE++jajODB9BaOIU+EByX/YIWXhDYWyK7S1QXkKWSuW04kDT3pBxOjSVLxGoTSiPw20FcDX6m4tUsovPQYrfHCjZvaH3BgjbO+6KHwhL1x6Kt+eI8m59xn4nSitJZwqtGHFXCmsmvifNQk8DMVMFps6CpJnN62psnxki5RJ2P0S2i2JSpqUZrPhjUOSW2HAqlifnXoSjO6yZV+bFLsVMgfPhPnS+qHTSp4hT/ZCX+8PsIyxE/zNhjAv0ACBfJpLwSdo2nvMOgd3OYkimEyMFvKalvMEMQjR1OBYhhCCGB2JWC03iUV2KJUUishgamxCFM4yXnD0vfNpM4BJGAlCDHMIQYAoYZOeopWYRTj2WqziMmYklqh1WpGjCPhAFIgTKwwbzH3FcH9qBMSSjpitzQiTJkMARDw/fRDSdVfCElD2EYcQ5fvEn/sDhRWkc9AoE23I4fk6uLl+J1LTpjmjfQ6uautn/l+KkQlUKMlKGZjJAFJaJDrhV2pUiISuNyrXwhmK3H6EsG0Ayfckt8ZBhWub3YEJAlVCHwwD91yCHOWd8pWX4f7iIdATalC+9oeqD6nF4ITUp6BTmj05PgrBp7XdT8wQuy8AFwJSjSCLq5aRySH9Ne1E6l8fiJSBOEJy9NxE77CQugznYmDRqN1WSUEUZqgVKSH3dHpcFkQRVEUxmvDMqoVi1UWTYLolqhWrTlZVVkYKpTccKLcMgo5Yuf0Vo9EZm3uea1T+SBmdEdalXrgMpTbaBjOKi4yFFb3bGeFsSofqcnalCrCkwH7OoAB5LRSKzPzy095VmVtFrngftqEnXiCeqlREob67klHlo9yqYsivJSJdFcljSoh1qmYEp/PmSlTAN5BYeoo83y2I0SxIqVlTVkY/dLmbGglmwwiRGzbdtZZILpq7GWOFXQPKp2SklK7ZZMgDp4Q/NFybafJYAkVlMb79ifLCvPvNCIn2bGTNHiiypmZNFqTkzRvIh41PBFmVjyuIag2mMczUjiT0iSZCkMjDAmZqksrGzSpMdfS0nW/zd2Djly5clXoNAwTkWKubh5lChVpjwv2KjTDL/o8a+ZFppntc36wsNcd023xGtvLLDMbMfd98oaW7w16H8bbHfWaTtUqLRYlfOqnXHOZRdcdMl/hrtmwBU7jfBSl5uuu2GkJ56Zo8Yoo9WpVW+dBmM0atKsVYs27R7rMM5Y4000wU/Wm2ySKaZ66rl+t+yyOwJChNvuuZM3QkJ8EF+EjPgh/rDHXvv96IR9fnDSLFsLQALhkMMOFpRg8wtJqBeOOBolYQlPRCITFWpooSc6jDCDhhV2OOGGF34EEUYUcWLyFEmkkSU28iiijGq1tX6UXC6XT9nyVDyuPBioaYfKbYOpuYWlX4VdlytvbWyLRxFt4ovdheOKUkwbasbXQDdXNjWUt0yBVBNtGSz9mpJiamZuYdOWwfLLNapGVS/oguvlla0t1cLLF3/G1OqAqm5hP0NX8v1pVG1V9VK64CoE0rce26M9gnjgTLraC0ONRNdnCmhoS/lRRxfiIa3zy9wBBjVC7WBtYhSplWTltS1yBQ==) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: local(IBM Plex Serif Italic), local(IBMPlexSerif-Italic), url(data:font/woff2;base64,d09GMgABAAAAAEGoABAAAAAAqPgAAEFAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGnob9kAchXQGYD9QZkVkgQQAhCIREAqBsGiBigMLhBIAATYCJAOIIAQgBYVcB4gUG2ySN9DbdwJxt6oSQmPpbiRC2DiCMdj9axSS9ClXk////3NyY0QqFmhW/W1GQEeTzwRlS9b0ou2mTsluG6vKznFK6lGdv8KUkBoSbgaIGCjcZc/uZ7UDS0DGimlABq61267srZjmIWagKUB7UQ78g+nuPcut6Urt5DUvL9x0J02QDCeRbFGOeZxUMQ7hLKu+f59egMkgPQk5iGl8/tuQ8OE7076oFqx6kywC4xY+qua8xD/107c6t+UnhVn5YSDbIYDBFRKHVsPg9p/nTz33/Z/USqGkS2EPAgp6UJqZGZ6fW09iAqPGqlmwKmK4ja1ZMWLkiEEPRjhCURQ7OPlGIrSVGOjdWYXJVegVxlX9NOfja3oB/On1ckkuWKAU0/YTsR6x2vSM2IQlOztjUSH6//nTvJI9hmsYWecuzO7mBX7zg/CjHyDQulyoAsYq3KnoQ2W6haLzSZfTb20ohRAarOj8yTFU2Lr//+u0xO+9sFUgYmSkpRiES0pv9+nKvGQIwVkyh2yrU7+lX3YggelMjnGf7tJSu2IWEt2a7mYEj5Yo1eCu4ROPIDgDyIRbwoGHdFD7T/upqU1sh2AEgXDEws/NESkMwwfA5ofw5W4szGqWv9eySde7alIztowXoGteMqPAC1zgAjKcQQHZf9Yg25FBgQb4x3CIwoU1cP8sBJAhNw/Q2+cBef9nS/tP+6rc1sgy9RJPMA8xfNpjPaYYIZu+VVM11dUlmpVW454xaAwk70gm6p5u+820wKAl6wGTzQ8BvA8APi6EnzCi7P8o+0H4U4oooyBLf/iRCSc8QA4STugAfPvvTN3dSdLryAUYLtjgfK5pKQfQPu9lN2ixrBUtxBaxGoWVoOBEzPcXcbf3/2tiod19txykSBERCW4IIQSRIL135m8tl1oGUhsim4bBtk6YlOd916VmmVPY2hnYCfO0l1ePsdncZxsJGLSEB4zf/zkR4Nc/Gj0Bfvbl5FHA89+Qb0RgSXCpmRgtdoKRKHFIgiQkxRBkvfXIQQeR884jGTKQAgVIhTocmW6MnBz57X9aOBKCixIpgfCgQH684YuLMxq3/4GHH0//vP9cNctmtnjNPDc80HtR5ER/dtkFV83T/G/pot9vh3p8vXCU6RNhoBEtlrfaEniQ7b8TL7Hzlmgx8f39uYfVdjotR5GWcOKS8zlcuLIph7pZEy2+ObWI9qBNjdJHe0ZDo9OjG6PfZgRxKJurvNnMBMxsH54ljQeXIWwwfz6R3EPTcHAYGT4Ypsek8dDxovHh8YXx9AQobzkZPFkyGZtMTf7R4A9ZvWpuMzcvIxVyE3AgWFBuz0MvfRTnW6Tg+KJEpTN5WlXIcnBXkcmBDCryReWN5J7APnwDR/JkkqxnGtBMtoK27PRyEksW1Jpktdcsx+7iJXV7N/kog501W+63h/YVvlm9VnUDcLNNgmygCe2dd3jder2K/gsG84c9MMpyfIMJTGGGGCxxDvjSiyRXyeZX0WadvkW9Ta71eCaqBzRlC9nW0bqVlmYCAgHaHSm6oeSmheYHT7jLWyUEjADFvFgvllVQLy+d4hYjAZSXnyjWelBzoZwwIqDhtRiy1g46k4Agm3099c6p1VfMbzj7GaMT0BIvyksBWwFGlv2JOUrYeCheA3G0IQkuh4R84s+ColrJTeRkZRVSjWwGByQxzywLVr2lnLhLLmEyn6j4xItBFW25aE9uX+4buWtKvXyslxx5xInL6l7V8KqmR7Rc1JbryHWDXtAPBsEwNQrGwSSYpmapojJ6EZ23nFvNlaVikY+sKjPyTmJJEm2kgCVNUwqm1RrEdJOBwRlR+VOWC5S56uBFtdXAoE1AjLID9FhlMNPBQQBLiqIskO7NqRCZz202yXkfseclB7xD91vxkTTp7Qdlp69A5RSuGqoGI6bWarM6mlYgsSD3+wAMGkCpVQGB5MUpzrpLUNaMSuN6VHv6H4gJcCG4hmy+9JCskcASus24klnNi141Myz4Qm0BCIgF3zo/UdwZDAwcxARAoxFKm2hPQ2aExiQeSuk7+skWZIAc8DvAeVJJRp4mueB3wby7YlnVfhQZhNqjS9gOtqxZ0OO1ZDlDOWbqxP3UL8OpFPRDAIAq10WIBXuigEUvDAHt2VYmBlSh5mM94QDJLzQK87MzdLwVmXVWu2AgwLSEorXAg5K1LJsxFbZpDRASWCgPV/mjTJpEg7XH3SzJsB20M6hEFqTgOmoDekOz1T7YsNTFhPKw2kACLmTdTFcwYJoCBzNbUc3XIFSbGIJJVLxQOzhqEgxMWwFTgee6SlYaWEMEALgllqsIUOsNqMM8IM7smAmCdcF0INCarQAuW4EN4rW6BXiVoUhYY/QHa9cDpv7mDTkAhNfsDeNWsf7T9Ac5ZslUWFFJRU1D28C4CZOmTJuxxIoSt0IelVq0aTffYlvstMtue+y1z35HHXPcpMeeeuYzn4tpnqhraGpp6+jq6RsYGhmbmJopDuZh9brBfRKIyEOKHRw5AHyyJsPg7KtOIK5kbC8XEL2WYjXbXc6xsSyJja0nbkIELxWAAEGsMcDBA62tLcdhfrxzichRUtiCXOzohwLxb6MA41iBkBfW1bKZhCpgf5Iaxz9gI0qSrC3iwmN/tdYAIuhwdXFqaTee4KNRyeEKooOiFYmBfH8qGnIysNeqTAOvxGniuZVDi3+QFaTLViJh2eK2yc9r+6uGnAeUFnLVAGfmEsP1UK73uCjWBb5VSZFRVMYfipclaatEI0TYHlmM0giCE7u3WsSZ30Qbb+9avQosRa8pL897c68WlRSVtTZ84n2feESyggqNmw5Ue6kXIIiFFdFqqhAc9YwKRFBinMT9AGzqg0xS/Eq3BYTY1wvmRRcsZYPAtaZHxj0YTdCuVXmiroixUDM1rcAjm6OeHdH16cExTIDTlgNbQpuJIt/rx8wksAs292P5cCEr43AYgHgnDgO8MqRI4pATwMcFlwTDHc625geVoS8ViJ3zuxVD4c8x4cJOxQ6sSGD8+2WCGOxgczpzcWPrpgDkxfuVEFwcKBocStSozM7BIz6wW4YJiT70dMlmZ6Sjopo1Bl1EFXBUyQBAlQHHyw8H/GLlvJmIv7wMoi8GGYxMPfJqiolEufCUjfxWr1mRGkfpwcgW8KCuscT3wT2a8CDlFtMqxjjUqwgQT6zVK4Wa1B2mhXXIQy7WNN5AqtgUwvjWTgH7K643Td6Vcnk8GRLALOFASbMFAgQJi3beGGInqHpbTTdh0kXM4foCsAID2V64acLhxodOQk61/jIW80El00K5KOUGl51PbrZIMgNCTdK+vYm01VGzIOEz/c2FGFPWoqX+4mWX7Rx1G8UAFYSM4lCIZcNcfPwgDvpTTGW8htamwRkmSFS1QjyDTi9lKtBWHLptL75m4Qo2p0lyLplA5cAKipgSUUPGAGcSMo03R7akZpPhUt21hjuSZ7qX+V5X9YaS99je5/lI1sfyPqH5CvaNsu81/cD0o9hPQj9T/cLyq8RvqN9V/KHoTzl/GfG3yD8C/1L8d4kM3ncyoZmIW/Kc/Ll+ACBDrYcLVhX5ijyWmogUhTVjugCAIXFimoW+lghjcfaheBGbIxJxuRgAi8sjEAFIAGRKjXCAHOSbA4AJ1Kr79fMV6/0UgC+49SOKKOtwgpm2Yn1wSAEwopK7uf24fAzIPL1ZCBdpYOV65WBJ5TE7Mlokv71mw8CkaXMuG/faO0BnPQyfeOlx1S/JvpBIrIM2z5ln/lt/avOe3ZdCnRAQY4E02fwtAT77xDq531eI/x44AhHNOuUYQBxewLh38JBu+Jj/u+7siSX9cFeX8TgO3+wE8Brm/gOOLNDUE1PF/+LfeOEQPYn3WswV0PXCgg6Am31zLnkOukZwJBNHrn2cHNkHBNy+DbPTpZCxRZvULohJO5F3kHnHJEDCOp9+g/67NoXYVJabGhEECJdcsALgwTnIPY02fHQeiN7wxCwgZpVsOl2BIi0shetG7wJPhaOAtwASygQpLhZ1thVZXdg5JcYNAZO+5QGbRNFMShzOS9UWNPyv6uqx1KLV/hb7kdFAze+Ah1wDYGHCWucdP+Au6UB3TU3r/IDAI1Z2WcSm5KC3USpHt7bL0KCXDh0UdP1xakfoVg5c77k7AWvi2dZfCJlcJ/vcxvGIrhqg+unhlsdARC1gjTvAqwSKLtlqgYCgIMg4ibuwhViJxcDl44wp5nq1gKWWZ/kgIr68xEdxOYgqrgiRHnZnno8yC80DjQF80pg/FwYE6xBCFn0dLAiflLEkKB0AF64CEFQ8mZDBAVMCm+GNFn2RxIFjGEhziIZA5WcYitdmQLbIfPC3EWvsSQimyTUjcx4AA66t/RQEIubzuby48MToWdZIGmjyiG5B6tkVpE0KwPU5C7RpTHXFLJ4A/EHk+dlqvrmd9xNUOKuejhOPqZDVB5YElIC1uZxKsQ/0mKj1ZSAiMtuU+lg1QNz9cHA0uFneelHr6napdvyEbUkPcEkVHGBUX5lzloF4IkBejbQtSnSBjucCFt8lCHjPft0zDNzr8MCEhZqkBVXdCNmilMtcMetK2F0LqBLeObsGIyc4hhatA0gFp4VzxA/WmBmVYA0N8Pogogvuifl9iqj3tFXcRH0MQeqxwA0fHWgv/mol9Vqr80VyRcOO13IlT62CIlZmkq5/6kGAQ4waDzAPr5F2QqojZY313YikEKSDxv9RKm/9iMxdDV0mHTaOOkBiUOS4/rCDfjPp5EaDShDRvK14QASIHy/8mzFHk4yE3rQlIJYNdqm+SOTxUEBcfukQqqZQV6WMk8w+UnCG2X5BkA4+V1E6QmdA4oDxGuOkd2hdxJY1drY85zWBhwcDEBdkNrNLnXDDaUIR5K2U7B5j+1aXmYl0MJGLt0vFDXtQ1+kejfxE4ETgL7cZq4n1pV2k4cOpxloBcrjiKr07KkeQgkBig+yzGGf7GTdZNcVRFlHx/I6s48zo5w4s1hkg6y0DVTLIFADI4I5Jm58UaWlTn7ww0KtIYoYYYYH3ozAn4k00I/cYZqcyPVU+mirNOIcbtGg27gSoMmUwXbICtuE1Yuw7g2wdNAl8Lgxu4rUzUHQ/ABBKsB9u5Dr1rToMjIHpVdtodnDjr25kxzvzAgnlWrEOqKkkgAuA7l4H7rS2NR6QXNHs7sc9jMDrOPMB7Y1kBefDMUBpce1SSXw2zqXrJIhmAfFEQhyt3JXivVXlg87rCr6WpkdQ42Hi1uwuGkTN0XKqhOxuQi+q3GzXTTwRr5EYJpolX4kAYrVweOtON2gsJdDLedKLQBMUC8qAVOZo6DjETwJy1VqSCzGlD46XBujFEJgVfN6bLZFCVM6bioxwNlmShYpPlRye0KXfgGqh8jXLvA2+1ImrU6utUMTZ3qHb9c9gWi8Fmsi4n6ZeIxdLygKkrFddyEJaFS2LdPoGI0OmF8MZZjmcnbHjYdY5EIMZTV2MPAFMKzFyF4HmOXh/ruWFvAYLEC3LCSBBD06krOBIgTSC5atgKWFohdhVu+M23l5/UyXOWjDP4qdHbxTnqW7jdDKimVoMSca+tV8IqAECemFnYrKB5Kj+OBJvSGzu1nmNJ5OrE8KQZeUG8+JshXl59ActQXTQkEU+y/TrSoemazh7ipuWzQRhFdawXTxEfYnJOw0Nio3ewE0yHp8EyVAkxjctC6D4LZVVVAHUANQ1nL8XkcgUJhWAJkdnGGHKycFkhjzCIgGgAGxOAK65yMyeGcC9Uj7GN0F5fXBIARRVrTpoKqVUCtXUFQAHCcYLLtkmsxn80I2AQi9Qmo80sHK9ONkXpDMZMpC/rWDBGsXUasjz0jPijFP2nFOixjARncfVWiv2+aRzZBgQzogsCwDAMoAlAIKARCCh8gKhNYGASCSpEYgiRCxHhilsNe4HQN8/lzEAkJpy/rYWSFQ1DqGMgtf100G9ngLQGbc+C4ASDu+SzFBJfXBIAUji+YomZQB6+Ek3lWpF8xHn1BoYQsmce+dS1BqAjqJEQ0HFgkXzZk2aMK1uXBknxLvKnExnihtNKkt+XlB2JUk2L0v4XzhNW5cu1WcamoBNmWKbMcuxYgOz5ULkypWOG7e6XvCC1Ete0nctSyzhaaUtvOy0X5iDjol10g3JbrlviAxFRqnXZqoOHeZ66JF5ZOQWoNa7fpM2kLohshQoU6NJhydk3vrsXxYSQqqkHcOIYhOHuMQrAQmLOY5kpyClqUp9WtKRrizJqmxIT3ZkXwYyluM5m0v5ILfyIE/zcb7Mq0znl/zV1gRO47ATlpPe2MzSwUcef+rZF85edcNt93z6nCrUOqxs+i/efuLxH+Im5AuiCSRqgGgG0Q1iKEhUAEkPEINBTAKJGYinIAkBiS9ItEEMA4mJvEZvlM2dvCXL6h5v4flTo5ekqvpasvomkJmkpm5kY0aSRyRDpQCZRpYSmTpeQkTq2Z1I666fVl+i5nRPebAgJzpM2YbDUF/ClG8KWqJDM2STImW/rqg8zdkLpq23D4yJREkspOjJSh9D2FtpHRcb7eBll/2CHHJMhJPOiXXRFaWtmi5Trn7y3RqMZJ15MBzY+JJ/ZgCVJtR3P95Usy203FqbtfuPyVGnXXTdXRX2QblU55WsIofJiqY7yVnSVq1aQjKJOvlAOsmN+NV3MoscIDV1pxrLT50BcoQst3xLpFw34lHX40jv617+R71EyZ9gFIfq5DuxJcpkCHEnt0gf4llnvWUNxq3OhLrAcfIbZHuMxi+xAnB8yxgPmIn7iSRIZC5VX5b6G0Ji/Yuzg1yc5yqDmwLu5PGYEVSo5Vz8pVYyKJUNdvz9+N3BvuBgcCQ4HpwKzgYXgllwFbgB3Iag1oya8bHHaHFDXf4VWiKtDyED+/5Jq+ChyUyU7AMXnnfe3BXE5//x8jku/wP758Jr9t2LzhE0/4+5q0T8gjbtXNUc0opf8T2YMNZEcdErCovRJ2LHhY8QMVIMRMbIYqsnYW+Z7nhSV8DBMvyY97kIs5duESclHUdDTr9JQl8F0cOIqHnstUVmm+OJb8ZQlLvTJQINkSbY3wsniGqJXGTVrw+g4XocgHkf/bunu8+UKhaiJ0Ptw9RCU0SZ3EtW141JJVNJ28J4xCbnncpRpknfX6XaH6XCb6USITU4ELqIMcyPiSRhmKij5E4peTRiQYHkJ9Zv/y0WXn3WAzagsvIihd7XHCOmzYHJffZXf04wvvrTN5NmJoQEEyTNikmSvRpXO2MxPfdR8bSdAOqhKuitl6h+jOuXUk7xhhoEnIAXgrXlcBHYDIBD9j1iGgIWLT+i/7+H0W2hTNErgBqxDDDFECAXnjd3DVgWmcRaKOqHh8y7rP7jWOoIMnX7c/7of/W1c66++ILzOYx89YZFNgnK9JPp8HOej4FxIC2TsGbL/1XQ6PdfImv6HynFT97zm7LCUwVLWUqRNL3qQl2rj1s4ZzvdcLrddNfp/uY15jv6Res+PSzf/4OlWDkeaXrW+NyaauD8K0y3ne5CnjwXTR/t+8J92ZU//wsA/38nPP/W51vPN56/9vzGQ38i8KsX+7uwOgNbGnewP9Z8BV/1NV/HN3wT8C3f9l3fA3zfD/wQP/JjPwH8FPAzL+FlMhBACmW0XmgjIvCCmNMJz/OE5370/7L0eAaTxU7gcHl8gVAklkhlckViUnKKMnWWSq1J0+r0BqPJbEm32uwOZ4YrMys7x52bl19QWOQpLikt85aDFStXr90K7ek7cHCgf3B4dGTs0JHDR4+dOHXy9NkzF8YvXgKBqmrfi7n7Wxq+7Kh3autfXWbBRdcDZm9x/mOe5oG5W392+a7l9393uUJ4DYZ8j1/4+y8GN/7w/7HVj8wL236s51V2v/Z9vgfDp/CVm4DgKFOlTdCjZYBMAGpZyEaw+l0F6x6soN0FdTr4avfVo8IR4NDhcAGqZiowhzM5uUiUmiNCYLLmEjCuMGtitnEWTATSo9hbO2o0klzVfc81TlwFCgWmMaLJVhoVHktMs8E8KTwftFnhr3KanQJBCfcmTsU0SCvuUCGwLoedHBCEsOCjKVkmz6WglOiC7wnvAc1GGDGido5VNAypXKQ0phJCUoIvqImopnXypkPHfS0KjYCGxPrZQazNmwXshNQYS+n9GV6hHu02aEkdrpJcgrGDm3g5YWZEA1qcCxLT2SjWa6jKsFDXJousjNANwbhOydiIwBhRETE1lKyjdknAoUpJgmO0rfmm6Wr3O17dLDOMkWMYEcUl2mUqRaKpMQ0jRG37jzddRCqaCU1VRevTjk0I6dhYjjG2MSFqsq4iKv24aIZW0VKrRmZJfZuooi486bzGMSpcMuC01rAwhOK7WtclIznAYOCpEalRhwZgKZvR7BYraFV5j6vRKaWpbJSRxpn4Tefwq9+9jcIG9KtyGa2l9jjpt+K8DXz/AAH/PF6SAp5tkz8M5mmFs1V6d2v5zz8PmARuVTPNpoK48tD9e3eFXUL9+ztLY8zycapMLc8PrhRLFfDvINwVlbZ3sbVSusfY7Nh/6W8RkzgJBuogZu6wsoZ47V0zNw+yg41aPmAX0KfHotWMQnA8vN1+CGbNbqYFRiIQIyGt7UYHjthu6bAzk5qg2OzM3prDd8f8OQ4Y7eolArqlbt9wf4vczWnaYW/av1FEhZ05238ib6BOsJEP/27DLclsZHIPzeEY87hYvuz76/T8fAokmnBQXq9rBf8N7M07neTX+OtywCEw8X3zC/iioAhO8gE/KQMcKJ7raSxQnPEC6sFk6Q3mbRur3XRTapJQZOotyZ2882LcvneQGmKkoHBHi6zYV8+0WqqajTBIZMP2YUd+AhlYPlkr/0aKNLZ5274g2EUv/Q1qhP7bUQomy+igCQQ2SpgFquMIBc/GrByymx6GKLiycBJjInxp0GKbee6+i5StCee9uScD5nDpXd54STJqzFkwmOf16v0G/woScMi8qifHbdZUhKuc+DTlnEJSFyOrumhuKTuowrACixkOP8BQtj6SsafvioccLYoBM39kkgvaJSdL5iW1aHJID/6U7S9pl5PFeqfsbD5cPoLK+76BgDTj3osuWpG++/YhvcEIi+VYpEK7+znduB+dLaxOYKw7HaNRlmg3er0yhutuqxZgsmJThjV6F+y+VZbufM9pWpntQcM06rst7sIKXkQdDLTdRLnEPMSxgKkQ/S7xc/FLHxrrSG2oL1upqKtlq3A9EtBM7mnw9GZlHfbKjP1b6wvJ8etX3M28Zzu24/O61ehEsIT5BBx07pad5sDR47CubaC+hPpugpqY7cwbdqODAzbU7YcPEUrEciH5V13ggyWDDnbz5rWEq47cCJhT7RkpJdk0hXVSTqdbYmUPuXSfuzSI7LrzRIKGLI60lEnaWImcvP3IerRcHJWDdzqqS9zZrrb4mK77VV14tNZJCPmhRfWe+sAnJUVm1u/HKGevjJ53QLQNHB+8PatvBjqp4Trx2IKrjkx02cTQRJ243+lA3QXbpHpxdOht81OJQTJn1DQGd1avYnl0q9I7zKGpwL+UNbo8Wui7zG+vV/pRsEIY431/1uAgyveuqyCA9goG3mzz0iks5+s8gfxXDwmO0lFg5AGHDKIEcuOuJ6f/XR1lAZX/Dul0/n+A8L3eHf0bZBkHt+TBIZMeKbJIWThqnd5J025kdNJs0bwOsAHnNY6MwfLDhGfdudP5/pBWFgGjzRbn5ez6kIbl2QlP4jtPROW99M/ZVZTQCSXAXn6Iqf1qQZjP58HX3hwYiaPP+yZqx2HaQ6TH4OnDMT1K+3qYFSPzhSVmPRVSBFCUzYwreL+9VR1mmZzvYMWuYDq5rgm1qeEuJymaHH9uDUuOgl5v/7wW+QQmiazQ9OcX2Y9bepLRWgjaRn/OEqTIZs2G1ynGbOe1qBUBc8FF7ZK91UarrmimxaNwoZ/vS2+dZJbBdi/MOrycVQXjeP05LmBzk93Sp8cUm+KW22QtYfruY33uzYtF6v2y02IwDmCNTmH1pZdag1rSfXmh1jv0gobMHd2H9wbPK7qtLvsdaWbc1nYpgR8UHSsG+MPCg1VbjiVczQBEkVmMOJYP3gt74yVsfF7/vHH8Ucsu62+9Uxe4hhYIC2iCWlsCzLh/GURJfXMo1S0W9gy6wIFZB6vlTIbTYmvRDhqwpspP+VECUzPTO0eTe09pYiSnSNuUlpTPkbXhQIrj41ZbUPBPfWnPQo+KwbtdOGG2aLjTagkxq0OaUKjG+K9Q8x7l5VPpSDS4qzS2JTrNOQewVnmK05/tCOXOLwUFT8UqgQ3cOzmndWUZSITZOjMMCCyeui4b6pAdmxCuSrbsbXnVh6Kr3l85ZoLRoHrLtko9/LmFUe693ZhM6PVOdkhonKamHltQ/diNCaM3N2TDQ9u7O3p6OqUqgWLbcYDw73RHX25uLqOp4RzOhmtwtvlzLm1g5050p26DSq6Zu2kCcjZHjTGG9Y2B0XqtzkCGQGs4Eh0CcV8lWEpSv7Q2Bz7RPzua7AbeVfhBNfbOpJPt+Z1OQAbeKOmmM3RQVX48cwIAy35ZUYkOzdx7uUWx6auU3FGOdvGNxQW77d1idPKeLd5J12Ngh9hhD4ejTkyD+XHlRmeeNmWMuCqwHJmk6ecERgfeQ0DRNTsiJ7dTZDG2bm5kJJIj3YkJtyfJLCe9sLAtbeoTVOZlbgGgyLbbYYtwxscV9PzDlEowiluW/ziwtibpr8iDdcBhbluKjNxdWKl4bKwqQUpqV9l8tuppDE/pR63B9N5N+0DgwA+vbKMFYA3cK2kJZ73oHG5Egd5pNYkdWm1zP4+6U7u0iMNnhnW1fh6xCD+Je9bkZCzWHWRB7axy0Ailq9nYEiaqO12bTdQouK2udXHKWkVILsU/FfGWFV7VFoTnYHuBjR6lhRrLxlUImcFyv/o7Sy77+zxr8vtkoUMfAyPV5cQO/XpJ8uhOnEmpIs0m5C75+ekUqWgggbRALiXncaqq5qMpdO70Ynhkg2a8aZJbkh7+IaU2HemWKizI1iBPBp18OyBgS2SCcHuzrIZ1q0RCFl30nB/oX58m/87PmAvAacdqZldvNpF2Y4Fr9fTcRQrX2jmCNad/kCipixHkOV6q7TYe2kDnss4XO5Zrjuy7gtH+NL0ToihtZqSEhELBnn5GS8ndbZC47/5Tv7AkZxdkG+CXSQCaGkpFlVPOSssenpVY5MH9p/6GNTS+KGZ7u+B+EltsSvNtVIuvs0W3YpV75wZVAPGDHyiPjC6Ey4WDQ+0Ame57fwgO1JTDIZE2POmsTNSM+6RJ2faA4NEaRyamYTYEoil4UisaWA4GW+eeUZNZF+q+OGAHORm87RIwJz4LqOlPd5MAtS1m9E3Wq9+3IEphXYgANgkE3c6HA6+tAka8GMtu7SUaoAEecXP4PyLM/U9WKHu/+0HIWD6eHVq8bFzuUkgPplhDe66yRQ8oVLjGA5pT1PIN1wE7M7Sh68YD3rsSOiFhYiBGHSlKJ7bdrW7idd8yhZso3hLcwZvoMutexSGbvsuzAjVDrNe3EMqiU5WjfdUaNzqq4bAfvSa8fX4VJCgwipRNFe9UzXJ3HK/m7er6Fc7P2Rs61J5D9MVoqDnKwyjpbxRMW7M6Ns9Bkuf33c723RICyJL8pf4L8ax7qMEtLWVwGhYwsi4vmkXKpU1lV7U2+bz2ua5TXvqM2gQp0ZEGryKRZbZ7hU4V/Dvk4i7csS97BoSB7BRZzr5mHHjp68No01T0Lx4mzozDcKwLF6rsi0qCMXr8ZGO1SzKgj+w46HQGNHOPwOjzUpYk5Vhk7UFF3CvyAVQctogVUcyfH/Zjaeempj8UX9cTbPNdmSBFQoVaVimW6yh8EvZ0kRldRYpSVDxwGZK8PJPxA25S+9OKm7e6mMu1daawufMQCqAvbJLlR2ga69h0VzhOWMKO40HtBeZ687zKp8Z6VQNeM2dHwYGq5BU6TMfXYnxozDkt8JSbe3KIti02GGBCx3ezx6EkbdDwvU125NS6Dat1pDw0c/gjEI/fFBuvivvL4YmDBhBX6DhW+k0ngyuJGFu+cosryfahvhPMPsA2Cxpq5Ieewnn/hczge5ZvqO9hmfkeCwpGijrY5r4n3OgDw9/XGY5q3oavFPOuFPMGys0pqrL/JdLnQlLtgavF1yvS4pWnVu2/Qousi5zFjz0ZC/RwwkVUaJhTZ8eX5sneKR5l+R1Wiuhg5+P2sa70U222O+9xMlc9f0bpGFtQ3713xnvmnfweOBHsDM5RyqliGn4ci792JjT8/88cwjqoJWlNGkG89bGbgkA6xXHOb5xKac8XbzAk7N23+pmdepLSkipiZGk1RazZ5uwgdnQyxkdW0IQxk5w8/VyTCM+5vwV8VJpNXcLpbs2OYnyKK4/cZWrbbyZN+lKP31kcdnuEWRlJa3r9V9L/YUr1uRTwBH65xKEXkcwp6aJTfbK3ZD7NutxJEaVZk5TssusZ4qVdUyf4nkkDdBYyInUpTTzK0ys8SMcYE24pYaD3GeJdtu14fRQtkYbbHJWfi5XByRjRFmEGlbj2l+bU9H6MK0L2Hzi0BVNgxhQYxsng8PZl9+OzUBVKZpgDinPY1ha3VXv+4d/LzDXUyef8nz9iW5idaWcv6hwAVQvuztwRo73xozgE6bC+O0DXjdxCFSUlNxcxeEi52yw6kNSJyLddRn/JJVwyHxYU4EoKxVFl/5aEgv+dHb98QX4nybO/58JAvFKQYvgRvQcZUxrgYAn30REG973iQbUI2DN+/eHvflCYX0ug7Qc16av5avCUxvlSomUVT71Cum4VY5IOy5u+fZE52ZUVrGgfrU0RsHq8KZrTvxEADtriOuZSPqxJ79u0DVoMUmCvtjh8sXrewhhekIidRsA8hv06ouOrrlj8GJaUfcqGZuVm2dKS2B6Ny2Ve9GSYzSP6xfxD+8F5uOCJl4Ni1OAJ61AxJ6MSvAlv+GRbuS3WGKJTMMII8d9AWMvFNFOe5WkahKDdTiGfn5XwfXxExzt/LH4nlijpt6EThFrkFglZRDVJtNSZGL7KoFBwC6y6ahYQrWd/cOC3zAW/eK55GOtdFz94XbM9BHwT3v/17JktAqEr8W/yXwbgb7OW5COduO0o5WWBQMe1/tU2PyvWwMujhi3PECeSmk5APDXfZ3OWC8AT+Ok8tztLdbRjx6G22RjGeJPO4zE2c7OOzdghoVGlbgvbJPU7rV72x8zO3XeW4EcJol5J+Q8RENSeRFsill7rO9qzKhM8g18szjFJmI6VJjoKs0NqlPHi7X8VxCe63ek6Ht3CenAA60zRKUSsXKO+nFNEr+m91o0NIGWtiacXtqaSislbUoQvjBZNC2mwUwE4sCtMNPFuKmiHi+pItvLdkERoTWzJqKvN69bYo++YF/0SOb7/4cgf/738AhPy4hiQf3no8iHNP9FJ4F19u+K3nt8hwNEme3CTI9aAWx7HDeeRd0ZgHoeqEe3v/LG4cSylfNKGZHL7DLEkpbDQllbM/Io8Rxb3TFf/U1w5V1kXn2kRN9g0hEXyuQ5flXOeMF1dQ7NqOV6thrwitTknPYm3hB8jq6qg26zFcl5GqpTUnFjq1EhZ+7fAIop2mZAWhjUi0LsMZMuIf5UrIjaZmjOYQ1JY5irKSgzdCCuubV0TUsMq1msKqYpT80MLQgQ/xxU7ZvZHCoQdLpYoPRNp4zVnp8FpV8ANRdcmt2STApqEHJEX//RddEIT/y73OSYfBt5igWotkNTs1Bss+Q02JEqdbFJwaa49GQli74BgR7LD8G3GEQR3QrhjbJ3Mqj2qPoSglQrXg2D4g789IEE2JfhVlS57pVA1K52/NzRmWXbb8IwfyfkvSZ7J01h4nsujH6+TxlktbqvRZ+egfyQaJG7K3C8eXJ5DOkfLS6VFldBqkmtzstpkTqp5RWaL3UyjXlb0BJpaI0PYHIUZTaN+TXzLHTSS54Xqo8+jsuWKh3JU1vl0RgxtqZF/9HW/SSbS7sZNeA/0OwiGPzas+sA4fnVllr1GqNHn8hadnoNdpEp083QWQcnx7VNr9StuKtSbGzPibLjKADQDmmVh01AFsOPyyKOzlX0FWYwYo8cKr01aGIZ0BusnWs8eoAbO+OnZfQT5VxL+LgZ+VxmsY0ZKL/y04A8P9DtkWfgfMrvWNm2H7hxYrRf27hjoHqSKz/rDbSroU8gyW9vdLr2F3+ut/Jl+c7K8P30YRh8+Qbrbh7zgtZLQ6i3fZqmzCZtga8WWoStDy/bdl8CWzEyzV9+rHNyU+mUJbJ2i8rIBOlPi4mjMgrJny25sSEbF/5m6ktN4mNB77Uc45/P69sWtCYgqlm9WdY6rUWK+72ySkDmXFaa7jGkILyvEZsPLe80ED/T77y9vkKfrrwquopiN3M1gdEzuik6p8IRXd9fj/NnKjC6mVcjL0zNLU86m2GEWWtzw5YcL9C3g1TKkMZEOgd4qyVd/03WXHg3JiMlLg4uSX7WaCc+4r9bzsf0xfIuNkwOLWTDK7hjvG6LZzWk8E5YwzhBTr/68L1FjSxOxnLrkAoo8ycTIgn1nlFw1XsZTYaxVSsG3K6QEgRx1zEhS2lIl7FyTrowFmjme3srdlHlG7iBOKbO7a8/LA8HBOvBin7NIGKv1rpDS86rZ5Z+NTjyo91TVEuqqt4slHe8BYZFWGFT5BLB75748iISoYOFDMMBzQOchRdsmEzjYuqNYEizelBliCg3yrTH+5jBssofaQjk2O0hRxUqbE1XQM8iQ/0/oT//ZD7oCqaL4rbPq8OIIAPsU7GQCzOZkpf5c1qqwL7XDmgp7meqALkMK/OxZv2ZBvwM/vIxDpmPh7bHIMpW6vcKfgRu/fwjyR74v8UNnwMAPSTOC30sGOm/jF1g0cslpYMtG1OjK/V8U2kP+PQwYfJ8e+hS8/tpGZBw6B1bC5UKbmRtTSM4XuNaaGBwh7mZYxsxrv4cNBALmbOU4mrIPC3fisCUBB8f2tToNfelAM02/oVb92bQgqbAM50lbPd8SnfAnmIJP/9ZGDxcFTrCajgRSObYnGppcRKTm6rQ/MeAwj04nGKk6n1b92TQYgutVDjs7Mo+Qy81YZ2UKk3VJfLqdRvChMH/oZnqFuP1+umMqbaUvHcGNZgiz7SzD9Eax2dG/le8yTET5q4wwxVeFgROsY1fpmTHRl6DTV7vLffYchhtnOV2syFyim5cxamOI0UNJ1WTyoE7YRM0ObYrQk3jRzFWc45NFPrhXrSQti8cE1FQbcE1K2wj4h3jsGlT4yudJYrHhxdI4z1gxwr5MyNfh2AN2JEnRT2E8jWON3UHsI/vvG5ZN1nnVAuKLN89eR38cT0LTnmqQIftusAV0+zYnVYC1/XlISse0x6HGUYgoVci7RSoB3dbrpPDRP195c+OjqF9P36pktGkV0oReE6MglneK53vSqw2nn2Zk7x+Dhw4PKZ7ibiN0fvghkeIgFtNWPlYZMCydGDTAKY+w8GRuvlYQQSYRDQpDfkrzD6xtmWJ9vi2nAmaBLfUEk9/ExHR53Kztw/0btMDJq3ux4AsbigInWR1Trfv8oWo11hcTohDDc2zppQT6SXEbnvAQj12LCu98zvay9T8uDBr7tGzQIKwFRdHvZz/+iHzw6C9eFJ8rlZS1itg0ojFJl5/c/N3a3qACkZ27n8HrZnM5pgFtQmfJoYiGhkC6G+YA3gV29OQM7zp6tdgG2EjxoUaFfkb19rTw6oUSDApDnrLl11PLtaLAMZb8bsAksKWeZHIzWHCuGmEKmAVWjtR24TYIpoGjisLJb/kSiQIvI2iXjk7N4UYKYbyGA69z2Lw5SsZCY32VUXf/FQfWPelQdVHgOEt2fdedZQ7n9cFw6bNi6FfetPldB/bRwKLte4oLiwxjEFSn8G0fOpAO/RL3N2aiP0FP1c3P2TdqG4V/eEiuBoRM65YICruNRMCSsDtQUWc6cr/W5fz/QsVunKGR1JoJ6uDJMDLmKAG1DQtfOYeNvF71HgVzIvN+8KavOIztf2oxCUm/k4YcFdfLqh43EfTWPYczYkAATrmKhRfgSucXjQnJPaeFhSL68iVjS2r3/bHRl1/l1p0sYoDVcB6Xd1HgKAqcYbUO8uFqfYLckJfSUuzNbHNyjdyPZpXgcBUyfUlBwZQQugBpcJ1hk50a6MAQjzilAg3EH5vOQWkRbTNf7NbAdodNtKVB+yAebEoV/F7Y4/d0wAZPWEIkYojY1ajo3g5jfuZcVoVs8udTi3K6UxagsCullP6wiyQDf9sUszd0kkcbhIxkJkZgBukP8wByknXAGuw9r0FFDXZURWvNTAvnzRqNBcaCt+deiKeLFzrz1IAHx/x27wis5KpwqTkU7K95kPCKFXhCmrd8FhvZW2bATrced6D6Led3LOBcTdqNjdSkBYnglHX0o5z/Rg1R8z5geyCPmZg3pOnJ5qK3MWM0RqQH8oK/JxPRwR8kgzTvgAi4viWw6Dfau4eP9pGw3YvT5ig5NaODwc2Q/WOkr61SRJeLFI+ywKbwXInDkEjoTmkpzH6JrxXja0J+2YiWQsXnx6Ff6sIGh1uazr912Zm6ab/QQJ47A18t3pbdkJqHLfYTbwsyzwoWFEZ1E1xC93B6bCjBIapP13vIQvq+Q6sJ9EwKYTRj8T5LOUcX6Gjj6GxZHBE3Orx/Jta8riIItkBqFvNGDoPQjoTVzNYqSqevkzQrYTbP0viNse6aHsduux7UzrrngyPPrB1YKFi2ojaWh2PWWD0r8v+qJWjhZBOa+4YOEJv6hrZmJimgZ5BDQ4FNUhzQJUjxY9IW6CChqQ/qIzZnQz+D9o+TC2qSo36+K6WgJgVs3I6/GadGkZJJyNMY1B7kzJ4tcI1TLY27V3T+v3+XK5/gCeTmtoJv8WgYnvFPo5XAn7LflOfMY/9E/aJqRyqJWdkr+LEBkxodIhHtAOp24rZdJvqPAQOgYof8wyQO2it0W5Qy/m0K9jA2DhEd698cGhEhvj+0bLvvCJbsJahTyhvijVZVSreqnu+2pVZdbxlEds1dWV/3ElWy0yp5RiejQVeg2lnftlHvTqvADOZBhaodX/Sgt5CRRMI7GFnYyS4tnHKTgF8Teg2BrIuLpiJiBLCPiYJOTgQHLxrvz8j4h+sLiiYGxEzGPK3uRSAG82Wn3oy6BkZ3xcahwRiu4fJ+9e9JYHgvmn8ELS1XCvHPnhKykMG6SNQsnZoaZ0Xq7F5j/Lbrf5xNlMGoxjwF5TFBM3wLh1kvPt3DklPzlFoXQ3J69ZMf86LoQgwxFIXlgIfnZjydobRmiqm2Jp5DMP2sJ3HU0TW1dO7OaaQPf1uBwksVkJ781tKVQVzThcsXZNeTvM0N6UfO847Dlw8DW8ea+mtftQQZo1G9OGoRio3ErEEigmLjXMmf4OWz2JSA9Qix0xG0/xIH4/kHnDCI0qnY0bgYeixC8QjV3hMdb9nw3g3jJ1OXYBkD+UGGMNQWdOyprciKI/C4Vci4n2OWzUj6iSDJZuHQNzVBwZ+HEnDqyn6Aza0fMcb39IDt1+zpSv71/Low1J1oe2tlhlxly0/Hpk6hyXhc/kmAV0lNMYVFfPk8C/Rtp6YVm9CMPDx2dRz+SBv2umpmXR/Pgkq/x08UZTuV1eSU/1+5vtWZ/HGL9IjGHWva6swCPW+i+vc+7C4luUX2OwO18BgtOLq0+QArl0UxxQVmhDkvsFh52C7gavSa8Y385o1qWbY9d+lv4HGnMNl4metvdEbSAbHayGv4FropBy7fxgtJuTKdhcO/e0xgzgS3LwdkGE5Twv6LEiNsy17y43NIMVFrhxKS5R/xW8gqvvhgxUU7dJGKuFi6EAZevktNoPLxSdLnh1S0Ncb48P8Yft2PZvpj+ujV6wzqo2wG/SoUK2+MBkbWtwy9P/TljbHZw+ubB68OghhXybrS2G9e+ZC98B9iywUl6eRjYyoftOXPnYj1HnPdpkfhi6eaE8IsXRoPfdHx9qT2TSloO2U+teD+ww0ya2Eh2f5KQfPRIol+6q0xhvXOqS7MyHDpY1Nl03zcMIyOQ112TQRv+oXDOMcxYjhJgGI8Hm2gXrcVFPR+1xWk732WvsRlDzqs58VI7vNUBjPCusMPss9urXBhEZ9F0hvlgfi8ENyCcm2kcIjBRGDaTkeTgwioswTMTaBFsSS7W2cuz+BHAJfXSM0JLYYbyGfTbolJfYrJmaorQ8/89fX/273o6WNRC3vLI7yqT7nUCGIZ5o86eHl0ELtagx+ZZH1j2IbI5zEIC4sLH1dI9g+Di3CnvTxbGT9H7y3XaMTxgnIlad6uUpXBM4vdtsn41/dvL1W7C5R34pfNymJB1nafRcuhEpsvb+05VoGNFCYIaPCafYLv03BdiJAIK+cFtrRt/ez6jqirebvFz7Jyvk0Epxs6q2wZF7Pd3yqC1UUVVoc0Mpjd07IP2lPDgx1P7OabtRew9P0OZUTQOjHg1D3pUYaM2PGuE8hGS0VGBVj4pZL7E4tOnDTL78C1XNMEw4beszI+Jh0rym18EpyFOyzeHGX8QmN9hVEnM8k3zryfLZejbyS1k8nXDcJmanaoP8JA5mUwRTlOpm56odiYcZol/bILtjtb+pzyd1pwP4rgJbfhEyPUB69WK0kHGZglapoNaDKR7tgIfhpomneeDWKXxsijw6e1V4HnB7f/DAWMVEM9qZnb1nmLtxQDXVXiC3wgHDUH93ctnTCInmZxKG+/JbC2Aauu30mNiXpxWpc8l1zzxoAQl6Mx8F0Z8SwK233pLSDvRSujQ2SiXYF56wNkppdjL5NHu2dsD7j49p8C//WDuwvUvr2acKoU8zq/yZOXsZpVE4gwsMeYQS6svqwgs7M9LW8oDSTCdr44sXfvSftBKwgP/G1fdqL+3gIF55S151LB95uGRj/55wDNP7JRGcKsKg90i6/MVP6+cmZ5U70krpndnFrnclWLNcz//0+R4svgn0F4s4fkaoU2+g6+88ff3/KHxldYJP1j6FcyNoLnUbwh6sttYe9+s+QeWQYNWM9Sld9RzEX5YMug20xJtc/WVG+icgf7gpY07KBs7wjqYGn5mhbdRrNSvkkeZyDM38aZGePJym+Ypk6wchpZe6Bz/h3Izk/Tsve1A3w+ca9ft+eBM/0+hWQOMm7wjW7BeFfPrqVMz/yFiX1JxPkQcQI0bA2TnPO7c2TkSgFc2wucHzG7oFAy/1o+IRraAxnFeufW1BFwbF1MXJzB8Hx2Nj02xqpzjWj3k4qxCmQblbp/HQNDFgs1byTXTMol/zBMuO6RheCuj83TPue2LM2Cp8rK+zsltyijdd8fWnyEc/vJDM4aEj/CEcYQqK9ifp1zHOVejmBTtgUlhhEOolCPxvrTbl67NMRZrj12mywYSWANXz8ILhmSXkqYxDxVRrnaCF+wii5apn32iEl/KY6fMzTQQytdgGZFEAdQt+8O4Fk2EKPlkNr/PPpQowPXDMndCXjm99744NPLsBhsmj5etJzNX2YJ/v2Ha6B4lYO/0E3Ti2kRiLWEYl+mI+Q389DicEQ79jQa6CwnruNXNtlVrhqh6dhSTqf5VM7EIUHP8BWDxUR56BV+RMi8F0/XC0PFdq30hx4RnjoQa5Kv/W2hw1p7e1oNuQnTM0FTq29IS9+4dcITw6kgC545eu62Y2Iy0bg7V2OgbP09HMPAJ3VFRF8Y7C9EV/Zmi88c8fNy/uYeQFVG33WF/nWkPJNhZo8FgREymD98zMa/8OeNfzktP4D/J91Ze/Aa9r6QTmyJtig/ZPzxHDeyLsMwd59cRntDqhKMOy4hxunMJHVMzp4TazU8ZLNkHiw/QNuk4RGbK12e9IuuG3mcxTf2fc3p/HNepHOGyscd5Jb3dseBsEwXKIRI8Y/+z4jBYYWxAoUQzfA/ONWExwKFEE3wPw54leLOPf35P+9uPYiGgHsZKAyRxb/0f/BrCHgdA4UhWuB/H5TycGUXpUvkEjyXS7mcJ6IMcRI58FwuxUQUSORzPJdLMRHp0/KdPnuuuSf35J7cE/2/IrcBz+VSTMRgmTt2E2+1x4hcuEVN56bl6QxMjBtqJPJGeWhKmw4PD83odN70XMfPqJOPN7pO8d9Ol2AEAwBmKH16r3762+vX5b33bOcB8HSe5XT9SLMP318rtn/ZM/UHPnrl67wUHL2Ex0W182ffY6GtUBnYTYf6e030Yb5Hu5Uekh/bBvJL28L85DbfiOR+7U7/L2+bVoA5APPzyM03hPlW932PNOYjSdT9dX5HaCu3pfz6sp5pJWEOcGHNNxCmK8AcSJMcD/UOkIyCaYQJ9cds0TWYbEta6nCbAfPewU/q7+RU3eNzMK2RWSqrQch6DPEFEVQLe7iNMCcPnqq/9RvIzzbgL0UE5YT6U17TC9ucBgx2l4xYeckWcOQ5f8svo572rKXO1/n+SnZ8oe5Zl3cVxN4aTyJfnav28d5mtoxKH5pjpvTMy406j0BlwxGt86SzllH9XYJz8upuvJwL3b7hXoxoGGUMEOAEamsfHCQWPvvgRjOx32smdJ4V4Aen9+SCpbLKrlpMUmZ0W5TxtZGhNrvC4x5pP95Bs4otwtf+oTrBvlosQ/sfvXTFcEh0b2AEKiABNxgBFickJwiaHYpbOjN5qVklS1gzCq+F/S++3uDiW/tVW2QycrAzGhOl9ulk/433+iyD9qOpcf2iHOBXsTC1L6uvyzeKlQdWiYmt0wxegv4ni/Gl7e3wfboy5/K/De9jSyy44qYCH4tGUjwMcpm0LEmSTRrnPtTzbktgECc+0VRcFccgJsQtkbj8iPPRBmXQb4BBkjvEmYkyil/58k8xp3ogtAJ69GEv9GHfjc8gfszj2B9ii9UEFvp0E6Rl39fk9P8YBMaPealDv/orbBFIiF96PuNTYhGpE5xC/atAUYbNKnb/U6mwlEqvguDKu4OIYZwNqwLZcYtNq+H5jGrrKba5xDaF9Fzov/R96Kl0i/vXw0FSBa5GqVuAQlEZeTFvpA4nHojhkOqdp+lDvg+VU2/TkdtKNq7bic+0PzYIRUVQf0190yUcAYHoEaL4WUU7fdodfvVik+8fTNiacKnB0/nnoH8R+D3cAq+CV8LzF/hRQg714khf3W9cfEH9TSetM8bbNd+l96SvilfS0yMWlc9Lp6rXQjelIkvGpzaY0Yo9HWGay8rYP6MH3zf0rz1ddXjc+qbYwDx/Tmr07+XCuGTN9O6jSnsHouwp8KAMtiBcLIH+FI5U4IpRlgihgQyuJV9Cf2Hss/hNf2sIMsF0AsPwyF41avqySm4VtzBYT4Wm86kiVJxqRBHit6ZTkZqhliWpgV5uLFiaaf7Ets5IBXAqIEVENqYYdfdSHD9VKZ40tikBw4xJCYmz4XXT5JXixGS/Zi06BfjUqtOGpq93WjO2Sc+J9qAM2IGKxBb5+dGMVCshqzNUy45zShURqMkwVuYLc2vzd2lmZsg77H9b/vZDo1rFt7sDftXmojm2ucCnBohg7tGzV/796y+cd6l9alPOz6cSaGGqnVfcVseYaWtc41Z90xhhJD3bbmw6FjzDmOhY90cdPXFxtNQEk9piCnWiiWy13mZNaInVUJ+sB8q2nTGYhaYSM8K2C26RqqurKs1VS/YoUdyenygb91ZLbJ+ZA6jLU6Z3w7yrL7lWK5/v3FEHnlBAgf67+icE9itmAiS8kp1ElvIzqzR+co2ZyZelbA6XBV0H/OdVBeZz++B094mmlraOrh4DMwy2HzVWIYn/2po1Z94CHT0DIxMzi3RWNnYOThlcMmXJlsMtV558BQoV8VBMsRKlyniV59Qts9xF27yywgZr7TbsYJBPpiy11TtLDuq1yvs+9dYpI361zJ1zyE3XHVah0iZVbqt2wy333XHXPd+pMemBh46o9cZRTz32RJ0f/GS1ej4NGvk12afZbC0CWrVr02GO7801T6f5Fuhy1meqeq54adecDEuE8EY/NMMRLdtxPV8iiUrTdZ8ishsVw5/LY8eUa8Hy3VPPQlgom8PFeHyBUCRWUFRSVlFVU9eQaGpp6+jqSfXhtn7+Y94n6fVW1AmLaxhV7C/tA9l/6KDXM1NzYA7NiTGTqv+IlP1kRIaaOj5EFf2m82I6mQoWYXp3GePCgfMCzeVtE8Z7elSYY+a4OTFmcsJEz0zNvjkwh+aoOWaOmxMPOakPXVLdqRKnlFe2t1UTwa42mVgdrRs7lrtfxN4l/qrqHiERj1KoCHO2xS1DbUyDkHnH21HKCa9tE9V0pA/phdq4RIjLIiUMMcjkMNfIeNlP9HitTZICAAA=) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Serif';
+  font-style: italic;
+  font-weight: 700;
+  font-display: swap;
+  src: local(IBM Plex Serif Bold Italic), local(IBMPlexSerif-BoldItalic), url(data:font/woff2;base64,d09GMgABAAAAAEMkABAAAAAAqIwAAEK9AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGnob9WwchXQGYD9QZkVkgQQAhCIREAqBsBiBigoLhBIAATYCJAOIIAQgBYYSB4gUG1WSFxi3JwTIbuCpOjb7T6Aogo1DEKBhHhXBxgGQBH/Vxf//ZyRQkbGu3Kw/IoqoRe1iZ8FQMBMt7c855sDCi5ooqX3Q5VCH7FrK5NRSK7yn3sqyn+u037tSvptvcGg5Nrz8oQuhc8eixLTaMa6X//W2KYZduO5uBOi6UQz6/GvXdjiEqMzC2DV24eBVuiZDn4+L0snS547W3iV/R+L+2zPg1Jzm1PfY1o9zBraN/ElOXqP4OX/vvZc4ZjFCWoKHIDWg4kgqjteCB0LdgZo5UKOOWrEqfCZ1PnXiS/5ww7p0Rnx2nQ+xW2pZ/hLkkCBBglzlVQ55lRRUcEt3uBYYLeDh2/m+hXl5FkKXNdndbsQznsv3v98vPYG3cAIv+XPMK9yZ7ppfhN+sKmEIZCuBVdnFuE6FIeGqXP6sRKJQ78S0RJXakpn+/y7nYenzY6nqOiRCtmpZUX9rM2YY+2bvYIcjJf8lNrcMzmbJ1jsAgajzU3ie/36/R9fe930IlFGSI0kkDFlCYTrVSV1VhWGjquoAFY8nsDnD89v8PwuLqkuGgAhSiohEq4RKCWbMqkW1S5fpq+2/6lW7fJGs3/t/+edf6fSl6+74JkqMbCkWaa2/1VNYfkjpzL+1foUr2MKQyImhy6XLlODULlur6h53JmktE8xc4+MFhclsBlwV4Xs41CdZl7EuY/2MKVCuLYGqF7hgJSwNsWuAf2mHZu33Vu/mFUgBayKjr83nSjSmsYktAYyvMKSyI7jhLJF8lowkkyhdIwvwtQD492aq7X4slsQBIgdLKCVo5pQqs+hChJxiGULae+/v39v992+RTuTdESQOYMQxAVACIdi3tyfN7lGEZZCiSdCBplNUTIRIhQwq5Fw5xdzZnTrV7iqXsbWrVHRtiPDwLp3Nf3npmkKdo7LCBXcap9rk6AprdYMaY8vDOJRHsRUSieZhY69+Do102WX1Qgh9v2vshv/VRm9e71fooxQREZHghRCCeEHczuzvs3yev/YbqaPn6XDMwGVsddEfaRWgKCixDe7/704ABIDmnx8LAPW7cwQALXezAAQgBCSbiWKmu76IIYIRoTSIkWIQGTIQ++xDnHEGkS0bkScPka8U7YNWlDZtiN/Yg3p0aMIGHQ7hgGBAQd6d/ZOCadEPPqwZD+tnFszUQfHq1NlpUGOAMeblHKqnXnluJizT/5gYrIsnaPwsoXFZk6DAIjlx+sobYEDuePPS6u7vBXKCHbhxPO6QC+6r9UlHbBKe2LxLe76kM3/T2Zld3JVLSItW7UpbqzdTxnpjbgu3bzuwzme57op2GxKeYzxX6WItdjS7Q3v7/eL9gf21/ZN9/n7Z1O67Dt0PkkPOofyQccg+1B5+H4XcfseCY9ox43jomHusPxrQjg9Js3aCvWialdCy3/4HfAsy7gMvwS/gF/gD/gMn6oSEt5aV6YiJsCm2nlqKvgwSRYVCMUg6lto3Eh9s0wfwkU+kzXItrzRUo5pXLzSaTaM5bH46Yb+PjskXokyBKUY32metLP5f3BsXfCAfySe0X/MX+AJ+UJlUSBXVSJ3XIE1Bq0k71QHdzV6P9LvmwGTIiLFBdDxMKGPA4bzpjsrDRYRMDHwxLo4MYtj0ke2nUirzABOmiHTFVKFE4/qkvxb8k3lsflGQt7qz+O9bBV4xk1h0o0pY6V7hWUCKt+VHYr9HRUMCSxYWJj4lCJUJQZC2mMLkVPK5RZF8LkJU7kZlwTWSolVj/BKnFbRJeafUi/rlg2iYGTXHgbcn7Vf8Q05StSRlT+yFn0vBtJK8YNZDUa5gWWLDkmU3NPCdN577YNlHd3xyx28LiA8vSF1QdlGh+lFNSd2uhjualrGCSkO3vFfXDwYMvVHduD1hkbnJ1rdvoEMy8WajyIi4po7uGsrFSMWwspkylYbq6ZpYgzEACAgwgEHCoZ4aYWiRMPzn6aPVRTwYEQrGo2A8QgzQIaEAemaq/DxHrZtq6/KOkj2ScTjW7q6xpNv/eQeKGAcubt99SoETDk28bKd5v4K0oHs0gfxp6QNgRNx2JwQS28Hk1dEg4sQyn8P7tArRJLvIYZPyyp2harpKF0AiYxTDGMZ5MWYQMYqhGR22dr4QaaSIEXUvMtsXCaLS8Ln1g6WFUL+aqFKzEA+SVjNGK3GaZN3fpmlX25QAT8An0HDVgoRcJyXBT8G0QtbHrSBtN3EnNMxhzJDXb/NtOgki3+dELDtdeTsv4XpgwFg7+ET2Dngpt/M4OlCQTOxMvc2c2WQZRSsKqqaEkY4OJRRIulapM2uW5xhbRExOQuh9KPNidVN8XtR/HmeBPdNArUI4l6LiWjGHIuOjMIUGSZWrcty0GtqKUoQMHPoT5GFLIZ4LsZEt2plU6yQXTpnKZvjSQ4/jxO/KsWyRjbEsQpvSgRRuzdKRyoF2+lBk3CQRWxW9GZURmBCeGb+/JRCheAQs4HDxCIiIyShkUFJRy5RFJ5teDosQocaLEGW6dLPNscgK22y3w0677LbHPvsdcNAhhx1x1BVXXVPhqutuIP0DqbKKqpq6hqaWto6unr6BoZGxye2bhu5756QiBGUoYhljyNxpzGGEvXSC4/S6y8QXZT1AmBMAgMnxDyRRINGdY6n4PhSoTYaSS9KUhoUSqIMnXJeIAWBbphQWs+Q/KgEgf3oJPARWIsC0/L0tuUbbfiaKZnmgjxDJ6rUakGcOYnpjrVjALN4gtxTgjJtiBTUGZGUyxBt3HpAAFfUCTcyq4JKcM3+xEBkUAYBSQ4mMikXQ6Y579llNOgdvrZIy6y7HIHNmgygyYuOiHH8kzVCCuJ2lTPtIXMZqVB5Z8Go5C64g2CGRAD6NWMY7lPKCl7qhsWvvhTuWGwiR7W8oWbbhjtyQZTnxOjEI5Rd3VYnvyKAY4f4WyIQhQ6SKqcoNOhyUQelMMhBJPRDJZGrAhVdOPC5RRiSgsXiOZfUdiJQhJnbRoy6jC75OgZ0IkDVCWgwo9iGT+RyDurZ5Cpg3il3gRRW0xQu1KPad7KqPYYpXB7js0GHh2Qi4tzyUdBmhPSYKCLrzbeBHsmw2aSgRIsjBWIJaXQrGUEyINRkOCon8JtS3oiaEF6Y4lp4ZkoDQ8NhxHQpGmAJhxCys3SA4bky5JVpxchlNmXricase4znbNVkcL/li5xMiIQdScZwGK0A+X/MMZUszthbniW9e/vXWyCaMUE3V9SpQJOtoCwDvnnSQHnRTu4BHfQjrmda5e3SCXYaQMCiGzG5dFgTjAuhR5wsJhn8KMrlE8CkpIHbVN+0ElAS9bw4+2Y22LLezUm5qkkvQY3EDCGWgOKrQgrkdD47MMpp63QC89VEF2GIgUgPdrwBZxNYw3k1t1Wl8DEQZn0jKknFYkufWxzUkwsaWYmbRnoK4bQ7RBNqj57B2YcYQYMCiqeiCRhEQ4tZBJaKQSMx0yArUrbSnOgT3Dmx3iokpdPShnW4TQwqewgScZcgSso2IeFZwqoYp7pJvqr0UlU2g2sGpbFyVgqcmcVPH8VPH66NOFKgmGKQquVUTEaqLmOqqXOWargqlq2I9qrNeVWGKamuWKjKs0o6qlk6qAi0q1s8qz9+qRFxFM6gsj+oYHq/UcAuJKvZMJXqu8v2jcvyrYvxXRelUmV6odC/VFL9WgDcOyzvj/GGT8x5AsTIebCLDBNICCgzK2IXTPTwURns2BBOAqbxlc8Vpqg0WqnwtUZEkcAQhY2GhoKACsEFBk4gD4AJ4+EXcgFjMp5WjvyW/4OX+SXH7MoIAUsjHbkaBhLgGAVWBOLURBkEAkSTOa+eJ44CBCphWmD4BgzoL8HK/LOBMW2lNNo6H5PmZPVqLqejoJ2WYkn2xG07DnXBt/i1uvQe77SCBhBN0/yuBxoHD8kttd82EHrBii6GhubMcOCb9Ni+WE9BYwL/62uAuDiJhMgwkBWJjjXZdymZmh79LC0xIT7s+nBBR3DNVdJyj3UCTdpcdNMEY1YQOSwjgULU0j+BIEpUxMU1X8QsNYt41YYv3jHPPBmvE61krJAg7VykVMmps1k1e6HKhbQ8hJ8WWn00D+c0g+2P3/Hu4lkPkqxzBKcW6zDgwJU4QeygmkS5Tdmz4Ol1FQ9PfSRAPGho5cMxK8ggTi5XBGKBxmgTMVDwu2EJax5oauV7QGwVME9kImBHNb8ris6UYJvFnxuHNe9dNkCFiKhDnbEkxEc/oEWLo0mt+OWpYNM+1OcEOgT3ORFONt3Ntb5/veW9j/YHTR5f95z3WSPfAuOOjAHQOpJeq2HQDziZCbcDEitAH4hcdkTwE3Yjt+WM+54rq03TW3TFb4EYGccI8WDS4lIbkzLWonW3KRShEEClr9cS7H5umMwmsPB9aQgss4kUmmzYjVk6KMxQmZcNTyFX+ApBVPIQYpI6C06pxodl9Bgg8rpIpO4yGnKY7h2VHHl3SZOWufKpnN+DSbPBpVYB7AkshKndsVOzgiS44hB4+uknnUa5y9DOH7gRirL4ogtS4AL659LjuB2jUEzjW+coPmvwGu3ndAKCLMshihpNrdbK7H/zaA8v/oGJZAwYOUCVxtMUD9MmwJhOQ8Acm2YoPbcrjAB7b4+4KgWETNblbuvuUVOFqAVFmOpeTZGgifUW8hnK4jK/qslNgYSveTIM6UMNVJEtrZb8jEI3G/eA8ARRjQNefUKiKqnikPTiLskU4jdNarD7jcTQYQL6bvshoXXDZmOQiECs5RkcRZApKAi3NOKaBbDlGx9PnBZu9nRE0XjgA8mmRysb5kGVrXTdjVZIZZ9VRWXm4gThhEVHcNrbp9SWtba53juhFrS6SoPG0Qg8uqdO1aukZIBXbYkTzTp6IRY4Ox75NOiw1WNusTlO84OMfvS4+qmFIxrER9esGVB3Xs8D0bsGVI+KErJjk7jFmNYB4GKClIiZoBFSS4buGBbleyil2pI5JkjLENEojMeI840IiYrQ4101chjxHA1O/89jx2SHHzIXY5Ab2juhkJ7oMdoijQyekYagBH1xob0JIOpO53qcgEfUtzkmgew+d0Kb4qVyVto3q9AdjKZMi4WBSXBUmbLw49N+uUTpdgq4Mh63Y1/xM+1rD9/rWudZwR90IaiHnhkSNplHdr+PB5xVpppQillJbebCdYqeD07B9ZDu3A7OygVHAh17EgnhbFgVGiozmOlfxfFky+WzhHs6Z7jiYkHEsOW0GitZpjpllZJbGR55ho3wuxwh2zhLRn5YcnAsFtVj3ORgX16mF2VRdxbwbDhHUy8U5e2p1Putii0IhGxp11InK2hmDxNOXL9C7Iejs+OKRud8JagqceNILPe6p1OgY5dERtj2qfQFt2lSbNVrQwjOjeZiGIRjL7O2IVS4QQ6B8GGOeLSIgAaq7ryusbM9Fpro23Q63mDu49NJsA5JEFp0rnav/dfubG5LQKXLyxcAmEqfJMVwmOsEE3vZ8mvGsVxzpOo/+ndaW6Ecb9ZyC5t3cexWtBNQbgYmurtVnEgCvz8J5c8DPI/GWDGeYNkm2fbhhz5qbi/WfY8adMvHY8iAjhs6NN7OI0gqaVjSIXKIXvGPzoic2nRnxasicK1guTCBKrbAkhARipXB8JasLlzIRaMAPTvMYH7neh9t5a5x3kJZr1zFMoMP06TGv5pn9m1icg5AgXIqQDQAZpNspJe5bt3w30z2h6mvE6NREgQdrw4eQeJzTE59uYZ0g7FyDJdoc1VXNRvis9bQmQExmZVy38WxlKWCTn6haxuZ5iQm79Wfj3op2dV6a3610me9MiXAGMeAqNL3PJh2/O4l2sJItbKeAbWnYR+1iEGc6lshmD4zZPifHm5g9uWGaGCzH9yMHACI0dABSAIAMCxuAEy4ABR4+ASEAFwCuxEujlebhMwcHCFlAMmXGHNbbrz81MGWFgCgZYAvADpl7IlIARn+a1+ElSEdFVwAXN8IgCKAgfOypAABuUIBPoJhwAIMggKVkrT7jKeygSMDLAYCZzsbBOjMuvVQbTHXLN4dCMDrZif8lPZIAw85xhm+ZZ5DD9JllkBbRgrExHsBlvACC9MRtuGpNI+yM50YFhpBBSRZHzGkOezg5cM7NGk9shbu1BLzGuTCJWMgO8pCh+ZGBq/nKvk9v6cRV8V/UDP95/4TQVxgEhEwfOwWwl7CGTJIi50mNMAgCHAotEa9Hjk2IY/piOh3DxDPHIwkMbIM4i37pf9O3R8YBoMaXRopHxGSw/gx0suhJZBIaTyYBC8DHR5gwQTFjYQIppkTd8SVTSpXCnQSCFzkkH0oYallwsmWD5DAgswkmkieco6hIKqVieGuVykc7PV/TLOEnm2yljfxts8cA+xw23DFXjXDdHTGyPTFdmVpp6tWbq1GTeT5oswBZ49uJrEhCMXLleaFYpXotPjD45qeuGMIn5iGFHm5Skx51smPKsGgyNuGJjTbJSc/cLM7KZGRTdmRfjuRULuRa7uR+niQ/palOQ96kLZ/Skd8FtaeElGXJZZZfSRXVNqeWBndkxzeyUxpfXWd2fpd2dbO6pbt6oMd6ppd6o9l92GctbHlr29R3iHYQH0BiC+IdiDYQ6SCxA4kniGQQe0HiAqIJJH4gkYDEGYQeJAEgOkBiBkiCQPwDyRkQn0FCA+IjJCVhvHnYyEuG3LsywGd6PJf4KlfJ0fJyebfcynO9d2hFX3KVHeqHpW0Ykhk9ucOwBFGY23cwDC8ZMbnDMLSip0A/urC9H7hTX+aKu3ochNGQGWksuQliOFtpHZUsW/nbbo8g+x02yDGnDXfORa21HSPHA5M8uqnRSOtSBOw91B74Z04hNYWw50RpZltoubU2qPfXySEnnHPFLR02Q3Kr2a28Sz4hbxt0L02U62U7eZ2nLlxSyO9FTuGsATlVvid/4wUF5DS5Si6SN6hDK+E9z3JIQf+1fFmx9UfXNfkY5ZOcPEaOkYfJLrJi0GT5q7xB1hU41XRHdZ4L/CoUjC9BVo1ZheR4Jh9zSkB6CBHH2P7v8i7BJPKEkfKZyFFEDBcLZfCyyT4q+53h7bRsal/6UoY//UlpPFq+CwB+eysxVvZ4TAA9AQQBGAQIBowEjAdEAqYA4gE6wEzAfMBSBKjuhuHfVfDFuvARr7J7337ynr79xGbFBtnlkv7Ws89JTYfyStOnQvXj0h8F/J+khKkIeuekzsSgj6fG1jk1ym18RG4ZQdE6tGecPYDHGh1fOq1cDiNFIgBi5IWPRTGdko54joRFviv7gCn8VBN2+lZXlPFm7hbIic8GWweCsEKREGjWbpHZ5mh5awzi7MmSBCyEe4ju6SOCn2UuUm/7RkhnNTtCvbN98QuUCB+NbAX4/Y3BtAjBpXdgoVaUUT5wjU+HIBRJZ5fGZcraX5Qif1Dy/UYpQBDFDMy0RNij3jVCg0LJOpfkoY3ojpCREGeUePgfJILRn3pGJmgrLvH41lyKomQO3vampOf5Go0OX7w1KRVDWLJ1wpzGCFrzlWy01lEzlfVjLOjbDZ+Pwi43cpOK1S/Z0D2XZjFsUGs5vABuBeCxb4SccODmiyeO6/odtrciuxGQd4GeprLBjSgEkOefSZ0NuBCR8ikGje/mFj5PBv12ReBbBIdPq535eTpaztJNnZUYp/2EQxnf5St86hf8vBz6r+ecfdYBaRh+BUHjf+RinbADpMi1jJONMy+X/y3kGHxwnqWMhClubp+1YfHobjcK2Sp2Ntsmny2/4KTgrFFYjhkDziN3JJ8UNSeg1i9sgmcr2Tp51ddRMv/P28mbrTPjHOlK0AD4dxFapuVEy/4WXeoHKdD0QBxPQ0QGUCkOdvZeAF7KVwAoVAQAgGIlypRDeYVKVV93qtWoBQBAHQAA6r0FvANygQAAgAxAgeciQD/v7X1Jn5eEfYYS9rmK/i/L4fL4AqEoVSyRpsnS5YoMpUqt0WZm6bL1OYZco8lssdrsDqfLnZdf4PH6/IVFxYFgKBwpicZKy8orKqvA/AWLlqyxZD4cfJwvFkqVWtUeGhkeHZuYmpx2ZpqN1hMvYKY2Lqlu4GhHy5u+ZGTswywgYR4AQLcYZ7JXTG8DgNQl9dUr5+1+/KKsvLqmovKuR6D5p8YmAAuqbmL1hlUbszZv2bpp5y7sOHBwf97rlzOAF5MBoI4RNC4+cwmZCwAgBQCqAmQAogU43QD9AbWBrJ6pTNFYaOS5BgvxUhdCWXTW6AqDF3TIBRRqWIlNlVOIse2wEgociDgl226zeXYRebCdhQJIrg5Q5pjVhRV0q5NnFaFUGtQ7izpdlEToycGLO53IlSt/gMPJGUbpo3drAwDNOGxtS2si6JMyE3HzqJQh+4ggyqL9ETBKRp0iR9s2NoBdxo/GaZWyHfDCPIjLVNJLMIeDKsVJtcYUhZPs+U1baX87KFGE2hXKqP6J/YbGKLb0scEYpxilp5kWhr/5ahlKUTTLYpblPMCXEctJPfTNWFQL0CihtoF2zcSEYCxjGu4yLmVE/S6+uufnywcirhsnnaMOqyBYpOMSAULhcBQsCwQskygEXDbREDE1w+QkEcODmaK2EQBqTQRuzTgAy5bwhcO+Jyxl/oUxz1vCPBbt1rrQiIRSDseUQo4gkHUJoQQQAJrcnsJOt/XhcKlVK0m9I21uFgovqTYvLIjGv3vHskbN2eWpuXKe+PofUMk2sThbCr75eaHruocTwbOgPSLad/GFKxzawZM/e56VFa1N/HPbzpnCyq2WmttOX8o9jyLmvwW3j/EnMGefnkmatMs/POoEwsJz9Ug3sxpXiEYVo7B7Tebw2EPizQH+RZU+izQeyql8FA+MOK3SnTRo6sKP8WlKhH1efW3z88Q979SAkw5dhRwIHz0aW7EbGla9hhavLd3H4yv3zf67XQX3eraPFw/hCtivn8QTbDXTd7ENENGomsgRPcWOAw95FaB0/MfTvmhSIJubt6OZzn1YTngGkrMLI87fgBFMeJrneYOi9YkvRl3Vdd0B4RBz9mwhAixE8HkEm2gs9SCNUhVdP8cr+zRokOKjmoSlQks4R3wl2vjzwJrW2EOL7SB1IEXsnD1Jfr1ZzktJGzCkVEGAbJzSJ+HK0qDNUJn4xd0slUMrFJylhu9L08nBUtMM39uoM4GXH41FR2C203hNY/MOKWfergA7XReasqjx3u9megQjE8qJJji+sEcV8jp7JS4AzGCOHeeYmdsCxdVwSQEHSi58KXR3MdhaWSslm2YzHo2aFVrkfSQpv5wLVjOFHvZ5HjabXecNmSFy9GMu5g+K4paJegOuSgywA8RpbVgf0PHaQpinLnEtvFIs8oSxBSwflMqS15wtFIOeAO0JUvYWHv1mt+monD3qokhjWRj8yi1eJAaST+iynMsJ57/OU8rPEInkuRcKWeaaBrI+pd+fncxBxvkDVdGoA6jiDiPYyBi0TOBWoLGwbA0JsKRYajTrXvMxQFotcc3ZN8HtzouoRoBSYC0c4Mcd0KItdzy126t22OC6PMwzRpDCf29QJYbdeM3qCxETGoylLW91K9m0kCrX0uUuoODrUU6EkGiZCgM6zPDNmwkB1E60lUdjwfm0tAdtwVKztAKXlqlyWEjPY6nGEZlDlqqS6xqqBvLT3VckAfhAoTBdMU7SEG2AXER/tNEFsZJRXGnjN2JT5FmRq1cF7pxZgRjRLdvMjlkksZJEkwsk5GtxxUYdYX/DVGZJqU6TOiYP+QsevG4kih6dBRbMZXUSFUh5Xfgx+uaIWX10lNitRFawb9rCTGV2yZb1CwSmBpjoaDTBMU8JOt/PaDXHSGEO6H3d5So2bHkXOVkizihbKqNINbzQoZYxW4UGegLrctqHZYHfzKG1qEiz+JwlaqAZO5q/NVpn/h40/1x9cn4DL9LLKUKM1AESU7aZ6aP1fbzW4rU5Sy/uABujl7Nqv2hWIOA30+YbDOp5SshypxqcUcvMNS96CIzhLarhy+ZtY8i5e6pXiRP2GnIw5zCdB39NHFTT+mVi74w0TWxXHfDQIK0xE6Ow1cmZ1SWDBaHRt4weERxUjX4xo/YAxJ4QeTu1zWG4OdwKeCFaslmaJF8yUdQ6oRxxaxf9dyqzdQL+RCgDXdJq+MBi5bthbYEa75cFir8DtYbIho5XLPpUbGHiC1l9odvL9bo/3xQWlrCpA0CgNn205V2A2WOuGLFr1ERbbdUdLPx4Tei2WoD3lazsODG5yyPSnxany9YfmMXLQcHYOfdP516Dib3eMnsRm7TWDvtK+RSN5uCDn1bTLTox97hjt96gz63+m402P4QZ1cnlbjl/xXbpfo4/jsGZERIPtLs4U5KEc5cENnfbpzCo9s1M/edGRHXdAe8GLUQDYpFXP+hujLiFcNHhGnKVM1wY3Syw4fNzLaTswZ5H4AX1SNIa8rB+lH0P0zsp13aGitavVv3V/4/40ecsWR0miXCoUlmkSo5Zbsdko1QLIFVNq3cmAou8mZVAiFP3WnnxVN/Uk8uhk7+qIb8NrWXaEAE7pVEtllkQMdA7z/mWzKPoQxOeohOYPFRLGjPefBZGrXEoS3hJ8OjcpTLVzZasJEe0vxw6k8Tjbp3kBkGTePOSkMyXLdFNEYYu6rvXpDl5zbevFo62EGVN6+sL3NHDsBWtgMb05fyRdiqvy8tvsmW4BXILvFqNfc59No2Lghan4rRe7zpOWCpoFwdTSH5r5FuosWmBVTCuqPSnB1LCWZocy5ADghu+WllcEffDG2u7+uWKwrLdTY1lG8p7jntaG0VqJMI8Bso8Cb9fp4ISEqk3Zrw2P+HNOIWx46Y9KrvCBz69lDz3uonGXlNBY2/HyIwSa301nquzfYGKHMy9CSPkNjf8uBJ07A+fxX06stKJxmEFMsgI3d0M9Px+Y5Iqg9x6NBB5AMKamhY6E/iRzbmEUAibEqSBPylajeQIWd0sTLUULd55thpD1xbj9vttgX7uC75njnrZ02UHYWvHmUo0NGQn0m82SxkD4vYYWVIqlSVn0i1fCXW4ld62P9+N2R4l6SqkmbEbLiNqk6V2E1om9tbtJk5nuGK3pJuWuC5EUFSdtUZey74hSlPN3NyLPRDEccHlpLifGuLZJCkttIkb+Mhrf9VaAh8u2T83+FE++lPN8uSmZKOWDSgvnCB5a5W+I5gZwSoPWdYjaYY3pG8YRELs7CHwyBmYg4AvMXryDkKER7dLeoex1ts1ieOT8YkUBxoQ1gdaQJL2h0gQy0DulMRAIzxoWBmaDw+c/E9JHYD5pNaSjqhgUoGXhUh2GjM2pq3ddMIgUYUbYDXyDvelZUkaG4FSvxJKom1p2Xo9KXbh68rypAVT2RhXBjZneExrgP/r250EajfMj0F9B6kwpfEb4COWPICg1j68WvOL40z2QCN19K9LBw+rI1p76VKk0NSHd0+F7UxyYupGalAGj0Sh9rFQPvu7/AHSOto7RhRCArMbbiE9DwSKbVMFlq27D26Ml8UfZBzzwyaj1CTMkY3fzpoOO16TfHE3rxbv+FB1ZHgAGOjgw2etzXjXPfA0LJnoHykOhKdLd/qLKD5eInQzcyYQ2QD3YDfcQZEIyWyZskwSWNhakW5VVvb4Dy6BFMyjNcYrq5mViC9Di4F4kRJy4tc1V2NZubgXipfkbdqOcC9vDbzJLRCwifUQswv7pgQjIyGNY/TkBSo3IF1WqXfSAvSUbP+bvYd5/CPuClhsLWzEarySFpYrcMORz5/TFyPXJmyt1C9L1dHaIbRjStDVgmdu42oGImkEYGIV9wBhBdu+UvEEUQcgiP/3jaDaIA/Bfz34viDUgCyuUDALOe+60qG8+y6T33FaxfuPtI3JYQ+bzlYW0RFcDXP0+rtJEzYCMOcyJeK+2kot+D5aJsHoAkzLscYJiCll4zrEk52Q1cQKUv7KyppYdfWhXoEzDr37wLGE40b10qKRa1y+MotC3TFLCq1T+8aqFTa5ogQXcmnu9uXgUSxuJOtqoHpZ2o7b7WXUIasLnmWkpBzmX3RdMX4m1sfaQwbNZphAoYUMgrwxEkR5rM5Jz2J6zYvUUA3XANuNqO9jKsTpT+AACfpzKIKZxDb6EQD07Ut7U94lTD340ZPwUWWKRtB+vkryh3qHCIVMqQxowspwoG6yP+k9RMVBLDnuVAOlVC9vFGEtstX6ZQHYxyIiFQxdA1LJYduHj2bDvUvxmijg793G2rFloJplE22joZF7e4VK+LAxX/RuxTz55EnZDpKrHMMTvhEdzgVGYaCzOh7I8Euq0m2dWZwomTehRynhwGhG99cX0TN1FxqtPoozJZro0JjRD24kcoV49a0v3PVmYZBuumuTqKklDoiYIBGHGoCHLthPQ2NmWUB9PNx3mlNPaHLPRid0AVWHRz7MbM6/vU1+c/EKgPojAkLqkl/77QwU29PtHDtJRwkjleVDvd/xJn/EsD585LERo8zNFej6SunKoKLU/3yiw6d+kZEBhMmbmymdAEoLT2kkNdrY4Z/isKN3GnFz+COBV/zX0LhlmBx+Js5L/4eYun0XLbDlcrLYiEaE2PBw5UMQgQsPMlDSzixhYkqSVDi0/e6ETHeYQeCTGM5Zaz8SxTrr8j4JTtKK6mB+nlQ3WOzK/Thhhe3IcnAKXNoW/w8Tdzx6H8+8ClER/BQtiZP9aLWTaC62y9j+J6XCL/FeHd6307d0iIEbznuCZ/xa+YRo5g/rft/pJdl8xgxuyGqpFF8u54Muuvj9N4wnWe2m8ltv6Z1i+n9mguetGYTgwZtdvCRKEXpQcujGvFvsuScnhGUg041cNj6WEQjozdl5emvGfNHsxf8YOb7x15/ygYvwdA9mHlyaznfeKJL+EhtXxFOkOq2KEFkmN2GWUyipW03yAr6s7os8gXkkO/5pPBvSVaZiPxjHj3fk/nCgnOb/qq9hNsmUSN4AMXbOlmoQlI/yNzDXnpgcp86YaupBpS0GGwboXV30rvBZMTi9mbhNUgw1Gas4NeX2vlj9pOC5k5+4iw216V0Pse558AIpNfJqr/02KGs8kncoppS4dPHLIehuezpY8Jej95n0XmF2jSXmzMjfi+m3hfxVzXr9nDu9dyyDsnsDrp9gzZdnjQcfdghXcCj9k4j8k4O4goPyT8PAuTJikjg++NchiQltJwkFh1notDbxldjMALBV4qAKHChUo9MFlsUbmb9MaQR31PSy70nFV9EmcjU2by6e3EEf3wdU/PVHn2CSWEk/UTyZJFgZrUs+UFDTYnQHqitbT39agDMr5uB26649a+vdNm1e/AhIqPnlbLmn7O14tVqYwqvjUxwJIttUIutzMa2dS7syVEzRatzEP4JsrSRodRUbpnyxWIIllboyfvgBfAjPcOC/iEHQ8wVvLHj/QPgfCg98LhrbnGvPejdhkCMTLutTarBWtcORc2RCuoqXkvacQw1dE9V6cbw7Qvp0Lu2XA0FKVmWD2SEX2R946XWQLdlr03HoxTZ3lxK82jiOGCn57nDbJ6Xk6phg49qON8eCoRRw4EorYTaVNPgvGt7Vy6L7ikyPE5c3PsOpQ0hOstlfQY8H5/cw+vTuR7AdFxZ5uZztO+eLjNJWv69DBi7DxTYSkubMUNO6sjoCDV1FKzLDyeLpjL1DvM5Zs082s5lGm8vukvX6ittkKhOZME/QMT7SXoig36e//xQGd80U1nRXzv++dKgvKdoCLsMbawMOGSt/gYf7K6SqeWpgpvELbJlVrFyNm3hVyZSyHcV2lgrKdJkNAmaR1dEmsxqUMuft8eFSTwrlIvt0ZH0lpAve25NszRxEIvQhGZu502Jr4cDnDe5y3G2rzCzeHrgyK5T033Axeh34De/bHIeqeCPUHz4gBoDqj8O4gsN50p91ICeUWy14WvX7I9g/3TkhbMTape0Y7h4ebt3vokAZnv2ZkF3IYqr/CEBKtQt/xcLKyYgVmpr4cwjFLtgzvf7jN9ZvbuZ5HJImh5E2SzPob27wzpDlmxrZeSZRRa5PuMTcGMyRZ34hRnI6P9oybg5VLjJlqentqrK8HDn356XJGQ6t12pE0mkCYwupLIx0pDY2tLbYezPLqqyzcfnEGYvaoUxOYLSYoTwx9+tAIimZMMggW0oind8yGHamryfAQeL3gJi8Zdoc5TR5HHbbkbT1VnCrI/5jMvQhTJ0CyrjCbIybNC7sZRPLX1NVjIHm/ZbhZYnZPnNurcDW/IexUunOurm+IIUdljSMnVZYs67NKU2myUVhgILLCik/8spsGmKbtMlYVmSvTdVrDiyDx9u0d9s2WjFpTanmYA3eg7ERQz/Y8FqNXcep+bmdfqhYZ7YrixhMXIx8c5lQb6FHlCpSc1qtNRI1dwitqj+MmvKmelob1kUIrZYgs81yo6He58HE9FNtjMFPsh8NjB2Rf2Yf+80C/5a7rE15DlGuNPftoKQ4C+hBI4jGlQAFbxiYPBjUHKhbuCpYmmMTHWP44txgxUo/VbkbWkhlWAcxfNOOzyhTUMbPvjQNqiyN8+NyB0tNq4LtDLGu9DMLFDca/vf3HSRZerk5+W9zMi1p5H+VgGa40auToY9k3sUz6TTqffXEai5MKPqm/+doXBk3tn1GKutpqXsILn5yb9vn77vjT8j7evdMb6/xNj9uzIfqymUf9ZFcbtg3cuXRtp9m2FMu218zdQSzYbDwvNsFBi9uFmxW8hz+zh3IXdns3xljJP0rqtXPs23T5m91w2YjjfFvQYbaGIhg7MQQtRllCRMU7dr9J5jIpI/yDBZWhV5Jakmrt8TC9tZUc4HO1TfcCuG78yv4UlpJjrs63bky9000rtT0x6qpLaSwS5vEqE6Ngs4PVYMKXsxD8s+o7PpTiE28unDmYKUPLfTv7obwfx59yKqTg4ugrH56CU5/bmYLM/F2mXnJ7rRRm3FsXxzS9EdrqC1Q2KXh5RJ9Dg8wCVsRN9uUZ9o+VcD572uFe3p8VHZY1lxI8obsKkGJzVItMGSfFsPLXljCETXXqpCQMJOdNX9GA5Cr2KQVljttDSLQr48uN8xgDrbJTvVqY3jG8Oiit70gG94xWFhJPDY3VDZPR1A596pI4dd5o9W01tKO6aL4Pm4qn8Ket2QBWD9NHkfE7RMoL5MXvVhFscd/jMuj05aCocKe0A+SJ9BnAXryjQf3CyNj2vJxicmv2XtAi+YtqVaiicPjutxvYMPf6OJn45rHSZN0ORvar8GOXzttZ0CX3q+9XV4nj2PjdhMs5SuYPX4hLk/y5jz3e9NA/kB3fQxj/jXeiaCmnWw4uC8M7Y0IFaLx9UNsjkcn4KdEQZY3+45mypv9EHhL3lbUBOq8bJs4+ZoYqEo+x3k+Bz8+myxHX4iB5XCjutgtQUdZIZlnk4MjTnu8EWGKOds/g0o61ZmBx9+zKUjBVBTaLzGeuJd6sJEeI/Mk+exg56RjL7rxbB5yZA+6lA2dATh4C5L5KHatKPz7YVrnwMg98ukSXi/7bOIvsnZVuevyGlnY1lROsOqaxSl4YX5pYQ5njr21wenM85pVxPcmASLzTzJyk/2JGfZRMhaPvEazXP0dGWRI/2HInG6urbJSnj/XQR3HAEyUObuNkyqF5iHE33Ay+uChj/tJRmqkgiF2ID+/MYv13NnO1g6nl7Nk8QAD6nvazo9M7AoTpf8w0vPzONbKdnn+bheNrv39R3WcTHQSiT9vItuB4Ur2ZwJqlE1DkwmTXwxwRj5dLA28Cx45KXPedRFE+s/5jBiPhqBAy15kcL46yuhredc8+PMXMuc5JxGsuGIMYPIDRFLXZOsN6lYrBOFHu4LUCyXSDJHHpimlq+W++24hg0ahEymSQ0ms6p08WyqQYl8NqJodtSvRmOXaYur5+AyIKrvnFTZiZF/gj0m+tBzYhSBGyCkXrWkjI7MwiqfiYAOCyhiL+wdYAaflhpaikOXSfLQ0hQoRGcoiWQ/WzpqxckaPsW3mCKf0TBNP+1KBawh6cFM7deyACCx6wpT6pWiEX7aqKIw/TOs6U+FY+HZu4hyYoI6Kks7A8xK9A8YrOfN5DAOP+paCkVEWXcZemAmavj1XZH0itk6xEbAq9e3jYiVcoL+ZMbx/Pe4hhsuEkIpiaTd/J4LbcifC07wSs+dvC93LPIYLTtJZqD9duQ6mzgM84S2Vc7Fb7LhOpPk2LjjOvjHy9UlEWUaqemla8nizTEWxrBtjm63laGH8bppoeCq26+akdWfAiDT5aN8n3W7iaf9S4OrlMoehKVWLZd3Oztz378s9qQj9FdYORb/3pFB3s9KW3R8rbYxli6YW1LebXacBetGUUwU8S3OX6wvjN9L4G0fuQYdKeEbNqnunyQlgPQjp+cio0Je4/qZsXxoJU7YvmXqwibtZhWE97zF7NuaOCvTQpq+efnTwnxGpu0c4QVeRTvZIiDtW8hhPL6eiLwzV85XOM2vFUzB2qGolaIW7hvh0L5+KpqCP71/88rsbASx7dF/wjJ8utL4tIqY5SpX+EBLcgLb+v4X6WZiearGmhYhgNZwqCy1Bo/ySIm/gHQ+3Jx+31RBz85Z3vusoH8zumpRSHA0bnlwDy+Halwp8Q8A9rij+LK1zSJpCWQZSRBzMtE2hccdfQ2mxcMpNIzTCjZ1pAhUXBaPPR3sk2+EH7Yq/h//moS52grKLvNFno71gdvg3M5snzoQP2zNH943yJl7sHFcM+7C4HxTAZa95gg9Fwn/x7D35y0uO+y/VN5iCcNIn+iIVEZ3WVo5qTbx/7PerMNR/hXW2MKfwOgb8lfRFfEYZn4qgoD/ZUPd66u3cl6LRp6N+uFz4idz00W1/83IQmyhXPgUuOJR43kus+MwyS+pffn6IgD9CzWH45/HWbNwigPYabCT0iq3PDr3m4nFnLpfv0GZQv4hTz0LlZv1qhDPL2GiL6OzBzJ8/s6ht1X8HzYmhftbabtm33RIYSaJ/FPx7Onj3IhKFnx0F2d5VWxQcyKnD9wm0x9k/z/R0UQlv2/si2yRp3YGTzQj932/uTZ/uMLMdwqHt4BDMPtEVKM5mzbBOanK7JkDlOqjSlNQi5vfz6SeIZIM1ZXdTZ+OuooI8jqkyX2pXmZg9lEbdusDEPX15p+htesbIC+AbxC8+pNsTAw9zZErIJK10GcvZSr4F6X3Axe3Ie4JnJZLpek0KP5EkWadD2VjYCYSlD6fR6NaLx/7nIKG2ujSjtwBxEn+Wv6VU7WmOLuZo+ZM8hnKv2VB24aKg8NDnS5yHr2PMC0QoVohNym5gTGcCTNG7iOE18TWE4Jp4v40mjyPjdvmbpGtvHH7Tbdqc+NoSy1xDDLvibNB/O1pSJ3v49U0v2DDsCOnl/AV82hckip6fzEjTmmR81kDy3crO6wgGvXL9Irz08hsmn23eWcjMqPNYkXR61fqFx2z/C3tA+wHizq2u/S9/irhDlOTyMBpj8sgwaWgV85LvvcwbCChcODg/nVqvDRRmZml3iZjpDGgZlvC/y9x5G1CYTa3W/aSQlLMZ4jbufsjNLy6y1OtqBT5LZukHykX1xhQtK3SkkK0quC9rZuyY/29pkuTli5rNTuXGmmnr/NX7QIvpH4baaWv9YJ+Nc41tbLc1T0x2uITJ0DpSSlFn4noCfgc1VYzxD1awNWa5EhHM5W+4pnMta1oiZX0KwRWzyj3f5c5FzHCP7Z2JO3uAYE9G/x/zYC5cwbA5KQz278GIdqHDzeQREksQoBgwE8IMQlzxCImxIMPF5RZO34YP2qnKRBZfQGTdVnxc+PrxZYGKHdrm58lPX51HfTzRdRKlhSibmLwITgLf/sDG+9ggoZC7cfM0fhozz+FkineHwrZRer55ykj9M7UrekZPgLE7sZyNpCciaSe0UzL8dSM9/jdE4/q2yjeHphHTEpA4QhK2ioAj4u5BBDUWXx56SzU1Cxmbu98WVOmgRRt19J4UsK0KFYM2JuGqcCj1DsI3GHZaVy49AVdEpX5C4OGmjE9P4IjhEwkJeFQHDVeMw3m1dIahTwDxbpZhSVZkpq7MAbAlNd+16Y7uADOOFsafpbUtDcGoEB6m9Mt7cHlm9ufNCW8CF1IJ37gRE47F54EVW0XDrZkk7HDWeSzjK4hGICSFR7AJKf7qBaK/7q4QZqdHPPo6ZlZi3LiIf0sVs+UGOGznt8YoxrqA4QM7R4P6axxzRWbcenELikhdTEDgfqkWlWhYTt4uZTI9m0oO5r0Dtl5/7psQu2a1zeK3Og69wW8d9LKNB7/txCZBAwRGylEsPJPtNFrElIja5UlXZ6wloYZVi4BVp6ILAd7cXSDYGI/ociGf2T0uP2uH2RSvDpRnjRuFWy91bl25385kQu9H6mCgR3fQpZvmOJl5zIgxuN81heepm7PGK5m3Tr7uvU31myyZ9UMnhy6k7Ar4siC0rSbwe72V913+V3mprhPGkuN7ibFB5WjzYlZw1hnzLt9r8SJMBj1uD1UsEP7/wgq+hIBKcm0cMmdB3Y5V0ptFcgeYVW5YeqokMMaiL3HaOwaqI4UWwZq9dO02GYtRciiK2k1KF9rHAJK5hvg0311irBOFM87cAiHH2BTWSTm716fOwbrnUtgKhiLbhStYZT2Rjrq/9ivhigWK4IbqDUmSjppCOHcnD3lyZ+qGXzCoLYK7eNpDJuXp/AIoXfrsOKLVw1dwpoQDTbJxDFleIPJ1IK2qszlkdzkKkPMf7e1nebDCa62hrx0wt+wAKQwn1qb+GSjk3z2zb1JLkrEknwDtaoHUyXtc8/7dfh1eUtoYMwq6zZESlUra0rgTTY1kN+RcbdBTts4romaDVsuv1foq9ZSiCuk6X3279kbqmOvj8jbxU6i72RnLAz/LuGYKUjrjLi/Rlb4rvQbvskQznud5pprAaUfvn3Znv9vTakSo9a7UqzX8yBQwEfqrK7j8lm8vUnfPGxlJV5fb/O0F6h5QssyImMMMGB/iMflQ5J2n0q0PYT2ItAuhW4JCCJszBfmCARy4voRnsDAr9Epii6TeFAvaW1JNmUt+Tz/Vxhz8dAu+D9fibBN7Qd/kR3/8yDYWP8H42qwA1+HRWGMsWzA1r36S2UU8YDlXg/g6JFazJg0O0snzn+p5YZL4QVehyF/roEnFZt4tBKWY9x2478L8TkeuKU02A01FSNflBn/OvU7bF5pKSEghNU8DlfFpS66JwfaK9R8GCz7lVrevawfmCuhsU8/SFEwC6fdhyek77/5O5C/7ZBP7/NHZemQTmFMCWSTUy1jUob7DP+/4/hE+9WxeDwBCgbN7LjHYxV3MYCocrLuA+RUTD8GkzpWsRHNgDF7Bea7mz/psvGc2+OFb4TI2Kr3l1xUv9YELJUVXCeQkFnEWCUS/zfIKy75IQNtb/L68v5N16dEfJJSfEmzwKDhpKwvyygZiq2/GAOvtreoPmgZOso9zQFJDomrmpwsnBJSdKlx+qgh8tmYV1nbywUDmg1Rod7dNd7VhebV4bxJoeGxLW7eW0JXaaqj2uWukeoEVo3jAwp3Iu49n/AJRkwXJokN04aIdTOfZU/FTxQcdp+MfFpH4z7bKCMz/zlPSD1kyzD97mKDnE5rmJnX2ALGvsG/qbKr2Jm3W3Fk0wZr/sqzq1tJX9yauI6ef1ln2F4epviL+REkIIohB5RGx+gqzcxWYeo6Qc7z0zt+n8J2kyfTz1eDLexdxvkQS+MOrKpc4wldj67car0sRJMnCxRoBe6WIPZ4K7XyRkJHALDsyNpvcz6zwFRBlrI1xRd7hZww5df9eDo0o3CZZAVEseWaYwgqSo4zw+fiWKq+/IGCSrnRGSKXBd8F2dxChfzcGaEbjuIInHuNYNPmjkfu2YewO+KqXuOTAJze7uEnIz1EpK8jo7MMUpZz59K7kcgsHB6y6JDrpCwpBg0azRwhVzxEiXydRCccm4AhdkwtMF+/jfad5PVW3nFLprxLBf1LMJPCeNeu6hs+M2Lytek9S0xOvfnPniJTD+zCVO/WcmTrmq+sgtsKx71C7qw2ompb+reMuho3lrQpw0JpTxqc7qUeKSGtmshUegytrgYBme9EyjoSfzVNFbGOSZxLRmUKjJ5ZjPwAho0RNApme6BYEWvv2iRmbx6z3GVkgg9KJySfFOwswqQAs3rtHwnz0uzfmAp4Ji3Yv7UgY9U/WvbcqoXN3nXZJoTd0OhAXDjd+Ua7cPVx9z7yWVZNK/DZ2OqD/QIhx+WIw953Rf3GQX41rrQ5gXwH9sUjV6kjxwrDuCd7nJUDgjT93hXrsYBZM4fNuakbI8xHwfBdeg79/urZw5Xu172buu5QLv6mMyNpjvntva164cjKUZzkEUNlgtIRTXSVUjOU3t0CjeZjVkYaGATMlBO4KpfoWsDSKzSHfI00QIlPSLu1+Xfv963Cn7JtCpVdYM6RMydLiu01IyFIBxgpERfzzd/2rDJI6mU1KDYwC4yhECboK0tYgGUaBcRSiCF0aBuA/IgOVvBTKZjybQxVgrEBUxD+lqyBrExKeqQBjBaIfukSOb0sH2xM2WAJKQJduPTrlky4fGLp0S8ovfTisS7ekLExEKot8EOjSrUdSRnzI1aVbUpb6ZBI8ikkCeHcNFyUVtSS7wpy0oMIXK3TISlUZ+MkqcBbCL1qE3rVoVsy9cq1XGXsb7B1f7XA+ucd4+J7+9y1TP3p/9K/OdiF/ayCYjjiWPHmjj6xkcv3yNp94ZRyZlKm4+uXXfBIA66aevgiLkv7Th1NQfHrlqTeKL6+c4pm1tXh2bfBeXO3TPNY7K88YJYdsiCPvAUD5OvJZ0ir5de1+3Oy327pkraKejl5beaDkMCjdYExgmWUBJUdDuRb6iyReWjVLAYX2/WoQrVAaTFqVN24ijVCuKp0hIjXFInlUJdgEr2wtW7PszXMuyWpTjayBPFAWAOHToGwvFM7sFiJuZhSyXArtNWxqLo5ncymEaPmRDuNhtoJkn5bURiqfYTK6UO7yR99oFWu1qOeaqkEUpKCvq/NysnLOZWQ6+tlRYcXWo6cR0GQ+cahaFfNB/9sCuu171FjJLh3PjbuF0LgoQOBzA43B+tRTdO7Ga9JycGw+R3KGXOS70/UmN+AmV+b85nfV7FapuF2fP1plNpQk9jlWBe2U+oUwd6LnFQKSvXOkSo4VMq1yXk/kn/QrgEvsiYaw26qSShDZ5BFzAohTb51zmcty6tUNU9B109xo3h25hED6mU+oNFqUSWumbBpDRtgNVat3Jz3bTO9Rt4nkkh2l/ee/KhPM0zdmiyWeR1J2cOq7hnbB05TQacxeB/CH4U6VRo1nvNtwBRtN3Ey85JPWQ5z7pGkaTX7N1U7CSyiPyCesGrwEkq5+Vq1iVQF5zXOivYnzgFX2jiEr9GoFt4whcOEFtnm+FMaL+TBfoyVKOVlq51aVRjLQi6mIgbTUKe9UVJcZntirjjP+abh96+SXnSLGQM4CuvgRoxxTrndNIq7A+ZMQnsmlbiSWrZym+sz3DDd24U41VECWixkD7uolYJkFrGRY5NaUk+96alxXp5ARpVSHCpkEPoON7I4I1U+YDDYGGTGnBZNrR0O+q09cmJ++i9wHYMMBkyvhBE6ghDVUOl8YcTiAhvaaPRcodIjrG+pF4tSIn6kobgFHSEH5HpgjpJWkkgyiJ5c3fbQePDu6VggWSVGbmZflYpEUpZEjSYbAVYCERli1ULuTHxrX6P9TAnjXPG3+Ev2J9hhRT1kwmq4ACA7UcD5mvJBCDShY/2hFNlifOExo/Bh98y0h8y79pjUBMiZ0Ot2B+SOZBeaLEKBHt1bD7ZX2F8UyoIKcfq0CmJsOVP2+IZAjdFgmYxAHX8HxF3oWrbtddCAYps4ES6AkuMjDCG5E6QnuCHI6uGeXX5rOJ2pGvQ4bD/A0QJCQyApSbN0O0gZ4FWT4JzfIYpsVQTZVRkxT58q/MZheugVmSpIg0WxyvtSn9nIhBhlBvpsz9a1VkRtIR0eex2eFzLiOxJlzy0wtFXz7wfAdeMGnbcv8PWTq8OvUEVqOzroMUTYYexpNJ858cuNQm5LEwxSTR+vi5l+wCzOJtr6fno5WaHy2qaQpyXTYPTx2lKgrmA4Uwlc6Lf307JXRZN7bXqjO+wbf2TOQHr6DBLy1vJjYbc7Kd4JcalaP/PKaT5zEnKXT9dLIPRFgd7FepUpVTzzk5AIkMKSbTRdATs6no/H0tHKVkqSOKv3LS+DNZxgN7LaTfiLDkt1Juh3w+cD5hmkACozPAeM5uT63TQqAhCllDMfifGEBobm5wNmac5KhuaBYqAuGebqHY5seKnD/1kpIpZFJJ98biUU1tHskcWYMchmZDDTI4LfBxs7BycUtz2iWeP584+NXqEixgKCQsIgSUTGlypSrUKkqliOrrXHPLm3W2mS9g846EcDVW2W7b77baLcMjzX56pBz/teh0zEXvfTcJdPUWEnrjDjfy1eiUJFi/4l3RakylyV4aqtqlaokivsoU7ImLVpN0maYXqcOXbr16tGn39/mm2zQFNNM9ZGjlpluphUMPslW4+SuGMswq9WoriTbcT1eX9dMmDbjhRumvLROLc/ffW3NkEVLI1Y98dCjCGzYsmPPgYiYhJSMIzknCt1050zJhSs37jx48qLiTc2HL781py1JDbw//Y6agnVyB1Xy4NUUUKioYkoWFpdepu9Rr3UwEdb36Rsf61isscum1aIxhtTEps4eIVArrmwllCysfgmFiiiqmOLKVkLJ166pbYo7fxIzp06fMzsOcp5Vk/5xpiL1HHK34M9u0mnjTv6I0Rsrzkeg7/iOld/s2I/ZObZD0OLtWBP+FcIo4offUobRYGihVR4rQZQc7DJbqH7dbDUBAA==) format('woff2');
+}
+
+/* https://fonts.googleapis.com/css2?family=IBM%20Plex%20Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local(IBM Plex Sans Regular), local(IBMPlexSans-Regular), url(data:font/woff2;base64,d09GMgABAAAAADkcAA4AAAAAldgAADjDAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnob+TQchkAGYACEKhEQCoGIKOsZC4QUAAE2AiQDiCQEIAWFXAeIJhtAhDVjWwbNoDuApKyq16qRCFuxSf0v+P+/Jx1jCKM2QDX7MyJJKJUJKMqKpmRla1RzDDetam0blsOLz1oHvtwE+kFuNPQiWiFaIi5caFoFNuQVCRgtd3bHmjgZPgwUfXo6haY7iLf7t6OnDYLPpmAS0D6CIlN12QN+x22v8HenflF13mwRGLfwUXPqRYLGIjOz91RCVkhoWSjWKAxbBoWkWtfuD/w2e5+wsBKMryASJSAgotItRuXCVbgsb7eMi5zenctbxd3cebVI5/XyYjch/j3Qu/tJtFYuWW088L2ZDsiG00WhtbDMIh7hHjAKWQINqMrKtc7UE9D/pC6V2k0KIk+Ga5wyb112hme0nXzChgfZntrmh9RJiSOZ6US0bQlwAQyVLVoFaEL6A2PGrFl9GoNxFuXKaq5KGtRhaJWl2Od/44uCszBn1W0nC1XWHmb2e0BfwmWU1E485Mks+hjir/w9ZPD9bGlRd24dhqsDuAGawOblKbCNAhtQYAIyjOEbdKAD7Tn+/9uad+WtXOQjLzKRH8GGmA9L1CqqiZhUYhVV3E4PJJVp0WmruqIogxuFAVAOAdlRuLAG7p9R6OanwRW8nJhzV9XXf29q2u7jvxUBQukPlRKtgUKmQr8XHXLonD/e/8Bi92MBkBDnCIC4pEQIF0DgUloswMGCvEglnnM+OQWeqbNSoJUCT87hHEIs5UqxqB17qXTRqWqdis5FUbgrDblVyChsPu0jiEi43ajAGqU7/RZGREQkSEhDCEFEZFi2/53NkQZw/C6I5+xDNp+t+7RnoKzhMehu0BWE457Kf5QFWAW4VheMMBS5EGpmCKtSiHk2QwzaDrHLMYhhxyFOOgNx0XVYTzyBGDcO46mnEP/5HzY4xB+wCUACAIEDCiS9ZWslJabCHf5hdgPxsmldLUC7qqu2GUTXV/a0gRoOMCcFpFiIue67qw1Cf0++5SEaCEAhMLACxEqGARaSl8c+z/fMAhyQfX+AA3LgJyDLKsABx9rmgI+cd9VPocpyrVvd5QF3lRwrfl92doKRtUMc4SjHPO/Nr5wfz+bNCsUJXZvcC9Vdm8Y60wnG5a2B9e8O32mbtjlhw8p22a7Zs/aefXa/OclHdqyn5yw6m89H5/pxp//OPvNTkFfh54VBqQQSNe2LG76D6lLnNleAh0K8VCK1OFejJuMFiWBahMgbjB3P2DONvQ774H32Y/Cr4Df8afob/DP+X0MPaG+DI54qZ9QkBjLq8JML2qbh+xfX4rJ9RHsvdbFusz6iP4VkrVQqHWRS2Wq5VL5GISgmSqmgLuo2HS5X312hr3j6PzSryyUy5IWcPOjBPNTeYzzoQQ960IMe4sGANyVjKUgbmVpftp5cJN91StAkWegH18GV7m+ZdQPFAFX5u1MeMa2kLRPbgx4acNg3Z3u1DsQ1PtL0i/oNf8sgCQQJGmAQSJQESV6wWjwzECkZ09r0Ffaiol6qhBcV+DCTRtbgRKECnr6K8EoSVBvyN1gMT60QG6Fz16DW4Lqneoqbr6V40kWZuIMVgpMStgiyb7T+TFPJYBFwAAgABBw0C0Z8oBH4IC+l6r1ddeTpw90zRCHtAp4QjprhU+FCdm/hr8u4h0zfUIngDnSG/NOULP5N+I/uVAhtyR2RrMMjty7Rb3NSH0mwiogpfTl3l48YWTfyNxQm9DGQ3RIxv7DFrwAAhf2ZI+hbUABABaAYklRKCNCulGXltuZ5qkiVsmI8y9BcLVyt6DoKG095FVB0Y+P4WPaMEjtrgHAMD7NAwedYLJ4SaGo+PyAinqHaaDtRITs4C0YmTiX5O6jWYWLq6Bhub0besYopKdum0eBuT6EL+K9oCb+FByCE3RkXI1HtIyAsg7SLNnb4DEOOpUy8hdnZCDXjc02G2ay4d9A3OZHMzC3zTcmiOKHE+0Uzkl49Ik4MkQqkMllqZhqiFjWkXa7PshEZE+0HRU/pjYGIQhkVidCskkk7ytJs5MNcQUixi7ooJMtxwUJDBWeFQgsgRJjjKRNv8Z+2EzBPXJkaA9Vp0KTZEEONMtoY403gaZHQaqJp5lrIt9hqO+yx1z5HHHPcCSedcsZZ55x3wSWXXXHVNdfdcFOX2+545bW33nnvo19+++Ovf/5LSknLyMrJKygqCe4ywvB65RhcDaAVCXGjLKy6+xa3wpfMhj7XACuZIZFRDN8SeW92EM+1B2YgYJvAOhQAS72g8dVbADGAZPEj5MZ5K8Y1AhiAq8RLI0YIlUuV+1YhzFJA6QooJ01QWM6TPXPYJVJ7zBWAScbJS3SYkBFrZjZNAURNYKm8m1CQF4Bry9ATiiJicjrMe83Nwdw0yqVaTBBDxfOARKyu6tLGKmZ2CnAdCmQsBI7TDa9KGI1YXXrNliR6woPV+ZBgYpnwlrJ0DoLdFKBOWxUiVaDKPh4tYUI4OlQLNQgwtLvRqjfJChD11t9QVAnsUyZlpL2L8CRqsQHZcw+iucTwoIcrN6fOUiKRYatRZ1I3QpsVxh6ATLyKmKhWA2dHCQSuXTVY9j+5kSR8nzZg9d73NBRAD4yMqPA4QokmQy/VyQgxNDhop7qZ3GSUeCTwC4dLgFflwY+HwZG0cRln0Kd/Uru09FD783D6XgXFDEGfOrOHjyG6xWzowi5oUy+smSsS9Q8p8gz52A1qpAOylGUqs0BaFUMstR5FHhFEjn3SzTrarSK+qIRBxzQ1tmlkNgE7UC2Cc4pDb00aWB1EdFIC2po3cDmrd8tRy51nAl9UkxGAtkzha3aG2lfM7o4UZPSqbq0iOVvnBeUDNySmW13qiul9ZonsODxEoF4AZ0x1E+4cJh4m7r3QSmKahb6a2OoJdTKYoza3gCwSN89w9kW3CxpgBhwKWcXMI3gcCLo6buMmdg8Fvv0AzLppCqEDfQ2XoQu68KQ47iwjVc/13+xhW9JROmKp2IEC2sgqnZIhGHUTKUemLhYNc6hHgvJylGhQSo8yBpQ1pwk7adJumnKYSo5Tn9PUcYZGnaW2y9TrCqVdpbpnVPOCxnykGZ+o4jMN+UIDvlLRN1r7Thd+0OAnHftFB35T7w91/tKuf7TtP5r7f8kKwXpNhZianXxCRyCAUo9FeUAAgHxGlABlkU6LEMV0PKwsDAASYCVtLq4/FBoQ5wYkeXjYABcPL4YPwAI4fhwnAA10LSCooirEwZ5sHQA1CqgP+IGA2JOXARSr3lbjCHqV87V8McsBuAgCPQMooE8zmEiWBQiVJ60JceB7d9AobkSWcP6+8zkNPQPzMxfP2MoP14a0h7J3OyWt+WZpzGfXPNtYikVqZjI0LFlca3zfSzvdCm5vE3RLCEKKBgSgAuJEtEqjS5ZaQopZU2lmELi/g7AFnwJXJCINrP+rT/0VaQXojBJNpil7gItkABDbTFKPHKLZjgjd0nSsECOPt1CpFQjIJvygAERsJ1C3wlAvqFygzdSpFFRefhYwlbCHDbiJZkbgUhJXpP459xXjVlhg65qfCKYivDDL9ESdsrNKg31TYcI0sOhJHda5qQbGi2cx7u3alaHP+1CrNkGZaCklaYQXnFya17WWr519BmDqdsb3vW4Op59+hvSMa4zwafwgCm4JBAl+5ZMQ7Sue2za2Fp/+9kFF209JXrB0KBRraWYvaTIAGYktPYc72QZr7GH5pldytDHJRri9Lt1RVuTposp6eHEL4XD+4qIHi9U8XrMAPzhJxVEIdAUrUol7GyZNTQwhCyEqmDsUZe3GoBFglKYkJsaKiDlDeKzlbm52D4ZmocooIh450yNQ1BK/YkZHZYb7MrbKUNP+hIXtho3ZzAVlo1nrmNHOPo16sumT7rioLGc467jtuuq1RAGmvhBsUzVwKIOgEtbUxHXrgotoFhpVqBVK7DxZTvrZWrEaW4KalRCTUC1Q0XEPf0cM84BZbrOIOtB50pRPNfS0XMKLFc6Zez6INXIHZYC18JAwEAog5o2Pwws6affDM3rXElcotwPQz6pHFyck7KruUdrda1gwtTBJtaawD7WF1NSqjLWGR8gL47mUGrWVMdNIX3i7lWX1tlgKytOGWpOGAiUlBOjhEMjNOW63m7iWGbZJyLukWc82nk9rwG+rQNJBnEskHpZ5QEXjxztnJ5lJ2X8iVD0C4C39ULwPUPjIWGiSugfyqLBRzoTkNXDxPhe9W5DK/YI0HN3B14yhAiSHrWyGzeDjTAIAIvB8lf4VPFRtCYipYrOFbR10996rryIdjV96pZcFnJsiD03RVoAyZXKWp5okTvqj36uwhi/cO1Ftb9wtfVDGihwHLgbpr56mmlf3ya+nPGvoD4olJNX59Bq7ggNeyRUhlom9qMvUt4TOWxzYdZ84s0cNNuDC0atMOLQtL9htxaea/uECG3FC8ZqlHzWpFWwFuAGy6JZNe13G4MFoOMNQQe3Uh+Cr+Ta56/RoJ2wvR7kUWPZuY2w1H7oqEMdLWSc6QosTmxAlMGrT8ktq/1sQ6nnZ29TCbbT/g64MdLm1fsFovDgtTpS/Q8YpbZGqiRd4n2kacTy+omxdDubu2+EOYGIfm6VsGDpbItp1vW/kDtbtHnnmnbiKJjat1oN8YmUnpCwx7KAwmWoY/JyAz5pCrUA+dcrAhwreZtQWrjD7GiLCXpdbbkFs2Ipw80Xa/Un3NmSZB2fl8ZTDQ9TrVy4P9XS/AXYMJ25kaGbTgju5aWv6Ao6tDjJ4ZsZMcGxDsJsjvXO6W1nQnwF4STTwJ3Kp8yDWHCFGZakeqMgIbDSirO0SvHABCfJZwaXlkKpIEfcFT028Ddc/W1VzRsp1sORoSitD5B6yena+x+Y4t/jgABC19MDwNREMX5PGd/5SItZZ4ALOLKYEIunag6rhlgEBBvMLCAKAUPrzDouIigHiAOeZlRLU/1TQGCwJhycQSSQygqdQaXSAATBZbtX2j34PF4/q29MNCPmBkNh9csBPo9Aqt6dMIvsBmZ40kX4b53nQgmTlu/gE4683AgCACgLoIzR7dsPWK6umgQmeDEU+w1GCskgHKxPMyRKSmn22AaAJCABGWvIK8qKKWto6WroWFvKWChZmYsaCWFmcOE4ZAOEMJVN8Ib+G22tjAqbP7/VDy0kA9UM/MDR/8iIgalSfV9vIQa+2gFvjmOUAXATDngEUoKYxIuhsQYBGEGEmkIp5e/5TFkV1ADk1LpYqXYjBx0OjstUp0iiWpCQgLYvIy2MUVbDq6kRNXZK+Pt3QiGFpzbK1g1vCL7JIoyWWanLUKc3OuKDFJddNdstdM9330hLf/LBecD4Who9b/9H4CYUT4taPmxzIwEsfVZmAuAMca0iXyrcdN/4sFZFsxQm4O3abnI8cnQj9RNhmmNsZsM+vwcWnlODBbXV7n9R1bwr0VZbl7whuK6LfSRZThHB1aK2w/GsisB0tNOmnGjE0s0zPDtKWrOT9T+xo8EBycu8EZJtgqrXiuwn+rQx3gmWG6HqvqnLZL4OyRX+hRqWHYiLUM6nxneJgvSzWrLUU/Ms3o2T0nGCi+Nw0jZBInyYlkTTJM4yyTIufu8Y+KOcIpR2jrPPNGdfdwLpJBbeo6Dbl3aGCu1R0j/IeNOc99AjxmNKeUMZTSnkjqQ/a2/4xiEWy547V9uFWLS0vCiATVeQzghQoi/R7DyGSaBoG5UsKxA/J4XEcfhLGOQ/crz6vriEgwSSwiHaub9OKslUr2tZYf4OcbK2CGgTUq35AlXzyFMARr+dUIAdbNcNJhKwIECNQy+Qi2zumxWYnBdiv0EbOfPj9HGFAVVpJUUoO4OLjZQM83IAsIoQlUT+W4x67YPVAnjKt2s00GX6fLUev9JgfbPT/3J/ddsdjyDg2dSBjhGDNxtz20IQ/vfImGCQACUWiJYpKlSVfiXmqNWrXa4lVNthmj9Od4yKXu9bNbnOPh/zAz/zSU573qjf9wbs+9lef+bdvw2GCMOHFllhatDgJkyZPmzlnvsqqqamO+prRvAZa2foG29G+jvRRxxrpTBe73q1+6n7j/d6L/h3ALsUGYyMnfpKHMozhjWhkoxz9WMcNEiUgEQASZ4nwSDwpqatqcL7BvYbYfWGQjaSSVJE0oiYpJJk4CI+MEEEVPWvw0hchiSYRdaSVDGL7zKyj+OyxPmvSeTSY7fOnHAUZWyKvyBzylgyQ8WVVZuTWGPDuBudXiUiySmH0Dh0qBF+2jQHpbjBzlUQLWj6QxDGJVQf0Ab7y4a7stJkmAPbda9dtkMDELIWV8294AGrTAK6lRASaBQ8wOeQY558KJZVGvQDJIcDSTLF9hd76xjcSLFuP6eZYZLm1Nttmj0M+8JkvnXLeVTf94K7HfvXM394GhwQh4caaaJo0OQqVKlerWac+y6yxyQ77nOE8B1zpegfd4T6P+JHHHPEMSJQNg0SQVTtLhEfYpLquyue89AepqJDFZGNVZcfKSYtEQFCSTByEVz3SWkXPtvOmib5Ek7i6oITZTXRmH5LPCCrjgQjrInx+lL9DHdHnFZlD3tb922B85drkICJSVb2NECQiCewjfOsuxVA99CeGAbJqRFqjJPozS2RkksTGK4XvLOo6YAm2tVCuweY8BxyUabi5wClnCD2hYk8Hk8DAuuga+NPExC8TKGTlwiFNhwJHw4lwOpwLF8OVZ3w9cCtwN/AgBJDv7mwMXn6TVjLV2T+7THhEXe8jx8I8zISq2u38ckb57v0u+2rtAOrlbe2twPn/3j8DEF7fWF8Jsht7W7tA+efiuSyye04M/tR1IwIjBklsduXACtESUXCI5NGyKoEAYb+om9+06rKrYl2GxnG4EX8mAh3NF0HV2+FmBby53uTnJeRiRcFIRHDHL/r16HXXl22c6mCREoEBwSiKd245RFCf0a/qXy5AltedAJgftr/8CxRREB0ShQzct8u5SIgAaWFcmmnkDBBp9auPFSBUtP9hXPEGxkX/wbgEgbgKixWLp/umEEYYGLOX0z4uzKOzrAmRLJOBy+h/3mQw/JyMLiVEkiiTvnrNJjvtdGUxaCLKOPW+m+deeBYcvPTXd4hnGzzih/gDIoKRmUWJWtcuMfyscU1yNXjQR/MBjsv/oeZCZMkCujIei8dgATPmAFcBOwPgmEMtKCIHtloXGzxJkbUQJOoFyLMAXWCGAVvAAAMYwCYQQLYBCwE2gUsAgJ2gcIKAVc0yidR09WVn+2kCseQXFRWgUlSN9qBH4mmp65yYyUlgVagdydTZF1/oDwN7RqF8NJuucSJvQJ0v75KnXHNf/uOtAPz3EvjmuWd7nr3zrOVu1h0RAHF7KhtJBnbz4TuaGXgTeMtFl4B3XQHgfdfc8A2AjdqCSwTfV24YfO0B8INHAD+BLAUIACmAui0WMBZ4P/+/FSb098OE/qao/8umppFnREmnZtDoDCaLzeHyMvkCYZZILMmW5shy8/LlCqVKrdHq9AajyWyx2uwOp8vt8Rb4AiwsKi4pLSuvqIRFD6E4r1i+F0RhnOZZUdZV0/bjMJlNV8v1BnRdXtv4/dSdHY/v9zXBwBOgG1x1FwCuvx8OvAxDzwC44YEfquYtlI9nbnxz67tvbw7hpDvf/nwbwD2fjcGCxxESoxmWEiWw/ilTP5y70Anw5r0ABFaAIOHwc9IDkBUAdC0g2wJrXwiwITDuB3o5INf3v3NSsPCwkKQakwPGxPaxClU4WNiiA6iYMUViGEQV0a/KUAjYKXFe052TViz5tubtXjUx9n4C0iyzrw+Dszo12kGIqYtvx7WHKFITqV0ZHnGEDrpejhoiFbtuvC5ew390wLKHeZZBReVQeTSbpQYQmnTycVgPWAzIAXMg7/Kvgv15TSJ9T5WdaqStGZOTTiJO5kmusEwa+VLniCmM9KSBqx/E2vOgIIttioGZyeUutlY2xiADDDqW7XzbYwv4RDKm7tDbmJgjqqK3RS+yp8ouK7y0o+rlR/d9rwiyI0UK6Aa6Q0AW2VECIQQiy+AwzeuyxJm+waIOynHLt3eEKaxyRG/rIPZQ2sBHoyNYYUwl1xaKwmXe/vsoMWYjpZQ+WaC2VtyZQUy34WFQPvvofYLTQmXwtf6nK/e/qi3nfniR1qsaYsXyL8WO1/QRGQAIJVWbZuT7dZPUsn5DCA0Pj9JWysBdvnamg+hkowTyUtp5+57YKeFWPd3QEYLa+lkyMP6xO4u7AVdMGgvfjVoCPEK6AppNSZD97ueXghNqq+x1Rm/8E7LZQDQuZ1a1htounzGC7xhtl4uI3lI8eZISCEOB9QAn8xjnDVa8y6KFSG/Bhx1xrFAqhQKxzg5CpmBN1D4H3Zt0cuokjOOr0rfzlnpwCTXRTtHB1aAkiR0Zyv4VgrIPv8/YoxxTqP2+ZYPzhUK2svg5oVZipvazitclPvtQl62AdO36LFzsQC5yxU6b5FloWkkStkWVkYrdH+1hPy43VKjTQg8xo0AWXI6mKPm62kZZZfOT1BY5Vw8wZSLw0RxKL4QO3v8Xj3rL8EHNi5tCoE4OL9elT7KpP8HwHNfkx6WbE0ZeTwmoE8hTRzDQamTqYsrtLjMfq2OZl1qmwJi3g9hYF7SWedP5NNLjVt1YCgVWIxSkj3+KXvJmTFCC9Tr5Gtikr+H8wJO4tIhcTshsYgbI0LOuSTkCY5dplaPwTFO5sfCY48xRlJxz3SRBiIQVMVMYC46HCnR9SdH+rVZIkuE3agwG8k+5knFYT2Y6o6QXQo99J4U866JXza7GE6SP9trN1D6lfgxxfSYZri8y9Jm5nD3o5PbqBG1NDx9TGHs0NQIFOfSQlzJ7pRkXD8DD3jw3w5ejiN7ArENW7OFQqhny9YUa6Ji3L3blEn03XS+EkOXwrCUSD/W703NDCSuzsJ2NGmIE2xZKnfSF/V+OQAAnmE3VgopOC+sJHB30xn+1ZZDmHvrQY2Qum4kjYc5MP7AzrLrkLIdDVhWnD0FxPkYRvjzmy6FENQIlUzK/FmTHFNoUNnI+XVhKwRJKfRtvnVsC5VLooeX4tioYYTI3Z2GLQ6NCcJfAxFla6lplggOBoSx0J1En1AOkNylfZ8a3sTydgcCMJnkYsuX+9vDRpCzc778pKJ3GXBq3FuzON8ht4Ke1n9oRiW0e1ToixwZYcnLj3XM7d/wMT+3d6SK7lS/wtNU5KHuSFIg9MsOVk6F1FUY1Alv1Dc1IeNxLZ37zxaGAdHotz8wAP2anUS2PUAV5VWPX7HAMguB8z8hblHwhGxjMmXs7xV6HWcTYapRZIte1GrVmPi9g4mHfIbewb4942BkNjkbseztS39rTsIhDR5zxb3dia75Ombv7nKFymBuAox7x7iiPt1LexCfsnuHMbruGOxW2/MoF7z14T6jGmlLdOyxOPgfIw+crgf03c6ekWCXnaz7KGA/YQr45QzMowF0w6oSoCNBuIdDMmksJpuchRng/R6tIBDaACxtOP2Ay+eAP2x9gmKIesgZzMWgCn1WQdqqXgg6w4wyH5F0NtBKWcslcFweTL0XbD48hVN1wjGpAhwodp/OJ5x4o+dpWHX7i7mz82Tvugp2XH7jRWnEos0FZ6li+X1Yp32Lv0GP2v+YPcUlGE205/4bA6scGbD+VAPKxyFPCS2TLCfBgvM60iZNx2vGrzAPbwTgbVHbbdrl3A31hKkqTnbot8Lb4HPQHwiKQkxjTkhpPXBqf0yfWm8+mLK2sbOvu0Zv60cG87TS+xnLuW976e7MmH2pMm97Ydt+7khd2QGp9671vi18+YtyNheUgswcjsEULQtJ23Vs+RQwxKfsDC5U7beQ+UgTiAUmstHti4IhQ2ap3Tu1t/LWCdOa7sX6GOtZCXVbFcZ07ZPO6p+DNGQ9/7ofQiZgNSBwkDpiaAoq4lAkuBJlzUlQJxeOFC/p31OlCl/EFLNj42Trm1cmhQu1l4VsgglKsbNtnqzmHwRUf88HbRWVE/YbD30KxJnlXBv6pSOlYvWWOcw6CoM02C6HPYBCyAkut44UHQEsfuzjBEiy1tQz6zkjJ6g3pcUr/YWsZOaMA+8HzQ53b5OOUOfyq3otmlIosGolkHcAv6RwyQ7D5PGFEXvvG8EGUbpZR9qqGEqxVMVsyb+jESu6T1KiFVKzWachFue33WdwfbK8Pe+rE+F32mQaxZsdO/+m9uG6ilR9S0Fbxa/WKRZmRmfujYEDfQlReHQDSPbtTeD/CMXLGvsltM1ijaT3wREtrjMz+iuPDp4+q/ifaRbDvk+OSXH/ML3rh4eQp71Xggy0WNxE7a2Ev5menELN6fBwIKxwrpjLN/kU7KuGffz7VK3f9ZnyPWfQJvg032x7ZXZ06DureFY4ftgqnt9u0tzeU3vF2mv9bRRlnJtUVXy8Gr4pDCCdqNZ5Rt6oZLW/8qu6ktf/vmEW5q7te9XzE38k/nUf4CrhCUs9eIiAf97E40UmTrezZfp63xzA24aJIXWKPU8TigK3TGpX5w2Y7YDOFBiLQvK0FJROIebK95LnJnf1TtOqd7a+9+NnRFfwvvXzz6hpo75Cr7SxpARIYj+D0GHluSQ4uMmZpEqtUWL3t+hdbD6ykJaXLG9YM7lIgSa5iaVHtbE+bxXMD8Gh4uFKoUSiQETyJu0XBG/nX6qZ8EaWbJfGQYB4Zt8ugxs6bhEGuXxPXnRguIbepNdQ6s/Vh7cp4mZkfrGfX+kqd0KW1HibAi26mVOJbxHWFN9m4mOnMjb3uBkJO2NFssUTv8m8OThDKdFldHsPz4SjbXCoIYR5ONRVtYlnFB0hcy2BIirnKBoWiO7nPLgYS5yoI1ElZwdDyj9/WHbY7/pcgRnv1iwQSfjwh4mUKoqrgrZzaPEMqu6mGekcPpBq75t66WDKOrAbRsyzVWB1/CdtN8BgGO0BV7H+Vylev7fVtFkpSEX4zdpy3+O3D6qQIvdtbut/Se9tfGgNzuP88QfT9DqV6utu4Nff37cjfli9c4fqLiTWj3jkJ9d70tNHgzcHFOeh6FKYdi8u65LtULBx1Br1GDCFeQ/f5sOHyIPmy/MmbI1tK2j+bw2lVxnIwwVrKMmWOQo6zA0B4UIYRQhxOE65BLt/zr5lPRepiy3xW2tVcHfFjZ55Dha+SZF6Zp2G9mphbP3Gebd62hvIA5+xowV5N+KvP1XJBv2DX8Z+9vhM+fzBk4XxKttlRU1kZLfOq0CTw9sh6vIfjKJqWZ2OFcceRcIIyiiG0JblJGlpG/0rye1kMK5f87q/KBHr66GeLU8mLvtqIbD3wKMyTOKDWNceZYfHqhn/nMWtpwcnmGzMup7pjgunLsvUCA3X18AWp7oOgpDCxMR/cl+L18eAU60kLeV2KUrt5g7Kc05zQLvRmUZzbXB14vtmqKOV1Jy6C/8QGxwCD7Vbz/L7BHd4yyysEDt1gtp+HLtJCWDl/alH3CmqMcgkfv1arWclqrM5ag051TAd87o3T6tM3zInrCCzuQU8QQ+ncqj2qO/ouITM6lHgC1Dgv3guLCXPXJWBjuKtfbw8CTMLMrq8OH7ZmJjtn6OlrcifaBV2Cr1/uGnrqxg0+42m+//u7cceOzO/4xAgxF70PbgQragTB0nydAv2L29RgTNzGsBhJAoEtyZNoYNNjNbOWhXxxoB1wa3RaucBfrBZJRCpOwZ0z+hRFFINliV2OKhhpGjHhM9ynxqXLM9ipxpsFSVlsTZRjyas/ztwreIMaTcq8gDw6LaPTAFOWOIzkxzN/qdXWgo3tKuYQHpLt/KhA/3lPxWxTUl+yTSBIcV/2popZyqjMxld/nDmZ8ROqN5g0QRqDSc+rKtAGxs/uAxZB5KXI1CnVeVb2gL6jwDvYMrXAonCzK35SLLVK5GxTUkGyLVOAui97UoV6jdmkC9BRVHO6RuD9oE7GPNPFi0Z8OzAJssLkr5MNTL3FdTegSu6W2bvLGhtt3C5D7VUBd7txPXMq/PXsXDl6g00ui5EVUUPKXHq3UiUWhYkoqlw+txA9pFyDlZ9xp2b1pI/xA0rOXfirffffbt/5AD2vG5Td6m/UN87lDijUydhQ4LyhgI+u7XFgS3T5oYI3Iqla8ZGBtIph1iVwS5trC3ioNlORhG9J/1F/NsZ9U8e9y7Orm0QbS0vFW2rbVuUWahcy6orz1tYLI4vpagWNy5vU4MTvcsgTL0lOiYTkfDlB5pTcwak1vIxDiVxuuZuj5DQ7TO10ub430+Pj9GlydOxep6ebo3vy16msVM50apRIlCS0C5MgUnOFqLfzPB9q3thozfhe119QMpRSUFXpzPBEdmD80HsbLzOZRMNLRXJGrstwTXQrKy3rluia/iS/k5vG7eSfBCdh4bpPPvhg3ZcLfX02VK+iaTxyBVubGprgFTW0VE8rVhWq9Uo6auh3Q8nQhKKRafRmzCsoiMwzNLBi4qmBqUsUJ9qFXcIvLL5Ol7mRCqXDh4zeCaVR+cxrzJ9/O4zmCa6RKwO0FnuiRm6XN3FMRYxFvgL6IktRK1dVNtOVqlbTp5TlKzkmtDnJJewUJrmbbSifIo/EH8vQDBp/rbdCRE6lzD3sFlYK3SFApq3iVGnjhwH2DuFZiTqFgchyVHlDdKaIrVNFohyF6sifRojyVrU+3bwk3djqqd/8U49lxKxsgNJhdwfdCDNMeGnPPq5hfJHxZudwx7kp+PNTWoadgD/oGsRqnMOVb4+nCZUEdQvHXERf5PPRF5qL0V7UqlaOuTiAw4v6jI9VGtmmlEEoPXFX81WDnT43lA7HltU0lZba62bZKUbPKX41T8ir5p+C/3bXM7aRdZ9WClRFlDnOVp4ZOxd+0hXmad6yNf6hO55zSV1thUVbpQ7bLijfyNx9UtfW5+IbQAmeKfLN38oL+bkmq07G/1Qdtrw8psbn4KTqrrnjBbaO7PrfzjnYuSqzJJsv5ytCl9fFFpdaeahl1JcEuvYOd8dtY7gRDg99UGOoKy2VjajmA/dWM7E9x1BB1mrLyNmG+HbzVnjzZKioq9yMx1vx3eUFE0MwcnCo0GjLxmHkuAJbhdsmx2JzsFab96Oh0qLi/EmMYrKkGCy1n1Ewn1EqHlT97K19LwbzUUzFHRf8H/3H3oohGzYMQ8WzXXGAvjGvJc8yfm9eR94FJUvm7ckvx5XnA2NjuKBfTxm481qWB+MZwzocb3ftaqf3cxSS9mj/0cLwE32a+6AYLrPbVfgwC1fkLHLpDU2WzjqBeCiP+1T5xlAs1ZbVFzsTc7SR4uSk7MxoT5PmCTWG2gjuB3YhjmfmiHiWdJEmsTovj5lnaHh4jexynNt+M0dtcWt8GotbTQrNVsecSNBKQ0AJIk+6VJO8xYQJkxtAkaVEWatM/e4/HsUriU/zqfVeXSWjcOPiKgVsc+E45Q3NXESRmcPDCe0P7QtySCFSbcKJGHV2KKnR04BYQpY7XaZFq/Jy0Wph8nWTJXSkZyuTi8XU7vhUfeNiSqaeLR1Y0CjXj6V6G31p/kkEjdEJHV+5te4GkViRbdW2D7Zr20fs4C+xzzDOnNaoyGWMFBFG+RnxjbhRvkOUQVJwtAks8e7A5M9Qi7Yq9fNkJeOtorv0CQs2DsbHHSe3VXj1Rk3KQ9mRl7w0bq5RZaB/5BZ8IEi04iiAvIJMtUBqL6krM9lzl/XGXxKrE+rsMGMGsSE6JLqBuPxdKqbacXZwY+1uUZZCKtS6M97mwxo/CaM4a8GarZUjl26IKw/5ma3H7HCI8R5ljX2bWQsenN2Nm18VOJIs8PB0mO/NeUqbr+25NFmanPjDccLMRbtlx38Rp+YFHVU8DYgjCD3pMm1qVV5uarVnsheh0J2eq43n5vUYM55LoFU4bE6j84sqbnwA5WFGSRwdtmwt2NJtvzw6LHb/m6Icf1OXnZ9i5yr0vPQy+IOgrxCxV4waaJmCZbTkpoyFwk9OzadQj+FVkRn5buYrm7+Cyucz0qmpr3s9wTp9jqnWA+cY71EbPVoekUKs0K/q1HZObdTCWheus4o4ie4phUbpm5KhJtbOUfzcJ7GzcFL8Ol6fx+JJy6dYsFir6LboHibvnvy2Tnk7H5yW8J74tmkAW617zdqKYW49/oZUCTEj2M8my+Ydxy4+XvjpP0OBZQsvYFdfgLVY2+P+Rclr6hPpWge19UScvb8szoUnuSBVRZmeqJ0pY8wVaOHsEtos8p/MFoaV0cL8kzyL5s4v/5cr1G8K3yTUc/8tz4fpS+ap58Gq1/l/ll2/pM9Hv3KlJHAqCJJWdmo+VHx6KS6LpvtfYqgD/J/xMNHZWBRcsaKjs3J5YXCjtv6hTW57RtQagpZbAsjWjU5P/sP6w7psgZOxiCFwSMFZsybJzAiJJxZpdTujlAxOsmW/J1lkqcuJ+W2Tni1WGHUGaoR8+5j2LDlawir8Ft9igsw+d0lt7dvGxtdW6+vGxre1tSVuSZ5LKdXKlYadUWnKAFCweo1rzQeqDyrsAAPDyrL3pPiD0lKSA5J5YPqGKnWVKqXYYPADNv2iRB/DYnsT2N91f0aV3KZTm0Pv2+N0FgFPYhD641exKUPZOZWCkZ4Q/VDUfiKqnPkdY8EH1ztfdt2kkhk9glMczYKrjcSGGEJMA/Hg3iEcEOYHaadlFpYIFrpclnmGamnFA2pypJU0rY5aJZVJC1Zh1X7SnIo3jPKVjVZvQ2GhXbdVIOf6rTqYm8Q6y1LYzynUPuHAqzOhvjQtKZCE2+fiZPWyROZMvS7Rakr7ad+apwqmOF+nyD2cfqSUvj8uiCeLou14FZaDa5aTK9Tf4OEPna5LLkg2slg2XABa6DQIKXUp39WUtCVL65Njk+uXLkk7fDQDaTeKkiMT40v9eG4200aejBvExsTx5LD9RLw6Hp62Ui5c2Zaevu3KBcrq6Hy2lf24IOA3nTutPn3OnGgN3cRE80T68Oy5DdWvC5IfMRQlp05xOWwBt5PzFDIeSyjfXmG8AoOpVHMcLoGRnDTl5s6A0/xsfSab8v0rrJtEyzRLleLv6PdG+8nU9iQ/sYUtAL5e7D6oTwP3ucv2XE2OJjv+kkRNrLHj7G4zP493UgwfY/3c78BLJl2ToknS0WlJeg34/tDVahXBQGgnGGDXHxbxaRRfpU8c9S29Hhu1Mjx0/YaPIyv4Yfa09OikSjQm5cE0EOn5rcF+hT5hbV1pfhUfzhYYHGUej6PMkFxYL2DtZeYx97I2/eC3k8y6Zwv5Xk2sXZk/iB2X79Ve9tYM3TcWTKiMqmcFxkPB7R/4RgrBOZ3EvrFkdYfLilujbI3YvqxNsGJKwIKP95PhPGBObvsF2r4/J6gJdVphjmeBqiI3fY6Hs9llghWuJ5xDDVdMsN+Xmglbra1i5KL5q0+V1TSXlNgpZacGHzFDwv+Cq1lvKvd4ZB7mk/J8C5dJSx7a/PixurKSoik3OhC8XWnW6eRme5h9xK1144WJnmYbKhTY0eZEjzCXm6+mMKlzfbcM4fkqwP6mRsaZzPy8pJBsRbSvJYcHRPI4wWd58x/VjILFC+vyVXRlLGaM54eee6aKY1pLnDpTq72tjiceyuF/5/pPUpKjYx1QxuX58b57Jo/NyLSmi5VJXOOdh+gwS4myRpnGb176qgK5HP5pFYENq7pJ0iWEnecs4t9zLOxyUqdSm9oo07rI/Cx3ulSVUpadbZln6JJnZSoEv2UeUDe8sYrHNZn/KJjY/vG4ULes5XOFxaVX6r+o4nZWoAxVf6Me/4F8ODo2+jB5t2ra/PTZIV3p4mtbo/z6GdqEs7nmk0p3J7FIFOqLha73c02Xqs5nED+l4hFJ7tnJu/cosSLnHac33Rr1MYAPhoN/n2j9kvRdHNu3BbPMMxTXJ/XGf3II3WeQkpc4diD+wFhijieln0T6WRHur60Z4qT0Y2Xt7xP8fd2SRT056T2Hr6yWK5jMuSorpVP83OW5GoGDIlUmlzDGYeTr2MapC2rkwHImbI4lkPP6pMLOOmxsRFDsZqhgZBGOlULpm7aVIz0qPOK7AjM/fsfvCTTx9x3x14U6SL8SY4m/kg4/E/RUEx2vZwSFRLz7q/+318n3Dxpcb1qpk3FT61pm3squ74ODxIEYQswAcVkA5EAzzpxQzvQ1/+kfnL6W//b2rs1fuPDXQ6pmViKrWbXOA/E0cb5R7wUe2I7vNbf3DmwwKRAsXMleSSdcejSkkksE1/X6r4S7X3j+kfAk+hwxbu7xReAgLFg39P778S/ABb4eO6qTZ2gK5HJbZSnBgqjwFXgVEmypKLUpCzU+OeOvoYOmOJi2a6KI/YhdOLEiLl+9AKtaIIvjzAInzjHoHMQhzlnQ8OrP4F2D4it+U/+Gr0DXeLx/Xr0KF09JObor4uzvEpO5U27HZqJsfdX/H9LzVR8xyHupD4TOVJx95EauoSfq0wBa96LDWxrK7Ta5jf5/YOA7S+RL/OGh0qSpKi6xlim5sJHPpGcqMunMzecRpC3+OGgBblSaJtTIRBKjRp11LuHko2Iy1YXiUReVeO+QKOTKQ/hEqTKYVbQEzSBnpZta2L+jlXfmfapAJcuSmNWT5JaMZ7G8xFCsX5f3jlrUFy5cJYMvlFqDjEO5TMN9b0SZKkF+Ps3NRI3f4yRfUjgThZofNcJAoea8sPowtZUUTGqlrgeDXC4tQbOUs9Id26zy6ZZCZe48JrVCaTAv74qGXxTr5wW+xA+3hjhcSjEBuBvDiONurIcbGnx82/NGOMyP4whvlNBWKlHvWODdXFDHpx+Gm/G4evyOCUN+7oOa1DEsz3QfEeaBf3WhJnX8ufbz1mzezQGnM+PV8bRNu+cyzhXqyU4h+LkSp8UEx0wjvrp3CDuA/4yEdRA+XvsLol/Mg/1+dCyf9ser9jvLDHxdMw72Jt1HhIw3q8GWnZsR+bHsy2UhEe5+c/ePAauhv7mLIo2TUMokj1PZceK08gpZXpUVhG8HQRwsa/2QsCFipaYIQXln5LCGnzFyim+AtZZCeF/DbQx5I0J/bnu4k77qfXuZl43PG6r2WuU9ym1lLaC80FIEiS1pQYO5U3irmfQhWEK7EwSnBQ3GB5N1rHtBkHe1oMF4YTK9FCZIRzIJ1e0b4SNViaIWNJg7hbdkMiKJVemgBQ3GB5NSBg3wtk59ElB9BNo+7TntBW0TOU/0d6L6Q9unPUea4NQbWQaq6eQauW/kc2pTxEGp7h/iXEn1Z9D2ac9pL5Am4rsT1d/aPu050kRK7qTvA6UJmaT+/5dc7VMvqJ2kKb0dfFts/NZFcrPxpgtkVB2VEQZvjEhgOqJRVfljYEN+6KJP5h2wAEsBYAn/N96T29/5d75PZ7AHAgDOyGWtPcQzX3Ct4WTO/vz0Key54jia4BGjxQh3+LkYBeOghgGOgPjdtu4EcQ+p186n6n51njqLXqf0Pi3Dfqruz5+FDOT0WwegIW5WCnJ2VhwBenXDfc2vnHlI54uWlojq/lCgs/CBtQSo+xlNIaCHK6wX4z9DgM36Xx2zbgClwjVe5fawWf8zsiHAC72bA/h7L5M/A9l8b3cXyCqFHpBfGutrCSl7zgiCOrblDewPwQdDYASBZU0RU+J9Dmzfy12dAU7L5E2g6x9HYTUc7NjtbSYrevJ218Sq3kCXCd/vIay8cF2/Q57LXcoipvmiMXpJMt3mhu8wkAsbBgGG+R+tNYnlYbK/nIAdB/j6+UY5AN/8mzqTWZc1W1Y6YDkMQMAib3+B8VWkZPUHcfs6yQpkDBTgD+APkE1wZDeeXkBWL8KxHUU/Q+8ZT2y4Yrv/eQpKfagSTkZWoUk4pswmsD5k9SGoD019MOqDWh+WnmANpM1VoeAJhUyrqOXSFOVn4kY/is4lrisobSvSbqe0Ogeu8fmunB4gq5HlLYmdXp689AwW1lt6JrPKcpgzXBoYlRHbffhaSfToJ7q1xNdBSNVQkktpZkObSL2J3yySs180FlZnPXkNt7bkN13JupMaDrMSPP5l9r0iDQNPwj2jEeuJ8vpMT29L2pO9P4GScpIurz2/EjkANs9/xOQ5EblOagqIjZT+FNCI5mqwt2KAW1dhDZEtJa11+xoxr2/bCABRVkErogMG46e92MeO3ERZSxaR5kY8657EjPB0OcJoqevLN5p60KyEVQSEwwY6GkCHhPh8S7r8TvGIsQycJkSnA9dDANCmS7uLCCgNaR8lOWpiCwioXXoOSfI7Rc+o4LFGOmzvXyGKwzvz9N2YcPUoDWi1pAQyI9lRE9QOc49/i8b3SMfuvvC/7pHlZRkca1oA5mq4CYXQC91wZK9X3sxQRvD2iUDXlZVIyPlxgx/gx3UvxzzImDwjyW4oD8oFE1o3hy0iup1IuxZ0CLmUIm1sma8omBWTZDuUeciZDislUFIPLTZSMhVW6kmvo8ZBCyC2Y/vRYLakyC0AvAuT0S84B0O0OaC3fzYIyApww7PDQdzkKE9cw9l6ZlclJX+E2Ocvf2f8Q2L8/AsxsfmXIGSmf6mofHj2qyHmP7CQRSCAc0HJjyBa6scI9YkfS+KyH4cRsh8vNrV+P9QsuTZDCfM1Ku06TNOlUb0GPVB8PJkkUAZKFmiz0SWDU29coUULtFN2v43aCbVG33CaUYMDzqOIBzJBeW7Wauvq+LiAwEC0+19qYtDmBbFrUWsqlEulNt2giithb6mdiroq27oBTlWrXq8WlbrAxTuWBNgbB19OjaGYUM0hVpNd05S9d+PntIUBbA+Jxa6+7A7WRCu0dziGInnmBC3arVG7Niiy4FQgLxcBhw/cuae4GCzvvYMUF1dWL5LsYJLTfroFZynXV4/LRssMTmQRfKOidHdjy9kKim1aM0B5HtvcicycWQEgUVWhKx6NElSOssSZFaXglKUQ05WassTZUCnSUWWgoWNgYmHj4O5EYRh4TVlExoGHniefnIKSipqGlo6egVGRDVj+m2Nj5+Dk4ubhVcCnUJFiJUqVKVehMljYbYGFvrLRuEVWWuZdB+0JDpb6wXzrPPPcCpsMOO22v2xzyEsvvLLLURec854q1VarcUmt8y665rIrrnqqzreuu+F99f60xi03jWrwi98s0aRRs1Yt2uzQrlOHLt169egzxYSpppum30wzHLPTbLPMMddngG3JN5U7YY3GZN+TWbbjer4+cs9Dj5D7Hnht0fVo/kbUnsVgtjwWuz8SuTuRxMvHLyAoJCwiKibOkZCUkpaRlZNXUFRSVlFVU9fQxDUr621r5PGqy/BmMx5Rb82fK4lqa0G1qtbUhtpUuyN6DfWGwY9BGIxPdZrMgU25yGT2aog0WFy4xddzKlt6ePxOdDY6nLp6qa2ypw6rGlZbalvtqN0Rvc26VbWm1tWG2lRbalvtqN1X7ak1jbWXZZ9RWd3bUxtrf0KFzWtDrdYHAy4I2tPYUlP70gd6fg5lUB3C4Q6H7rCLPoYeVIvHm4GnqOAxVvC8ctcd2RE9Se+NgDWiuiSaR8UzYnIBAA==) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local(IBM Plex Sans Bold), local(IBMPlexSans-Bold), url(data:font/woff2;base64,d09GMgABAAAAADnsAA4AAAAAlaQAADmTAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnob+hochkAGYACEKhEQCoGHMOozC4QUAAE2AiQDiCQEIAWFOAeIJhschCfEUx08ue4EtFSZ9Z26kQhh44CAiCfB//9/TVBjDOHNA1BtyxARFgqHS4sirWtV05bsLI7LSGOXz/aBNY8HT5etK18sRQykwpZiBMWV8fOLteq49pG44xh40UsxcBXp3n4sGEiHPzzyL7nm3+4o9DdVIzYaFAgmwLY6rseYKFzhq2QPX31n6FfFl5OdgW0jf5KTl6eH/R7zzNyfnwUCVoCOPbBRy21t2SeqrFq3VfQOYG7dksxtbIwxxlgk9KhFsWbAYIDEyBCjESmxJyJmoWID2m8GxqfVfBr1jG77PcE6JV00IqFnUr+Cb5m5uqcrXVNTu6ZM6QhpGyc1x8A252HWYZ9BhHWQwzrog/4PXdC9TT1r8Jt9V/Mv9iSYigrWIJhNYhJPYTqfgDc1ykzs+geVLOYksEAW6Jkznyavq2sEwtgKWyHcENjud6PpJKBEMk4w5i62JtusZO+XzP5M9VQKJya/+/zXnULr4F0xSj2A//9r6R14CzfwkvQVpvALNEWYblQR1Z6pRlLb49e4Crdgq1AJoiVI0gD/cAYhILt/Z/egB+IDbIrApVDFVZd0TfoPMEQHAAoA9P/T+fneyF64V7OudoNttkqV1MAV0Jt5svVjfVZOHAapHbUh4I7rZP/e1LTF4+cahKjT8PuGCpH0DC5V4sjTL5WiU+py/Pv+Yhe7fz/BIJ4OWNM8HxSI4yWSCsQdFLCLO2GX5JmUMpyiQnKK5J1SpJXCSU4hdKly5Vw0zp1Kty5KVWVw6dJFU7jp3TmrLNPJbiDpieKo4LDrv9fMRB0v0wE7GKHzOWqia4XYI2XMPemjly07932vo6pqVEVFRERE1bhlbD5TxSRKJWr/H2QBtgGe0gjJA1UiBCkNBJ08CK36IPRbB2GjIQgjTkI47SyEy25CeeklhFdeQXrtNYRvPjhohAOg4ohwBAQ0UCDNX21tJddk6Esu05gB//CUxmqgP95YUgXRzxQ214IUGrCMKxC2P/LpRxtrwX2RvIPBFwhAISChOPJHggRWSFuU747n3ARoIKf+nH+SnfkNIDYOQgNXW2+nIdeNelJgSOlJb1ZnY7ZnY0llVdChnhnP9AxpYkc+hjk8/9nP15UrmrEypKdxF4HZuHZZ5zmeAOgc9HYMHsPDiDFKjC59LOZiZmLaMFsxFzFPsGRsErYa2409iD2P/Q37vwPVIcmh3KHdC8GXlBRTgYQpoLqDxFx3JKjCqdmjbg9PwIqaqEkojU1ZGXB6e3ztZF8Va6XVniW+RdqZTqorZ4FYJDzl9qyRD01Sc32wOXKyu25FirE09Ip4TZSBf06d8w39Ry2qQ3QLeqF+lUHBsDWjgnHeQmyxYCnkqzF1xlPunKdOuQ8GWicfmauwOZVkCiUnW3ErkSZeodeo3ANfqBkWoSGapl5etNEYRIhKBFRDLgqUEwNrYnWxIXppYy6ZZJ4rbaIeoTYCcIJDY1avnrkl1OuuoKb7TeyVaBhUDAgeAnilAg8eAvg6z6+FwmXyZZvSmDS3i65o2ipx9kuJI5pFGgxrxxqg07SPBmgBlrAzWTz1gdFPlowkp8DcQsVAyrxHgQpVM6/uFN888Acc8rG5RJI6GXjGcdRoSggRKBgYGBAMDBgYGBgQuC9aLFtSQkVhbRZ8WoxR88WQYLqbfgEIqFR2QXPMk0CEmrEKPbfIKJPZP1HJb3SrVafDVj6hUHrii+vUglmWBhGiW4CmaJm5KptZp/dQoZGG3CIRbbZcgPt0Uq2yNuEllrpiuPjq2AJazKxl2kq+AE4y9DWPIs+S1iuG11CCN/AFvsF/aHDmYwkwQ9Mup8f0YWANNYxgDAvWImBpZnGMkzQ9wcxz3lphF2LrYAcO1h3kdVRpRKyKKHovlSN5YEqUksVFgzSYuz3P2oI5RuxUMlpGF7G1nAsbOlkKlvS/hmzJGQVrqRMWpdWtWaJrTO3TFbfGuJSSBx3c3snUXE/wCn1qqpWwrFiSdYLW42ukJrrcW9kf+ipVWtmNtYZJuxvZmTfQjOoxHqtPL42Sgl1uAYF0rQlA02bMjQuJJSuciAboSZnAq1oeOtrJlVdzB4ohGg2EOe3lI3501s2KGCBLLa1BZqZI6rQ4AbOWMXbNIeWgwe3XyXjmUb1x05RSoGRaW8AOxFNOgghzPcRqZTcOhv8KuuO5JJ+pXHijCBUmXAQWNg4BoUgxYsWJl0AkkZiKVjarYvWaTTTNHAststgSS9kt12uFPv1WWW2NtdZZb4NB++x3x6h77nvkibfeeW/Mn/6SZEXVdIfT5Ya2y4cGW3+9zUJ0YaBEUbppmdXVJmnntf2U5fmorlFCjxj3rjWYKGFHHaSRsDKGRQM7oCc/4EYAsy15GN74LMFtRQJ0mw1aQVO4y5aLdNFe9uQ83A9QnFBqNkAP4qxVW9tVAgFI6/AROYYlci1eMScdg6pE2f9uoQMdD4QDXyxD8ZePkvyZw4jlYcDWgYhTsxA/E2/ez8CGQFMfiHj4NWycbJSI37sHwcr18QsIpQASzHxe+BGfNuAI2V2TFUkmeo+PQsv5Z4/ZMkjMJYFfcWI+FHwgMAWaSx0GrSviYdZaCWoy+fUFPjTUKDgktjAi3pzBy0Db3qmRHGsIAeycNDxwnDKYx0XVaIi6XJ5WENnhI10VFZOujIRpVE5A/FYHH4fpkl0aywrWvBPXpmQd6qoot7FBw8s1zj8cm6fUiytkAGcvY3ybwYkm1cZUGEOxlgGkhmmwUkEoacVVsTefbLf6aBOwcvyj8tUaoeAstyIzJF4f+QZUFHsOHqBVcALrbI4CzryXeowAYEJtsIFA7+LeNhzgMBQJFTcgyNzhQpUSg+y0kFpIoFxV0lRjMYQ5i0OnZb6V4qsXfxMmgRxuGcwNYcCbD02I0tOmDH+OGY+zBEF30EO6i7yiqkQT1pd8DquSJZjtYjAT6k9Adbh8AuGcg192b3INgmK6uYBv7kTBF4B3CYAIDSei6vOx7XCSq8CR2i2bRZWFhDDbmZWXvpK+t7tjbO5FekQzRBJZY7l4V6bFU0Gyl2n5wSYS1dQST8e5AQd6SqWOSkkPaCK5Tg/AGXXCsOV29Sg1hxFUVmM10B1Uej8tOZGaf03I4StVmUTDLKpzaEiAphVoRJEa6lToptIgVQ1TzRQtukBLLtGyW9T2gMY8oQVPadYzGvSGrvSWBt5RtUs99mnOB1r1kbp8oimfacIXavlKc9/o1Hda+EEHftKuXzTxmzp/aMtf2vCPav8PnhE0R/yQ8hevvOAh8AFXlEIDJADlPmSZPUpiYZqlQP5URwZKAAR+0oJCgiQF5IVBUUREEIRERKliQAO6+Bj/7BFwA4/tJZWlVii+1SegZIFoIg4JhYfvACkQDSp5BLPJ15WxlNOBnoLE0AAFj/CypRc5EPx2XLeU3IOZcxRS+Ng15gbMyivebdCwqT0X99jl31zp+NhC8FUmJXXKZ/salupp9Y1ckBZlov1QSPxEVxZUCNYmE2nFKlneHDI+uFeK9SqfGJblfFaCUKXc9lwlYFgrBYg2ZgtdSbT+jgscXTOZuRfTR/sv90Oms43QtC1qJEV/AxS91D5/gNdRT+gR/8aIDtRsBgYNoGDRrOtTTAi7iOw81T6ZwOIaAK0XiTi+zTHHQpv7ci61GYguHYtT3VHfYhY9hS58PU7DgaxLJdRryNveCW94BEwiM42E5Ox4XwxsUpWI7WJ8UZ++rFmJFG+p46FVecGzq6AIbJdnjab8m8vwG0csnUyOQeKOF/lRYV7+ww5NCVPEk4/APOXor0yPpBpF7CumHdW1b6bJwUVYeDC8XbSA6bJqNNGr6ENxtlv6I83atfgj1U68NmNuaPlDvVUt4M6lwjdr4RTHYwwi2wc4CyuaTNnJA27rDStvrR7bkSxLFNHun7VagbFBmsGh1gMutrz1NfDZgPDpzcx+1wHTZrZEfWC3AoSlHRUSWQFzBPK/+eTigtipMZfiLUccZIqpjJMt9bcp4xRRa6U7dIEwZP7NirLce7VNAtJtmc9fa/iV4DZ4CF64PhD8cpJ4NQaNWqgW5rRiOVBcdshpNPfNQiJnH1Sm6XffuhCBvke55ZCZZCJVicFknV/VmeCM/a5AP/Dv7orp9r3ChhztkS3ehtCBy3mPqcuoKWFfjoqXOULSE8BOmSnL6/hE3/6RN99zhS4bTqNaMSDtE0WOS6aucbjLgq8JlQePU7ytm4twM/R92s02CMjNnBBZEdQ79DUmhZo3dtRtVkVP6uW0nToIeKYZO2hhwaspKsb1Zj/AOiWbon6+9w60oHEcLHvLzgJNpaVKCFYbfA7wi5RlW8Njo6CyG5bY+LMOUPVQPLlIsc6WgFtUjT/C8rYBsXMr2pSLjZaMwtI1ooj9iLigJ6M0YCeqff+Wu2w/OMdI9JNtogbsRHF4SS+QRWGkEt4mDpWDSpHBIfqRiwrGS0iJGI6IQk89oRDwT4tGDdxNsDA9kkMnBB3CWJppe+pRbX0FiA5v22xJ1OAhtsWCCr8Pi9DP2V3eTHdV3xOgjymYjl0cwMzaMD9wwPW9Es0F+LYo+cal8+Fo2U6aXMmWAvu4MbexlijwgTlC0qgglmVe94DS6cW3UalzuxEY6F+UWB8CnCbOebb1fvUG3KRB7g6QcoXNRraC9qQDSmtWusATk3sfvd/vrM3f0Cx42oSsIww71LaSCa0XmhhqajGgAK8P+QjW0UrhI3RQmf+F3e5Fc/qqyFyBb8yGcrDibxvmCqjExhLgf3g1bcorXHUNbKmAe9kEU2IfKELB/8q0BFYdr7eXEmtqaoihBPvViohiuHCYokoqEAAXibQBCwXb8aNFYe0McxFZU4BJMU6vgIGRkr+w3iV0sC5UK6IOiiwwUQN4eeqVE1t6tp7oHhSYJK6oeCdHsbzvAj0V8EETlIiyJe4AaSNapPhpY08MghSMwMGobSt4EI7gFlrikotykwDv41MaAMz87TsYLI/cSK0Ir1m3yGFynC1gjx5NseiAdhrzJKDmfI96Jlf5rlGhqrJYIS3wI8IQKzLgbJYFXoPWDkE1wL/AiSUT7wWO9nrZuexJJtKVsH3v7mRqkYsVEggQSt47qFrhalGB1cUlJAGk7t/PtIysHMiDgiK+fwchSKBQaWw6g8liszkEg4ubhxf4gF9AVh6EeERIRIlND4NUHFJyd6uAuEJSFH26w+bEweH9tu4n+BkiFCA0+q64oPrjSgCAEQL0EziHjkP9rNnGAZNMZRjLxVVtqOv3T7chliluthqHC0AHyIJRXVq0alHWqUu3Hl16TZvWYkaraRM0Y3J0TYbKmKEBKHZJjRTMnN4hnBqHoHmrH4ZSBaLDcRg29fAdUDYabVG6cQWz2QaWYyltACwFwyVlhZKkKlGK7xooBKFoHAReEm4/O5X1gAKfmCivkLy6tAS/doMiPIKkgJISqKgRGhpULdppunSx9BhgCzZePA8iiTxJyXlTsvCTIwdNrjzhWi0Vwa5PvH7rJNtoiMxUvvPZbb/9dZe/kRCuD0DHwapuEZRIcsxOFu+qeEHA0HOLKkQyN4nFCnOio1N8OK33EoajW50r8nWXQ7flXX4gEShTPDLwMGdnny4hUKHz85j+Z0WyZ07/oUYypOZjERmIQgR3gfq+79kRI4RWLfmC9EWtpcLNcaEAaz5YtTnbxbmERiSE1yGKRfR/3OKlmXhoCkyD99MQfkHHufwmOBxh5RVH0kqSZBmEyhJgHZGWKk1WBY/+RzyxpBiNRrDZBDc3wcvL4OOj8fMzjBmju+oq3V13Ke67T/PCC6o58zQLFpgWLbIsWWJYtsy0YoVl1SrDunWGDZuELVsU27apduyQjh2TBM1vfQAAOQA5oOmjQRx69UIrOIoby8UpLtT1+/c6TahSeKikjDei9//yriuJA8gC6NFD18/QI6mswseUYEk62ic6fVnpVrcc28u51buhpICoOw5u1YcvQUkxqivgCkXNLl3l41pwNunmqPIl6FuYV6BlLmjX3Qjqxv8fQ1xJFnSpa9empglCYqIC/CLCIEhI0djcvHz80jLGXHXXfS/Mmbdg0ZJlK1at27Bpy7Ydx0Tyc4dI1aTbVm2L+Xjmjb90b0iEI8Id4Rt8yKGFFUFikxRp1DEkM7kpSnlq05ypmZ329GRp+rI2m7MzgzmcYzmTi7me0fySR3mRd/knn/N/0UhnpGf9G1RK6eU0svFNqbyammppfm2tbH1bOr2t7ezC2tvf9d3age7vUE/0bC/3Zu/1tz7pq471v34dQK1RrijvCRzSUIcxvIke0YhHOboxQyQdSAqBRA8kEiBJABIRkOQBSSUQD4AEgKQUSEhAshJIKoCkBEikQGIGkmggoQKJFUhkQPISSIzdEy5xI4kCSyS0itBhJwSHI4uIlOwtO1M0KrjSWl/IcxJO3MQWIoFkkKBGmJ511tszPyD8gGimXF5sHSuRbFM3Mrg1CDvDojFhO1o6CHHrhCuDZge1FVzQdaDcUAmBU6/rnrMKThqNYDomITI+gNbYiaubRIPs9ne7NDsNMRlxUqHTziqDgHATAlhDAKSRuQdRNVdxmk01W7seS/VZa7OdBh12zBkXXTfqF4+88M4/Tn9ohDPCM/4JCiX0cBKZ+KREHk1MsSQ/tlSmPi2ZntZ0ZmHs6c/6bM1A9mcoJ3IWIukdgUghkWIiIQkkipRWVa7lwahw5bWsdAJSQUrCpRyJJlRiJTLystwoEC51RQYJbyoLpqxFG4H97LTFZcEkgiOJVaG1HomvIOHCDWQLCSQeVajRnecHUZKS8kFDkmgF64hAXEfKXzZelwyQk8KTEyVQnlcQtTREepmCWW4r9e3UhW0pKFd/U57tduAbaSp0xlmRXtIYr38XPxYSymU3gP/4sKARDuDEDTgNOAe4CLgCuA64BbgLeAB4DHgGeAl4GXgTAnSfbGv8cJq2Mtn5V0gTHpFGLWQtkffWGKJ6g//YX+Urxz78cE090B6prasBzpfrPxeIfKairBBEz02saQTxq++5L6LXc1Lw2u6pCEi9I4HKrhvYkq8gVBzRksjp5EIAYZhQM+zCarRRkFcx9RV09V8dgYqmq5CjTH36IhDLzUasD+AV8oEUxMVDb03TbKJHnu3Gra7OWxAwEBisvtW7BQTnOmtaLX87AbiyHhKgb7S/3YDCc7ZDfHAOgn/wvd4QHL2FV0Jjo1cFgSLfcBRH7nz9gFzzHXLZN8gVCAjXobRSgXZPC0ENCXlsL6V829BslbYSAsknC52j37x4jOGnZH4qJXgSJIjPhE2T/ETMc0h0Xm6dKV/Jv6ocGj5Iz028wDAILMIBELyoaWiDCLsx0Ts/f9KoHoMBfb8W4Or8VjX3sZUAurUjCoNEAXJmg8eBowFw5ZOWjCCDg3ZFuY5Tw1ohED4HAOIrQLdFjgAHQAIDDLAPBCCHQEEA+0DHEcBRyNCcgW3NNI44Mek91vP9bZxQoQfQyEJyPFlKbiYPhFBCllH8xsfBtsjWx4+pR2foLwPTfcgCchxdQvH+GZrlw316z9wly5//o/8DwP8+wJ/eHm08mn/0/ajzMAQQux7PXkjAca7pFTTAr4HfuOwK8HvXAPijG9eldejXqCVMdKrd5GeDzZ4Cf/Mc4B8ga4AAkAKoXQcJmBUG67DsGWMpNMbyqP6pXFoIJZQaRgunRzCYLDaHy+MLhJFR0TGxcfEJosSk5JRUsUQqkyuUKnWaRqvTG4ymdHNGZpYlO8eam5c/oaAQ2ju65i+7Pn1rN23cvHXLth27dg7s3rtncN+BQwcPDx05dvT4CWi0Pfrkpskb6qv+0lLpuR+awOOTwDPTvY7MKa6FZ2dsLmqdt+Kn41u3792/MzrsNDx8/PsfAF65+wDaeuYu6F60eMnC5b1gX71m1ZmzSw3g11MXDxAUJpuP9jMAUQCQDWJCcCF2QTmQG4AEAC/2UmODkUZ5c6g9dbNL4EkO6wOlWzdQI9MVzcnyqRAelkSPwZWySqa2bNddag+6SmizxLoxhvfvKGR0dDdN94t1PawbktEsDkaEUrNpxuUbYbtpeMXrDCaPAiDZxlApeHpuaFGWqS9Afrzp3WHRpxmSoa8GdIe/uiaitb3Eejv3vqLMGZjaOjO70tFGWquh2xnQdxV747RNfidrhLE+ZlYLrKhPvgoNG5/n2S/3IYZNyZbe9FkHviUZ4qDvZIjUCN6ju0YrsOc9O8zw8k1jcvtx5v6aEmRDqYpoJjTzAiqwSQIhhAil4DDXeZriRJY0OT1H0ZkmWXeevrt2QCex4yeOCTGm2JHUtyvrVCL/DDMEXymlsaJCHTU8KWCD/A7Wj4B/19JqBXPQ+pKf9Iw15LtmZ7wJ4WjTSvnDHLQ9vUv+N8FAHsl6EDrVJz8Z2S75QcMb3r4qY9rxNKyHmjioI28yVBiwwfnnMPfdjwRtVrLmebVY/fMsuyTs2JhJRtwgl2zUpHm7mABfNiS0LvzUVTb+okEdxcdTf+axDUo8qxja0W4GDZMQIIPprT9bqPs0kNYevNemeiyKv5nWRmeaMWWaJ5shu0IZERfiGlqKDECzi79ndXZcWqOk2Tuu4wk+uqMSZ8HAmd8kWFnBsnNGWdTqn2jcMtRxbi+Aim+HycnLdgqDmzCBgDlL76dYXSKKCmnIU3a4F2tQ/oF8hbx3obiHs9SMVlStc6cpUkyvODRqrT0DBbLLCo/Uxlc4KchCnxrJq04kk3oZIyM/izvFWlbWrN9Pg7SVnDyvCrdQk+y4fg+KOwg0ytYufVP/3R9Smq5r8g8GQyLLwNjIM6TzbzmSsWW/dvmpFxn+fOE1zdUOvqY+6Jn2YpIkpqNs82rcNeuB7Luu58FVVIyCPH8UE+WFhM47xMZn/4C8hmZxXhYWYSGO1rAgUkjIMOCrbZ0FObMmi5knM2M9Sy4XqqRnGDredgcadnFapeopEnJr58h9VARFBHYE2dthrydNpd9kFydCMEpzxTrrPWMqQOA8Si3fJuoVCvfgTYLIRq238UzioEJjQF8HzBlixRlMskGjICzYhIHEvS1T5Cav2kimNxk1KbqzWYJzzqI8ALOcQYwu2cq+sT2RdLFquhKejsAefHE4225IpRdcmcOCeq70SIgnheP+ri2R4dsa2bHHZEjGHt3slUwOA5P2KfsxwCB0JsFW822GOXQhXZj1ebBiaNc1ydxeK7W3t9xCGOhzwirDmgVWaNCu+LaXDavVjFz1JixOaF9rlP2YjlIwo+w8zsc2R6CcQ/vTdiaoJQs6TxZLsmjx0OocWm+mJnOnSQGh7E5hqChgg/CKgW90c2M9SEBk8wDgnsH9yMumal5WIRQ5qNL29w4vMrzPwiMmrpnpl9y3PFewXWovZ6ON9UkmT5cV6nj4DEq+0wLh3oC7Btf8nb/OwjHVrYFDOO7vB6tVZGh3Oh6Ocn5SoU/Xu6BdbBM8GkWEZ2dAF7Iz/HQxda8y5e4HAqrREx+POwOOzo/nPOKsw7h9IJ7l0cd5ZboRO/9sAhYLzjmjcE4h39nKyMYp4UzqdXuDHfb346MEA4cjeajziq8oq3XXaWi9lwNg8xXygXxmJUwRsCOVXMvO7UeC45Vrz2TAczu5EGptT0dlB7RbeU3kaTeIzHYVaCL7guvUQaENx2jsaBfp4P78vW2GDVLEna7BaD4IcoYZaOjoba226Ysvde5cPD5L7WHyWUklKYdQeURq1TMDwySpcxGcTjBKOsoj3ZTQRAcWjXTEkT1daY6TqnVLZFmo0L2i972vo+KryPsxPF30vncR2ONrkHYMh7ZcyjrZFpUeV6LR5tiqsK3lJ4ZMyGo4qKw2QoD6y9FoTRZmv7y0gPNG7XNd4xdjWMwlwHOToIWdnQyJsrf2VBnlX5dke2hPH0xJVsYe+wrUYoeV301+678TqM3vRBDQHQOhhrXl9t6qCLSAkYtIeKDYlQO6upQm5c9riREKH+J8m/VHlMWk2fOTSY3sue/BVtaHDMjZmSY3Mz/hDD2IkSVYKINP+pJ0bq1KPb3V5tIY84yWn5Jv8tNyILEICwYqyeAU2duEz7llP50L+BujSb4e3dNaY2gJJ4J7bmgKa97S7lGlXJXsAhvcykU5oNj5MRUJXYTmyV5ZBOmi1KTQw/hBuxTBMEz6eX2t/sH+/LxFtqydf0540m3vFbgOd9M25H/gIFfIdwrI89k6nxXc5GsxBhB0kz2luXsIBQIvL+bBIRxmoiB1MA7zJejRs66aFNZrsA3Hqa2tqtOO7eT0Np4EEMP7nikV8kVCoAWGxWFPvqFXcBTuViz/kZWpiRW/8JBBXhbme2wWZcBp1uuG1aZ4GI3OFyMc8ekBOzreGeDll/ROoWTL78Ow1fnNpuY/HQpbMQvPj2NRI6RNHqtKSObJezrcAyJNQghd7l7XaVgoaS9qnyFSFeUb5jYfy7IX/GO+K+HRcTp0zwyycSApE3HciYiW01UPHP/jeeXOYzWSy2BDfkuHI380S53fzJuKC6uaxrO++iF74D9bfZzczfTnkQF/B5pb8ClydrZj3Oe2J6OTqTL6Md8+ovzjq54CS88lvBwb8+6xiGWXgeF+7p6uVu+fQqbguzxl6tZewt0Uo6Q+h37Z/xnfighzk6jnDpPznhNs4F/B+UQyi3E267GnVwvjcjfrks8pD7P3kpO2sOQygar3A6hsZAT29f2V7/lj29nWf/nV7s6CSM2FmYZobB6tC/kWbWee16vVkw8V/A5M8Lxvocsl10A6Kn7/P4x3KSvV32eKrjY4HJdIIsnc+j9r2XhWq7fd/E9PDI/wwVahHmRecAVjUJ0fUXKN/QGTJbCn9S2zyz5h3ouyQU68VVTJcv0Adbb9UpLkAbvl0oyUhspPDdxEufvNl2TnSwx2cvhWh7lGKZ3aTirXkJdOwbeBI/gEQhWVZnb0skoBG8DkzE84Yejq54LrYXjtf/gS32B8RbOKfsEZTnHRkxlwIpa8o1g9CSk4eSqBT7voZrH7s/Z/UTQTclq3bqn34jjtYUYhDqNiY2cZMmpg28Wnnp3Z2CilxKPBvFwenkONchyPhx+ziHTqJW9hG/ZCaEEja+fqSEk63gFvG6k5vQ3fndhX2VNTVCT/jx1hs+MDGqVOJTp/yaUMJuRkf4JP21aOOcZ4RJI/5WnSLf24597c+wvuthb4TT/z3RzI2h8cro1rn6uw+Kb0Jsz5lUM4s/oMm0B+yZtPDiTP51WXhJqB9cSB/DZXkjMxaFdl4nDyiG1zWVjirvpJuQu+GHPTsGUx2dnGazLa8oP1/oWFKr2tuMA5vzH/cDYLk2P0CY7ZWhFgy9aq8+uKPQt2y4jcHHsW7YXYv29gbQQeDjwdbns6bIizWIuLiqzFlnphVga+jx3J7sMfjgRh1bDPZHgR65wXoYrPCjpIkjOoCm3UrT8PZV8LpFyt0eB4TKWv5S0tJCM3bLCq+YabwnvbtGSPE929B343E7QEtG/vE2o8CU3QUp4nrFq61meY4EwzgmSNvE0O1Bglfh67MTnPMN+gzr09Wz4v74Ze2ZOUnMdpxrcDK0YVmGCyNamnyxJz5slnZ1mebewNm2XzZwsn35fJZvYdjqY17FY6Hp/Tsj07YsfnNaOvTFq1Ad4mDe1o2TE0u3aloH87eyDUNzF+4n82Mj/lQthXom/oAES+WhyxOAPOmjnsal9A9npvmjaVNwdMl665x3ftkl31QZ0zRewsQ5thbRHd/2qE/CnHRp0WDE9Qb/31Rap9CoSPdd07cnFy+xZ/d98fy5y8cPqd3pJW/oGIlEcZhOi4rOALwRo2m6gSpEjitHNK1IDZEssgO9Dc2AwVY0VeVtwvaxWe7NgcXAqPImGEyBSfN2OfqyssVG5YmiyqMCghyuh39oZzbUalODpO2MrCMlMYcckzwNgunO1xYP8pS7OlXfXlaJgzOEUnuv/m2NcZNB7C1hL7QkyRUZQcaWoxNUWo9Tt48mt1Rvnn6OgaoSNvEj8i5eFUT1z3LuC6JBXSxEpKSbKK1SqvtWRdu/GjxKRO52UuaZ07T+MVwlSTykgGfjQ1W5oyITShWdAi9Ba2CE5rDLa+Tv5l1qwvY62PYoDpklRASo2iqFgSlfmRIyVFm0gnSU5Z8PHxnDwlWumJnTkUx0eZuRIWRZVnM4WJjQIdw5ehE1TvnC/kBYV7hgfxThXYg2rWHN7ukpu5YYpeIEWSjMW08TgOlCKyupDL3y93aPN7QVzRcrvl1svqQumyrrblXbmfHWhY82qlDqnjxLrTLlDDuW1TBAsCqzUEYWQG8S45jcMgSP4Znygl//n3Z8S6ybcn2BNKq6N6c60xK8tqlyXmZS6ItBVEd2dMtrVlRkuEEZiVhQJxVnlpaVa5mCGajZHVuQlYlAilNiiFUaKRVYalKOrZBhOjUUqTMuoN+nqm4vaDG/j2gOaAhXjqbqqUe+Abf8vry43c/3z42JNhMRejcVwPmuH0rIJCI10R+mg9Fld47z07Aq/8kEoKb1wxay+JTKJg5r3TV5C8SKRxV0Cpi6KBpbcw27J5jXfqcxu4isIZujBzq+TXzXESQ2Z6fbohUxIrFn2dpqDpZ2aCZthB1sDUZzJbs7KYRabGkTlg26XaNHO1+XmO0roB0I782iFZ5Nfut0LScfsoutERs8ip3YkEDrWYZqtMLypja7OZ8ywWdofJ2sRV5HcYaIZp8s+S2ERFutFSn5VuUgQF5cjwoa2zfObNhjGiM6lvpM/f2T9sAQRTci7mTNHcGPB8+C8eSXfYTIqO1BHmhiqqFhA8c+Qhr9l1o1MhmZtTc+bsh0qDLWpffXbgDWm8/wBoR/qEzh2QeQklKOn42PYhsgZ1a9HIhp1y5Hb5xpFFEKISz0fdWzSy9cR7XLC5yBrY+hxme3Y2s8hUmAw9SNou02Sby827FlnD2YF2RM3XkiuIJr6AaKwQ+fz932evpxRRWPy9XA/EI/lGVZqSWOfTun8N8Semb+q+Cv/YqqHDg573jaTxtMGV65kLFEkVnzq9dkwZr1me9fxIPAwcl9xZSaeLbXJ9eWwejfgRK3WsdSutsHBDteKYAlKSfhJ/r62kR06NFvqQqXWHpc5VnmVFVkFoujShhAx1AmGf8HiHdwf8NjygjlNKpT6+esC+WhtUn6oso6SlMYtMrRntavjz0XB/mS76F1TkL2W65U+G4eia4d5UHfU0inlao9uq1TEK28YX6xZvGN6dNSWkD0Xp23+YYclgL6CWwuaH5aOGfR1vUV1vN99Lh89eY9t3LvdDLvLbMrbNG2K9OrJ2KTo+d1h2FYKmq/VGuXy/vBy0wXg2fOrqOeI7H4Vt/5LXxV6omny2CojHp/01DZb/M1VUdDqLAZfoqRXY/cZIkT49XZY+2VCeHkKbzmVFOWRp/y+ITK+vK8x/wW8i5YTpqUnKrAQPYjxIn9q5mF26GKGtZH57e0mPDf+H2m7GWOz/VTEqBVZBJYNRTl1FLYdAlwQrLVEeXJKcHGxLVFjDEgyVCv+UScKa4XD2L4Iiwc9s+puNjXyculoG7VkYs109hrOV9LS3l8y3CXUxuzBc+zN7QRVeh0HlLx8Eu4jyaClycklyUrAtSWGlJaTmMuNV+IIoltExcrqIY+9SWen1bPURNoPvOOTE2wn5K9VN6iSNXqMtaKqwVTRV9NuBEca4kcqq9jdI8z33DBBZ/LsumSaKn/vWRB/0B7ZGaKgtaIxU+TLaaOm1zdi7TI1QX5vfKOyvJficpfQVZOq7cwNi2AdXdroS8SKRCL+wgbU51DV0M6uKs3XtedgHsoQko6nKprInCv+K8A7c9N3HbIeFUnYn2Z/cyd5+P1ti7G52kLraZXKZSqdr0qlWDkOc749D2JSC8umb91w8Ixmc+Huqym6HBxq5Sm62N4ibQOZmz8b+LIlPiE6LQqFKzq/ikTQG5v1sypCMcHN9gOerue98zGP8+RsXcC7xOWFJipCS5GRuTZIrOx6tyCOKwrhm1gdBleADq4qCD2Wxhwi5ubCEJa6z2O82FyKXn4ONmKhYj9vB+O6w1MccIXx00ZTxejKzTkhCmSx8QJi8fdCvh3Zdow7kRrxBLxSYMzvfhdA++fqV/rdtwL+DNr7HhIMfWp02DaFuCiPlEjLnLSxvKg8vaIKpWZji4gQPstFUaVPbE3k+EV64pd98MhZh8KFdrktT7vCOO7Zzku70HJ49eLsuEtwJXYeOWJdwp0N0hyEY2Jvxuha7rkr+ndqBCu3Yfxb1gfeA807E9sLN6PzNq3dj92C223aiC3bCPNfuS3kiZZw0t6kYdyR8mea/sBVY2goIn4imfm/a3owJc2uC0a6IJv4VVjWjgVHNusxviqgpl90PdN6XKUFLMvc5B96XlUNXV+vMVlj7aUK5XH1F/QDufdfr7oQ1wm5BcIBrHi8d9y8f+TUB48AZNiGZQzij9UvEn43vGqryvEq6ampKu3M9q2orL2mTJ1TELX9aLuyjHi6PrzOlvKrcrKI7fud9d6SDuNNwjemdVDdZ3LwWz6GkpUZZg+KMjaJpNZoDa6l8Ade33nB2ci/W1RH/oHbzeSfdbIirpEk81uRYDfqcnI863cecHNFqXdMbDq27MKySEy6MFYZzquPAwrZ5K+dtz9ku5dXXbhcNdHkjO7037RbVduRB1+KymWUz8Lf3BLx0jRjv0QfwIsuCtymyVn4PjwgODlp7ReO7ah3tjT9TqCj1okVIuRH/d+v9uNGlpCHl8KxXWTQGGb/mjouj38ZaPM/BehH/9Uear+8oih6A+yLOrwHTiAqA41lsKh6Hp7Ivwb3IcWG+i2YW35onbDObmUWmwjTos0lLFhXTlTL6hFhpDL3gyZ6OqGVuQYw0tovbccRGvoaURdDx+ZzMEufAV2UlCoq5w8khIZkhBnxkhSy+aONsffXwNNhVItxOKXppa4TwVWScMUoX6xNyMpTceachWEMTKU0S2cbwn0xJTHffM4H4ODwLVml3lLc8DoaXEQwVqZSUxmJxstSCDOSgtSRTczOFTNmNMpFea7I05VYpI4uE4zkwlLLvAQuDAhwCgnBRsPSeoEwAb7ThEoI3QRJBJ0i9XYTvG6X0CIJkGVo+bZROH6XVJoC3R7btmLRjy+wt4XNwG/3IpNuTIFUZYqk2sdv+KXRB+F5zx3WnWsg/a2KSpapkAT7inwXW9fugl02Y5YJ2L/H32/LfL2tTg6MUuhh26KWn6IyjocLMeHmqjJmUFrc1nxSwxRvpRSIEmyBBnMUoOj1VBNILd+3JPC+6t9PGCHzx3ewWzMV+NjG8AUPsyIe/USwNpZusZ7M52S0GsWZWip/XPC9CBdg/+pPznoy7Ezlw/f4qCPCZ74a1Ol8sTPUrk3iZhfubXEl7w/BG2WfgKfV5t7Eik5hrbuylGPXwQJKRV2KxQGbUC81aioURz7BQDscB1FCUuUwO7SmlI7gKeHqI6/5YH9pyS7ulzzyc2CFd5N/uv0La8au/YLqL3RVKkwDp88/IzOsWNRQnzSvuJm70bBtcA22XBOaD7iVGI3ueLxRsLubUkEitNV6UzQqblV6e+bZ+Zb/zuQf+KETzlYY8i6AJQeY4k/fzteRKopHPZ7sS/m2vzfFjvX+AGSThynHM5LzQ8+kZlZ+IBNcg/BvGa16COFGk0ovdkfG2mBhbvI+9X92kRkdSTeK4PGJsrJWYGhNqiiyM5ZrxgaNfXxsSpeD2iP6e6J6oCNVTxZpMJ95OdnHQ23KNcy6zWPi+KdOq4tOwzeeuPIygn1+ppDDch02+/HQ8FPrRw1NT2rETM0PjUq3MWBWuIIplchS+hcBAUHNSlGUyJWL+F1o9CxbUgaNPBPjjoJKpUGtGajTUGrEsNyQusYAqllAKk2IJOcIUJYUdmxY5vehhbGanJZKp52j1wt4nFxqHTLzWhbzpcdFx03nV8wPxx5ZbLS9/4U4OCgyazN2M5XQ07x9+FpvoktJUf2ZpcxIU+gRJekRqWdslo4k99ybITy7hcKOL1p9qj5u47mQ77dAX/vnnfUznr6AbPMjYQvk36JZMu2G+q1BNTaDvs9uIUu2b7Y4NuPIyY/aD66t2ZUolklz6X1iBiZYcn0NLUoaUJs+as6g5zkxpeQtZZ54dJpKRihJZJsfIgcQycA0BKzlET3LnhGVczFh+YsZpqb8LSQ+vXQsx99aA/ybC3LXKuMmNxAITZw1MdrB5oi042DbRHIwoJKlx/YGUwH7c5buHSZYAZrhF5Ou16rtQgm+mI68dOMylLAqypq/0IAaLF+xTU+jWqXCVHYnH4yPZ234Q+u9k9ORa5OwP7bIj7M5gP6LzuZmFeW7vD314gMcFd8KK950/Cf2HORVkf+KXszXGAuKPQ5hLeH9yBdxbzlgm8AiiBnkIljGaloDQ7MQJ7e0M8JA3vG7mXIZ1UitlgN9TZYe8qwc+eA5Xt2sADivlWzPsd5secjQceSHSQV+fBcUu0nqewcqcl5nBbI9M/bonFSh9DVUfqnWZ7SyeOvH5i5wx6VjOiweqeEEG11ytf9GzSeMHOX3PJIm/JoqfFYTkRFdioyrNIYoJDnlozWLtYrRj3gQYvKfXH7XyUPq1U9ei9DzrUb1+bAxuP+lEez7yt1uA+huEo5buKU75RoPoY3GfivKxI+aS3eu/oEfvZu8/WkP6wPlCcDTrii6vDjDS0xrTgv/tx++b1DhpIwyJjbpiq/UzksYIRRMWG9KJIaGaUDKRSL7cKoVAZNERbAlmj18E7qF7QlCCUaNLkjFJqrhDXCJ+lT/ap9ff75HM5Ox+B2C/OM1glNACxVPYixdphDnGtcYmaTgvNTEqwaRWqvkcZxYvYKufMwcMymnkUknmspDMZjwMipX6BF7Iajp6WEFmymNlMkUsk6wYRtN7Qnj6BMXjgGJPR6/iAP8mL0fPJr8VxzXOnu0B6dtjQxqDco/qYPKITyVJvWkG46rcw5uFL+A4s2AII3UYPzeOUJz2N+h/RhBuw8IZ93qjvZ4QKEMcseajYgZO28msZVvBBIzysA0wQZW7DMXeM2xLj7+BnX7T0YpON8T+SL0eOscJtWCUjT/gOlrxklf1simCMgHj/PQIT/pyfneEj3/W6Ex4eg2sy6nYfk9DBf9Nx85zt8b1hlUBlIBVfO8LB4e5P52rPuewaaYjuxzN2WV2/BL7XdznjeS2mF0C14R4brp54vlf/FNDmTU/PZgm1kuAJy2+ApwBNrY/tkm9toJGL86pa+5BfwcMA/8GdlqDZx39AzCIvxNM6z0cHlYm3r0PvZ3670CZKPNrIk8iOwH1+dYIRDinBhVy+/C/arwWgSL07SE81KBC1sJ4FesuEIjdalAhYzDuruGNaYdvqOohBBiFiEtqUCG3D/+TcScWZVyoQYWshXEhAgWcKuk+IPkEULeoL6gvqSvJRaLcnuRH3aK+QCrhzKlsBMm1mTRvaX5BqXSMlqoQ0yjJN6lb1BfUl0glsWxP8qduUV8glSR3ey1fkUqck8y/KVdalEtKA6l0D4M77NQ73pJRZZTcVe4Kr2P4VK+EuV5NE8WvxIJ4fCp6fz4EK7AGgA0cfnX++Lrzkx8up3xR2wsAXNLa7Ogz2vvBt0CcpSY/exp+vudPUV6XnykEOlbHgY5gTuoI4CJANxzZU3zvVz+ZW8oxZZGymL6nvVtHzC3lWN/FBCBv9g1AgPVZrpEA8tFAB9APO1JX984sWn/5b31epBwziC6mghoPKMcYGp1A3wZKJcLwUE2Y0jH5J6gGtZI7iodqQh7yz+UrYBMaZCCHzbBcB7lphuU2yHUoZ7trx+qSnuaVVxMMaG4lAzw8UjVBg4tdYnU4MT3DUlUJVdsyDFhxTpJmO7mxpbz1+ncfYPmj/qekDOXfPkPNmfzcMbRlfn51hOR+OEl2oCYnlzqyYJB3OwIBjLkv+fnnVyP6t3ZBvQJsfhdmAfCn3+RTty4LawZXZRAcIQECVvn/X2D+sbgsLjMIYdfpZkvEA2SAfzZvklxA0XvSTebSbOS5TtBbBHEFaSZhMS3/yhPWQlI0apaJikylr0L1rGC3Qh0Y4AkkyeEhBug5StS0jAnKbEm6hP1nnA6J3c23q2g3n6DD0ZrgoLJu6MhoW4OW48J1qNfgTXuEKMd2WS4m2Hhj1aNVidDDVOvmPtcQu4Fnuzh1gvDoaLuKGoXAJmUh1fUuLq8FZMMAFXXMCs42FfxK518zWSRxvLnl01LJ4tacmbGZRWSdLattiz0z82dTZgm4psnFcxoVn/J41x+2WAhPM58s1V2zjZaoCM5ndBGVo7SZc7tLaxc3ce0JxMtpnHLQtIgkcdO+u6x7KV+SlX+yoW3iZ8sh2xbBKWX9qDlR2jH7viKfQzAyjmPlgSLojCH474fsXFzGIyETTGAcCUDAYkJPcIAnXAt9jpEUEQKjcw/y898vJccJJUSA9UNavmIsseX64tuziojDk/C4lhFxj6SIEBgd5qg54LwgmHl11kuGLqiEvsZasFTBMEhkeYLOJfdWgzqu2CAsSZunhofWAElM1ZRQkz3zZw5JpdZ7o4lokxNYdnFyeLWJoKUCp82dJtrGkqUq4N8Ofsc79HnSaYRLicDYBETGK0VwsfGTMWLjOIDavuV7g0XcxHlLAJ619M4zklf59yoYAmRLMMPQQp+XiOG7d3Be7jpWLhcPN1vjhXYiPnA+xVe8ExPfwCVF8TXPLL7g7eBzHwpi5QTgLrASR8DrjiM5OhhHEfgpjkaNVxzDP+o4Fjm1b093kdlAok69KRpVKFOuGZkAD18sMhUxLXKx1Vi/Ug6yVNWqkStFE2uVRCixWspiGw74PIr4gUzwldaH/GH6En9cgDbQ0vS/1KSgy8kYVCsxGVm6QrWaQBuTMlSXTCanF9Y2AVykTjUb+HiQBwU4GYdAQksGY7RojsvYLcw7+ThBQuu4B2eAq4KtWmp/UmQdj545ZBK3udC3SYU6tdD7J+Gjf7yEQo4AJj62cEGzOnO9eFxcUXwIiPqx4MzWrcY5nKyy3H715DTg01Ykfn8it6mi+nMTDNTLNQC164EtJ9gcMFsCSAaIMIcATbkM/skKjqXPUKOsGGNzeFFW+PiCqMLQhKOLwMB8c95uLt5QlKyERb9NL8PfspKlSCUmISUjp6CkopZGQ0tHz8DIJJ1ZhkxZLLLlsMqVJ98EBQpDwV/5jjbzHNfrlXYLzbfGDpsDil/Mtcw//rXACp1+8oe/rbXTB//5aKPdLrlgjyLFFrO5osRFl91w1TXXvVbqjptu2avMX5a4Z9Rd5d56r0ulClVqVKu1Xp0G9Ro1mahZi0nemGyqKaaZYbohG8wy02xzvDNmxH2D9mmW0CPywO9+jtJjelyh1Fqj7OcVEHTsIL8THfajLuQEjVwmX0+Fcn8mqHYqUU1dQ1NLW0dXT9/A0MjYxNTM3MLSytrG1o4aXvgRRJjIRG2cWFvB44ktnzLziLResIiJpF4ohCIVrRglVEehyizBLUEJPuMN+TCmfNrFj5KIZkuh5WWcwupmnqAXPdozafGpzsJmDSlyxSpO8UqojlOCUKSiFK0YxSpO8Uo4bhxsFSVfhH1xYfHE5hK2+OdRWKfEXdb8GMD9nF9VVNtKfsUDs5xDOGvo23ybI+jxJR6NH0uL87bTJ6TgjHT1le8b9O6JeZBpRkeIT5/02eNwL/rCBQA=) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: local(IBM Plex Sans Italic), local(IBMPlexSans-Italic), url(data:font/woff2;base64,d09GMgABAAAAAD8cAA4AAAAAoDAAAD7BAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGoEAG/wkHIZABmAAhCoREAqBmhj3UwuEFAABNgIkA4gkBCAFhVAHiCYb5Is30Nt3OoXuBFSrev/M1x0daN0OSuWA3sVIhK3YpJ4a/P//JyQnQzYwYZtPX68QlahDRFamKqq7oDKlVatWgxOtuPRW1PYF0gRL/AhzYYPh/tCv4hAfqgExxc0UZsqBjTfUvE/GZhl1xhq7wWA3JGRijotV2KIrDnF9/eLi7+hEb9Otecw0cMFmGrjn2fEjDzxEKRFJRDMsLnbFP4lDVK9/HCX8HKqJTc/fky0C4xY+ak69PHw/9u3c+/6aRkQ9uaRNqCd8OkSNm4EqJp1NmIW2CxhEa1Z1j6wCa4IsyxpkMQkhiknENiIORMSJqPM8cULUNnHiB4GoAURwSc7M3v+ndaqUCMYiWCtbQENSgYLhHZ7f5v/ZAItyFlIhSpdyuUSKlI2NsTmj5irSZf+57VV+Fx0vamlzqzhNpn54INDUfQofcoSIuu3dN02BJFZIEYVW5pGmzddcPvx/m8neVMjCftyW1urAbEJa9/hvySnnXI0NE9KsqLjNVra82Mogvm/NPNyvBUIXyAVyYcmXKbgwFxW8oAUnfT+ggAKa3cLLt3tXN7JccEEQBUmSf91M1CVd0IqtKHoCbnnusNb/z+0z0r0LUSWHNiJSmbzhzv9DlnU2qqtpmTbqApUtWiV/8/kUYgRt1qzBYBAOo3373+9nnsANnMJbOIVXuIXfzrza8p9URaiCykTYAqqyW+N2KkxAuApP+mcBCCN205cg8NgCDhQSOQTcdkLqMMYGmek0NENypqShGIpBmxqADeAis+OqptW30+0e01CvF7x7qF3+HcW/l31ML4Rfd2WrpK5Sq221vTNSWwPykKxBacFwc762bI/Utod4AXkIluRdPiB+AcEX4Qn83O/3gN73eD4A4Xl/r9M3ty1jnk6hbtAd8V+i5BKu+3XqGf+gM545hFkWh8RYjCIYD7LOIYyDoFo2+zv9EdQVCueijE6DgsGFKOQXQqGvap6sLMrjKBRCIhFeIbzBOY3QQLNcBxEJofz0uxVVRNny0w1ViIiIuMELIYQgIjL0zOzvFnWrJptHa8DHMTZboC7+G3VhgHJEn2yD7hJ4/APrx7gAjeCAESgZFupCJElDZMhC5OiAmGQ5YqV1iI2KEMVOIk4rRVxyA+M//yHKlaMqVCD+8A8mWCIAE0IiBMGCBPF8Vuu1NwI7/2lWCxhejxzaH473HT36IeZLde5AJNXu4H8N2k3JdLr77dCB8PyPqYeqZ4wseNYxhHSYoKCK6az8TtWuFpLvWBDTD8QZs34AUuNMvSUst9Fuha645VmCDLPA1W50uxszF1ZMF7o1TgsmflpM1+k9+fP4sHFlch7xR/tjnAWPewly48DCNjvOY8bxGRuqETUOtQS1CrUhFL4XNYCoQZ1HvYzDxSnj6uNmxO2NOxn3a9zN6s/juLdxn+KT40kQTFle0UnDakkLmYn2JV/4PW4gGUpKclSRR1qxbmrCRJAHraBdaogFybeJj258UvgMRXImWJ1hDdZ9G8GmsYWrXzLVtouasdOCichNQdY+eskLNzosvFv2mRlwQ24GrWe25+ROsAvYa7lf7SB2WMYRk8eRk9y2bECG1Jn3Iwe8f/uJkizV6q39ExmnFEuxFp/aLvtFCsTQtIrWsDwHaIPZRFtoO7IT241xQYAkLYiVUbk5C1RrMd52iwyQlFJFzohe7EVCdimWSprCZ9JyZA/bJgvRjBurBWvJdW4DsBnf4miBgIAgQpYSRDkpi3ll5zUTN1F2oE0wGR/L+UREGcUMM0hOWRA0KF077KKD1GHaywIh4MEzo5q8IMroC6QcdPlvIcZ7wqDRTCkxiPP2gP/UdDRqlm8ikxNYyluOtV5iESJ4MKKMQKYyKCkQAAgUOAkTmkZkg91KCeWxR7IkjQPukj2BAFBQpgorr5TR6asOaSRRTQH1iGY0VsAOfdaXYQCDojpsEY1DcNglXUUzHFq3tWppd6KFxinmIyeoYSqW+JAU9VrKiN5KqZ5GCgqU0cshJ+SqCXLTHJLtSOfZeJmMtwof4RN8hi/xn2QQwACABBGLb/POgmv0HZBD87g7N4tKPmGm6fuD/pMsBCAQRPRf+ajEL0lPOjHU1UuFNpmOqEswIZYrAbzEjFnjx0Kp9MlsNJDkqLUCU3gZKpo2Y48WwydXhQoZToekALS981YfM0XFQgUpU+GCEBqc2HTJgEkiSn6zkA7IC+nAFIw3Fs8TAuiQJATQ4qRawkojFJmYSMKKtRAl0plBbYsKk+cSiADg38XAibwSoaVgYcuSjUdIRE5BSUNLR8/AyMTCxc2HiDba6WawXHlGm2ie+RZYqMBiSyy1zHIrrbLaGmuts94G+x1w0G13uN3T71qYsWjVmnUbNm3ZtmPXnn0HDh05dqK8eqrw9RtX3XEbqskDjGmEQdbKIUXgkpPPyBnUnzzukoZWo7S1IBdDr841TF1CxBdCZj3QDGzqsIBgrwfE1uYDperVNMp4RJD26YDu9ueq4soCJdgNEx3eMi0ijcjII1mxDfYgg5GrPEb0FI+3LfVCpi+sZuItHiFMmaoa6rW9dAtZRrCNhkbPiyVzQJ/eu81ew7N4Cg3dWG14ivJrfGNKxwaaT5uFKFcSRqKc6WKeU4Y7lyiBOId4zedbNCaJYUh1QeKGblEQQPaQWoLuyOI8a0Wr6/TIgDtkXCg4cHiJyds9jLG1R3XvjHhZkhOuQwHbyOGtvAExbbUC3EdESGa8aDJVKxDMXDEBQCpQj6Zml0zwnqayDwmIInxGuC5ZhbQbVRdVo9uHI3+JIOI6HaGAmJBoPYqxXBOge9knCMEBjKzudolRlyzqpOhXTxnxcjjIbYqtczhJFA9io316PIS59IOPEjzScog0hKfQPMDcehgFRT8rtm0YpJP4PKEu6iWHDSDBX8ZyVReN1G7Etresei3QIYITuRyIlc9eMeGc6e8HZuVzZdTjkA1cLk1AvQqHIZSwrBWUod8iei5TyynQmEcTLvFKGF1tM+y5YhkC2pRuM50DhjSJszh9caFee5KdKHj12eq7M0bS3Fp/PUwrlUcGxDEc1Ytd8rsHyAE9LeiaZA7xvnTLMcYhAWTGLCvnIBxC5gdghyDA2TNWYAjc2xFRb8xx9yFWRYmQL+W7Oi6V6YvMAe1SsbOSSBUAmZDImMnIkYqurVxIWJ0JU7JwpgRHUg1QorSdlVN9bxrHmRIvF+5SjSVwg2D2CUpZoVMdoqC7nGIJQonkda4DTzkIBQ0RPAlqCnyZ0QpAIBAiEqo2rDpwGmHRBqt22HRDoh9Cg9HLJUAeJqNRmYjOehgbkHmGlxf4q8ShCg/v8PEeow+IfUR8YuAzmS+0faXhG9Z3yA+qflL2i8jvkymC8xp5tUn0AZQSdXPyWsBRKcAHgHjszQDp0vOv8eXBD+AJ8GICABYAAHAAHoenJgD40wACaGnxAJ6WjpAIIAZI6NtcDKIQZRBiDENkirvSK+EDYW/Bgo8BPvzwgiCXUuHD/vkRKtnCSE2Rr0te79PywV9OyRGDRSMPUAQ7K8iY4fdmAmoaRCDhTn00UKTa6mi0ObeLnH6B7Ma4DXftKt/22ikvqwKkLrsgTlFwl9dKRSiWhFhAgWaugYnZhbrjyfZ/vW5kWW4R8oXazmeLKg/WOL0wZMGbdsUKDIEIzdkmLwse2/9SgF101/7Tz36otb0z0RWZD2km7c414bZ6ZQRncK4R9sItwYks7o7lDSkK1VsDCRpZZKwiZWG2aJSAaQ1F0yoAJNAM+5SEx6673eGdmxq0mWZK27mMlIXFHycBnubhLqmJQ1o3CE0isUvl2DTatKtM0eI8bH83uCsJmNH4s67ftCmOy6sRjxOJaWjaIsBcSu4KA0tPlZflgWOZWDO5GU7vM2WQ/+DC/AKpybbbHEslf9paBRUXKaIdD+Q5H8nNCk800Ljbtu08WddJmK2lqCsLPoUZfztsa1qC22/rEdVdIwEWBENX55Ck8WntbZZ4ksKNlk8TWIh7TvYbKc3GGGaJCWJKLTFw9S9SkiZv6lH/naaKmaS4XL3ntzOCeF7MYr5qLLRkXik9nMVICMOlTxSJOrZkNOxc5pkSAHLImnnwA0pZhrajIZ6ZtkGMIVhPxeWNZOimZuboU2gBrdMi/9b4rMqYIF1GxELQdmQUAemPaqpuUY0SWBKfH0SEQExHOzFw/QK3bcm4rfKFU6HRTdBEA2Te9fJWc4QAAaTGZiYe6q3LLmmSPJaAYJJui9mR5M+dCDGnD+9agXNxLHbRsNkOjpMzFxASjnhoHapBgC7tLhoEGuNkTshecJJiuX4exwJ9mzKj4nNwPKaI/RNi8dSjzRc5lyX2pkeRYo/0JJwM4+7RRKgUldqcheCAmVdgXPIRkfMiGsE5Tff92DZUBFCB+gqKuFRbJn7r240kbkjubcmyh7p3Kh4ZY7MHgqi9ThOiQwuw63VgOEe9as0rMVtf9zoj7IxkgiGlznWiLS6gkvXnoN0DDQTO42ST1TInCfTIhx/6JcccHVKUbXrRFvERYwuLuwCsVYgpj+Ggy9bntqWAmdplC74t0BFZRrUpp2XuNKa2W9EqLwgWVTFN+yx695Gc5k6KwArBPaN01WPcGcqyzc7AmTUwwTjpKtBnPwiUeQuJU0XS8jkgS4fpronlxWmv2eDuo9dYgFniYQiocxPaS5YKvagLudk676OL2i0RkwnrbU09XllSXZQUDjSpwtZWJJng/vJK121HZPKf6RBmAnDWAjNYqKYhefnT3spmyLYBizNRmrwUicZcSYYx6p3twDKYUg9ouwmyykRw0bulEN7ppSKRdKJwbGhy0GZarSnTkG3xtGA7+VvrUk5WOg4eTSm40CAoZiuRMZM5etBNdqdY6iYpE6RUWxVtiltUrXgxHYcq94iAlUhozqY+DGmqo6eSw+DJQPl2HQQ7VjrfROSN0behmlco2qmqIovICXRP4OdcyrgGq62lhsqZKdAIjXMKEhGMGWXENYVYPkUivclZY2EWoL3whYdu3cyXorISuIffCLGrwbLrBYDWbuMpmgXpdHv3AaD3KJ8Vg92LLefjRXF5s5YiRpNMg5w5ENdlh2cKcohzXOmFUCM7+oPU7IZIMBK8cPoO+cpqQzBj2zFLKo4I+5SmvMKEAdcN5vYc3F0M9xMjJsMPMRPmGfODMXPcAptGWgnqPzObcenKqewH0YboIwUS6iEWpoqjW47i49/zyJMELDOT4yI2UOThcwRShB7zSJHyEQdA3V2A4pyd01ONWAQFG0p2VByoBaHhRCsYnRD0QjGIwCgKo2i8xeAjFl9x+InHJAF/dTFLhkiBSkUkDUY6rAw4mYhlwctGIAehxukiTTQl1gyJ5hAtEGiJVCs8tMZTW7y0R6ZDutwk0ynMQG2mV5plbpqdZyGtAqSrLLac0cp0o1XW8rMOf9th7PDUTnswu9cBvINA4lC62GFFJIqROInMKYjTyJTAO4NaaeHz5BWc8icFCNYPl8O5hmjC/hkUQ+fqUeHrakAEDS7GYzMnpEvP7wsglsiDhScJKQCIBngDAsWqJVAtJjGfSfVixbMotVwt/6wRf/X54NkJCNtc6pbjB6BstqJEwqLKekN3RX8SwRA2CxaCDQiWuLMEkCQwFaRWOC4/wqmsgzbrey8ACFYS/BiA0BGLw0T/O8AgCD8NAeEAAwAAgBgmtQEOYbTUQin4UjLSk5PRiODFipKzsABsHIggQVhOoTgRIohEiSMWL56XBHXJJHFRaKstu/Y6cJikQJDFlqtjpXUa2KhIimKlOvhPhd5oVmMBHfVE2DfQPuCwvgJPlVoNAG7L1t3x4lV3xa5Jnp6KxB20RHDEaEmx8UDLCx0ZlDymozj04Yuw3bMIAGmEn374G4DZIKjBeMtFJQ+l4WiMxmhsutVNt1C3YdyBdRcdN4x7sO6j8zBd55HHtJ5g9hRUrV+YkVIzkBPzFGgKJQxfXU2k1PgjxHB0foEF9oRAffRodsyqW/evvzcP16abSCnm4+Mac8mbjxueeaImOtiMdDiPu4fOGUk88pf96o1d+PoZ1lWW2LFmLdd3hGUSfNxJj/64Uv8G3e6Rsuu/IGAMjeVqwhgWx3bQBLgcYQq/lApGDXzkkLrUiSSobpyIxj6aL53a3if4iBp7a3jg7BcuZI8jC1kkl+/4RB7mz98WQk3ablVDuF3pVuq4oL+lH85ciqpaODy7Xcy2Kocos96M56zzUTo9JRFBEktGCHApWCmueR2l4w3oGIOOOXNdxuIIiQgIiQgIEMw1qwyXoN7U6WcCqe+abVP0Ok609hNRoqSWiNVYjMc+JJAuPef1RVgxpFiUhxfvjoE3mgFLlvrlZ3DPIGblHUXiWQh7o5DIbT1aTqgQQLhtQZ56Ev9JGCHsI1gwGmBkhULQO6VnCCM/wpnswMDivBAgXInxMQCJHvkz4yIPcExQCvsd8FN1AvgBwtgFc7IJBChpacgBaiqAAuGNI+bBi4ycD1/1dDTAIGPddMttd9zlds99D2X0/U88ZUlQ5g1S9k9HSClEqi+3x14o995XfgtSTaREoU5fLT+H+3qMCTYyzRxb2NbO9rS/Qx3hOKc4ywUu/bncX7XXwxZ7ynNe8Zb3feor3/rR7/6NUiH1pKoMmbLlLKK46pVURk1qVfu61ruB5TaqCU1rTgUtb22b29n+CjtWSRe61p0e9qw3VfW5n1UPy4gZ2WjGe8zjmJCJmvhpMCmTBQkeEP6BRB9flv3NxvmmWYkwm2tbMqCstCxdDn9NecXHZS9TA77XsZ1V+YwDFfVuhZ81t4NcufVPtQwlMX85aJ5OqeOcpkqfy0dRvB1/tzJ34TtZfWELmnNV0BOi83Z82UrewltCe8J2gq5peioPVLZ1mVvhXSQwddf4fBo9mbL4kqMZEy11YGWSGUKYZbnojaMl3d8uw05Fmv4IV+cDd0TunIDqaGA1o3T//gykapNrlAmmmaPAcmttttN+hY4pccE1dzz0zBtVPvOTalkiJjI1emvWYYhRxtvAFLNspsuOdrevg813jJOc4TwXu9L1bnW3By3yhKWQmF0xJKZGZhhphNFW2EslOWaeepSqj0vrktZ1qdPRwLq8W/3XXx+du8y8MyLSMJyn7kFX1lf5Np+NnXr6iseTSGW1Xihb6N/mLDrqmJHqSUSRvKToJCG/5yfOW8rrZ9oNt0kMZ540Hnj+p/cmQyYfGmvFD5cO7MwwUzAFCoSy0kphbLdDOMWKRVKiVBT/+U8sFSrEQTEuuQ66+QcfLBFAxANMA+YAc8FisBKsBx1gA9gG9oBD4DA4iUD2ibZw6131Rjj3U3FhkiYu/L65SQ8INKvksl/Zm7zr/ObXAwbD9qZl0ACE/G8DbAJRX5p6dUHCt+4BQ9HonxGsF2kg8QTwI/dKguqdOBM9Z1BHhTcWQoihHilytEdAaBLkFvhJaaiNGfMKVJZjiz/agYrbr4TJNAe7XEBZ3PDxvkGulxLKG4kylUbLleeZjwQR6+oUeAMFEZTU36lahLjOGN25lQHIzCpzQN/XPvEbSAbEeEQlGSD/aTqlgBBSC+VGVstEOjfnn3eGkCcV/6Cu+gt1yR+oywjiGqaVpcN7ekQGioq9M+X7RNaeZS+N8KXJYHfyH/7GKV7JRKWiQfTmPp8Qc9/z5W79oBzInRIVH3O2+yyLb3zik87LlSM8EYCQkyFLNhNe14PefdNsKl0AB3kq134iM34LIyk6kmA0yAaO4SgDWiaA7WA0AJbMzTYRAgy6zUhrLDoPQpQPQToBWaHFwAAoKE/U8jsBMQQGAX1gQwgYhQmWGDQZp4aE27xjnevxiJiAhzZTpCnelMTIZexmmv0XsdQ1/wFNTKxPuM062rkeDpjBD5WmCFPtGnkhS/EVlPz/ti+3ZBfu909cLcDf7/Dhrs21qvqXqqwCCLen0QtfYBzP6mJZ4AV46ZLL4I2rAN65vkLroC/SJoLuKt67Xrq8BF+8BnyDqP5LZJFzSfAMAaXC8YJ/xUP/KQ/991z/lwXCZLE5WdzsHB5fIBSJJVKZXKFUqTVand5gNOXmmSELbLXZHU6X2+P15fsLAsFQOFJYVFxSWlYeraisqgbTps+cvXjFur5Nm7du2bZj187dyd+zb+/+A4eOHC4s+t+xo8dPYGhM5e7d0Dbs6+lrxophkDugTrbvE7u1AG1+aiZNXXam9OYt973bd/7vtLL3yVPAcF3FlGXy3FnzFyyct2QpFm9rVpWcvzgEOEeAxWucc8E1U64CHEAbHtw+uPszjy50vecrGSeGj9xiaPSoohn05iSzgNRe1aqhZCB0rYmECxNPwCeeg66+bveqHnkxgrOTdXOYdPZOHtNGJzNAvrut24XN0aebGa6z5hXgKyuHBIubN8zr1/ONXQBfq+hGAVhZx2yRyzkqQFEsUvtkMK5K1BW2ZiEQ1vRPPUGJhuYrjacFi/VTq+qorkKzsBrnbRyHCOt6qfB6rpBr1XM1zu+c9MREkpl9T6XQH50t893rHZfjAQZlX2tm3NUicBfntNwcWF/FGigT2mv0VCuk2lDGB5GSJKVftofTQCFStrZQMLVMeK4IiMrkgFKhIAgCGMzC1DlsxTUkcszSLXJUtVy0UtReG7SXsnUg8pMMzDCgZXtetBzHJkj8/wRFaEo6Qq0WURqFUXTYCOWxOD3OPy9FhRLjdwW0IpKoOBo3/t1o331DdP9ozKF5mdC3xs4bvs4hZBgU6ZEL8/3bPbik95vlxYdt1Yv8Q+CPLa54UiUR2NvV+Pn1nB9OY7dCUwLp2ZHTQxVff018+YSAMFF3PPo/Bbuenb9s4IiomwJUOUJ2iKDi00J5JzW/NdQs6zSlR97cLf3JZGJsN60vO1hOGr2NJ7AqO/JThiivRm85iN6Q5yPq+6yoNCMJLw15ERMaQjlExQUJKQRIUEYIC3FaPLFYYQt4vCqkaNyMosuxJwPzKNSIHX17tLJiveHVRsMJku+umsiU2dU4vFUhyDzsTQ0nMtHZauoUGgaseZkAzvDv0Rw6ZI80WEVxvtkJNJZ7E+/fjM7M1jvulTOShdqMZX1GIsjmndI49saz63CJTY+5qgEQQwbMYRf3UaqGk+2BxfUubL34dAiT9JAtkhxWSQZFWvRlduvi6rg0ES5MhYjTQ1q8gQpDbVhnnWbyqnmYyclUexqTldYBlrMPw+QenQdml2jof7UVfR9rSxIAMdbec6OsCLNGK3tUIcdQa1y1h/auxqqVwftmt8ytLiBcqtlZ3QXXXv9bkCUYjp/9AdZoesgVOTxXWhiMqFzdJIKwbAS9Xp2JOWODRiV1KFL0i8RR8iWf1zns9kVTID0eOani2BmorMaKCrHIQoigULHcj4KlBkGZ1AFS1wal8VXFaCSMmKi35mzqER55PtZZrcM2y6vbRUKeOtxwIH6nDFMYGWlu0EB/B9oulK2RA4VaDUxhI1Vvf2t2V4VpQFjZHFjJYEOHVIyYqN2QaK+25pSQeLQqkjQnzFWf2DVI1JakFGmL7aK2nEg6MKqEHNrMqczcly+rtAxzMbEFIV/4wW8XQGkmgKwz+ZAK1KgqKUqwDAanRlw2UpwtVdNVyIEHoCysiOAFE5MW3xRFu/IizeBS8s+sYyfvJIYbS4lmJseRimDimT0An7qQmJah9QUc6FeQy1NVoFSC06yhAUPagRuTciJqQymLlbyM4RrUcj9F7ScCrg6srMDQNCKSHYjMR+xcvUNiNEqcL9csygtTLhppJoZg1HNgfvxMLGfjG822ObTaN7dri8I98nsip2yiMuoi5PHTTOUS40D16N1KbUs4ySPPt3hWdMm6ySughvas/aR1918lhI/7xSG1xAd4XSp03BWau29WiFzUCkmenVptU6fxBVPiiR6QHjaBp4cwwGk8UdWW7LlriuHl3o8+qdQSRxmlfLcz4CqlPQUmaFvKUNDeQLtzQB8ob2TZPoD50A8FJUFFeA8hAoLbGBDIdAcqcjSfmTSWfiJM2DmQBRTBDRomDzv8SBRMhr0hQ8q3d+Pdfkex1YyfMS4hFQygfarGICpXHvbrT7Ji8kQrLmI4czuQzBZ8ukucjxeL0UCWeX2XQxLQjj1WoqdZ9z2+NLplplImyGrTYT2fh1w6tUKMsdiu23HJN6dJHDoUbOQSBl+Md9dw541oA6RHxQ8eDNSzcSrZIhDmGsC3TuNiNxE5+mWh2HhaMzkpMLl/DMeAG0xy1RYjxoBvN2QUx6H0L5Q6YpOISxDgo1oSP201Gq4UgMbpj8eEuTsGaykzM0TcTGredQ5MPxQwyataHfDHMjOW5WJi6QeCkfmEHQoeVvX8ZiZVijwEi0V80RBIUohl4Z4eWhOgmqKxLZhTZ/NdWhO2vjWQhfdafvvOcE2kg9Usbdnipysit7Z3+xPIV9o0l7bGIDrSy23Vg/IaybXWCef98uJvWsSh7/vGvSjR8WX2t41ZVlqyMGMZU242gc7xEA2nmtul2+Y7S1eEz+pBivWTLeKN5IuU9sg4HMXiYBuY5FHktx68QtY9CTIz0pyoaSMtabTadj9iwKbzGG7UoWujgfSZl3tfWmBd5qq23omOWi9lYlTx4FUjNk640OPiPF6a5tK8fbYMaR/g4ty91rzpelwlS7H4Ib0TUUWLi00rv+O1WuDHYn0Da7AQiV3x5fyAbXfqVBqedoW8lVlSnxlwoKVZaSZ0//2fXS9RY09pjjqcYu/bJkWG9aj25aY1jRFe4oChzYtGaSEcmfXkxU7hmAEq+J39gAvYdGxGBInM927G7aYB0niddajR+77k9SKs1GZiJbeaw2ImtJo8iBnSNIVzm2lGCuw1fbjMUVSscLZAMPOhkMJMsajhOae07mqSvQNUoDhak6l1b9sZP+7N2mVuqItS8epjFDWDqwm901iZAqqO8eA6Fd0hjbxnZl03uWE7/TUAq9FEN23CUHvud8NmqZ4cw4kOj1w8KjVSnLpYbjZTsf5kobYPtxOm3W6UGam4eNCLmKY7pFVgGRb6F4m5X/RXWuTp9ihnNTo6C4LMwq3OroahiEkvwL9XCkNdl5c6m8liw1lqFlQVki7ipfsmilyoF/WSPcxEEhNvow1XCpcwSuK/V5F6mHRhnepKZ31bsmTS/SbrcqLG8lxU6IY2xJu2Vkjyj4CftHpvJ2zWbvWriM8eDGQjcez/4tMm9IbwHiEG386EUaJ1oqlXIm3AjAuP7Vo7TumRCRiYvdcTNeHrRPeBG8SBC9R2Ly+I0F/HHRer1urO+Dc9wfwanUK7WJKwN2LFO1Ow9AIgMBfm/h0nWG+5Z+wM9v0a/wB3OU29P6eN3lNeo46rirsmba+8WXmPHPFDM9761pfDR1ljIZZsrs8cmPyXCM+sYevgMsmxmtt5rfN/Nz91BVPBjNQbJ2Gvt+iHzUGt/XNXDHf2wtfeIRTHus+sGNMRFtNXt8MLYTYAxQr9DiFWm4kJmswxYaB7sEZyy0/jCMP+qv2rn7IFgyB/ZnZpZdhlayAAG9q8M1x4AugZqWzZcgwD9bpEFioXOvuF31rXy9vhgwq/PDuxt1483VT3BndvvujQKJw6hG1THtbfK+4jCYv1IHXTGINU3kHEKLHvEwYcqRNFkUTCYnDPWeu06Mhf43Pa8vabsV6L/IINPtlwUb/KCqntz6JunpnM7mH+kY7sNRPNJueYWb2Tf9FBe87Bs8pMP97MHVXhR9Vxl60wki+hxiKVt4QvPR5koNZTRMvDwKqjHH8GufRMapp6BHx5ok5iuI0fvuXpwb6oqVgV1FJR4Q3Hgn24qRNz/ij4f0wRGUuWSxhOb1TS5jj8Q/ZYlfxTQnLsri95IdIwHtPEZCcvA0LR9BOGh5lgIjt6vqnQROGAJQBRg+Snn2V2wtGMOFQRyxzctj4A/pv7bZ4MmB8jgNGfLxbKM3zfxAXmglTSN6TFfZYeMMM+OnEujMhUA+BeFb1uAZiP4Z0Zbw8n/HQyRatn3rAn+HF8gSdq9fCGGpgRn4pcwClVugOytqdVLtmcWi/J+mHrBMc8mka6ABMb/dmBPsIHvnr91s2xcakd6ip76uNTR/i3vwYRrcDjwqufffuGAxuuKZHTTr3O1G8IrjLn/yG6RqXi+8y+tPgUgmITi7IiYufrJtA9MNUzAMepxu+Yado1DoNuU0186r/QuC5jxlxNVZwTnBrfDsCPTyoNhzaIw1VYBWoTdWYO1b6lmLkR7zcmh6eH1M1vXu3dLn5ZmhwM2kQM339R9rf4AuPfHD5hluxdzbZ66Z8Q7wJJeN+M8OSBnrL+grJ+is5odltlmWUSm40nMkDeFvLM0nepmovdgoUJaQmcOAZZeLtHPPYfI2B/+HSLLK+4uNQpottUEC+ZR4F4WSRHhoMpovjnT2TymFCtlZfcvj5CDe+aioVt19n5gfr5hVOnCLaPFOOIg1pPtSyZS+Ee2+xVBIR/zfxyzfO8aU5xsmIb6P2/huDQEIDnh6hom2deTafL+3coaomJGxclh+fIyhU7pGZ4m34HGLL9xufHrtHGrhFTs2jmccrM5VbW8nmKrxbnwN3L9OPAXRPv3BcY6EsVdG3BE69wMgZ6dalx5XSCnHZm3ETIP/CbgOo2U2wC1jh84H1eJoigFT4NvIx0YbSDfxnAJ0jsrNsZRWoVvp0xVFYB2yM8lcTGet31mVDI49k5B24wwovSGu2mdKcuqKf/0Qd8rOPnNkXC6b4pV3dPGdN+HOsAlw8PKRl0xqyw1nQTjGj85HGdNL0jd5aDxnK3FJcIYNKn9Rwh2Su3O+GDV7ZHgWiB3qnCQGK0yCuTO7NPt9Ebc/05UMa/O1jcufvW/Y0kQG6TnBk2m8qYOgGcajEsh4RTOnKwLIcVOkNgJ4p+NrlxdmAmzzDi8nvudVe/rMTAVeQZGQO/N1mGBM52DpwSv/pfTdbTV0SIr2NXWxyVPKMATmUJRvwRMpG6iKTGyYeaBBD3CzipcloDQKOrYi0NbvWi0sndw37veDw8XFRqqrwn+8srlPIsxLckm1DLiVrgMq7cYSnwnSGkJBrzzAba6xmYMKqDSJrqzhk4gs/vGgri0XIfqZJsyWFlQEfMnM2EuwKLRMh0/xihKYprCp1UXqBOS+BrvXIVM2I2RplqOxQynyCxMFJYZw7F0Dq148I6p36zGC86pK6XHyjfMLyFhlPxoamrYi2/xVsK8k8TUhINeZDh8CyA6G84z0//ygq7fiRwBvB+UN2Ngb7FQM9++TsBmNxd/x8Qfqyt/Wf+q+pHbD/D2NwGp8vx7oy4BIFcobeabRYSzdVYUhisDnt5NM+8gCAnfZjrhj7+td/QO3/5lqVp2urkQt/i9qELjBF7Ky/fx2uxYYXRRYxSmRXOFpWUYpBJDr2U9EDtycYpnalV1c3ukrRiJD7fZhAQFEn439Ik5hq8b6EYi1PSC1+VMvXWEeKKMNSLcx2Xp2J7u6Z3Pz5x9GPmQrzDntEuXtubS5A+n5tSIcZmD4AbxFP4YacKu/qHRfvXN6MOFN4HB/sHBSJ+G4OfZyEg37nVMlbEaA5mybgch9Kh3u7Sxmfr5V/K3j+FtE7xZntmPOeY6IjoCfBHKyLsXDur3lom2VDUO9rujbT5iAVOBt9lsOTYqdNyvPMzOuR0PC8dbtvJ5Uz82oyFmaLCsQFwsP9U27jp0wOilcU9E52hl68cpaNb0prSGqP0cKTQNX04D2TP7l+Nc7jEL3KwDp70r1Kso0tYIOQKnDe+rDwTuB9DbtXRfuPKA2yDjdFgLRatLx410RkuGxVOdzkZ2qDJXtLblVaf1hCllRXWBTjm9JLWkVuX4l0PHA0+kGQK5ZkCs/sDRkXIpKA0A4lYa7RFElVh9P6FA17313+WaFtDiTMaHuR34agfpHrIioUju55jHYBZOKZLeG+MjdlrUT0d/759tOLvZxWD7E50TDt98ipvc6EKuq6Ka8ScTlSXs2B2f1P3KETcqPa8ggLA7VNvRXW5/d5sFcvJVQE8tLKYZbZyYpYiycayMZM8IR/YA+o+bLczOnpUenNqrZyFLyipCNSEh++A/4mhzDVCjowR/rKQrT5h4Lnbj8kh+cJqDyZrteoAmLOlmJdCxohwtqMOnsJCKTfM+CGEBKuCo0b4PXFDAvVDV0x0eH9JZeA4EvQG5t1YDtH1HOYtjymKKgTrfrQjLCjlrHkVyT6Bf+Ebb2CYbz4sEeiEcMbPMboofZQF48LmF1v5dPdPJQx9oNkg2fBjQGh0hCBTcVPaXRsqckpYAYupmgWmt49pD9CqS1jH+99C4NPDyG67ZIgZdhj5ZkIaK3wyuDYQ6sP7pS12awU1t6KhsYoARwsWg2+D/YGsKCkeMSX+SLRweD+YQukPJFSjfkfO0I8lVuG4WCGy6e+l5WFtf3RIS+JrVPMfG5rABzOCinxEraDH5oUiPTTkY1oFpwZ8r05euD3YGUb9F47mblcng6tP8L4X7B6c49L/AmcA9Ew0PGn9QEnidwklJ8HFZcjO0TBfAtj/6f856cvsDivyD2sHtiUytgsoN2Ghx1gIDDyB6cYd34MjrEEUjNiOoJt9ep0j0liuo/Wa6iryzIQTmsVFyOSQr+QrFwZO07EE9TPe96Q1Okbt/4OVFwjg3Di3h6AQQ+DYAx/sH2iOe7rHLOWA3w+N3n8fVKKFVuo/RK8UZo2ASsoVBlsh/PCDviCU6/VhrckhUmaiVmczcp8/O0W3xJxsPyomhW/a+jeoPxCNDR9q5nbZS2qUJub+c33syN7A4UGkuARNrsUoyxdepLxrFiddo8W2Pq0uDw5uwO20kdPfreeC7sjmZiOMgaPdcAQDR9KH24K/qom+OvYmHgOnOKx1Z+sp+Wc7cvhiwiJhFtMdZ+NEhXTPMj9NqouR89MYLoy1pPcfg5Dh2hqgydBgg/o6KcvaWeg0+B1kifRAvyZ55+RZdEmRTznBpemb41Ykcq5LNZsp7Brkry3Ihtrh1mhhyAPjmHLZfy4M7KIKaKgEguS1mJIodPPVM1ayHRU6ug+cGkPg4BBJIvkU4n7U8DFs1nSDOLJbwisGsxG+UbHNySoYC4ds70HPkamfpehZVFnRnhXRR2ca31gwsJDtHCg9WxpgH/aBkaPuZtIc37T1+TWchrritBhqh1OjU5+IxK306Zc4ZHZZGTWydy4M7KQZqAliyesoke/iS3pnMByVOrovzxSlBJ2kS4NOsB1RHX2sbllsQeA5mgeTkOR8FcTtsZVUqww5VnuQX/nhSK3aogA+H+d2pqmNFkNNIJivjFaTOolasi9xkAHP78hW3T9p8//viwzSRVzpm1Z6PWrRYe9vDAYun8Op65znMsnBWbSxQfoyv8+WJVJAUinp4c8NP7DyvQzG0A8OklQX4H6fH79erIOyyfePNTxi55kY2af5NgKYIY0Xo7PRi4GzKVnulKiDPG84Bh7uHR3DwOA8Is8kpiQKBHxV70mmvVxH14E125mDKUlyImqnS622CFxdeCsHi/IRnqxPaSdQ5SdmfgoSESAL4U54h/oSlb99fLInHYE+gPLs6Yr3PEdEMzPiJqP0k6dk1ADKs6Sx/4bLf0Bt+6H4zufpE64/hzpwDhxBBMt75zzKLsBA0bzuQOoMNQDVSCscm4SBG/4Lma8g0DGTOZiMwpBED8Ro5ngW3icf1Ct+nhyyFe8tlb2zv+ibfl7C9XESmATZ+7LbwDETHZpk4VGQ6J7bQvV+0wB/r/IH/bDAyhcsztmxD2iEtgljR6wVUVcAUIdzfg0puVylnKcHRle/Tw4gvoabAnn0DmNRoaY2rcGaPuzdry8stPXpP+XPVww/fIoORW0WRGrMSuXysdT8GTyT60RykEQEpLQYdRwcTivCwjZuLkHHqbDYoly9J5q7GRZq3yh8JTU16YLUc1j4a2Qq9HejIK0K5wDEHv7jWGdF38jaL3nUyh6KVRtuKgvU/Rri/9j9IF/l0Co+RJdFHzRjoTPE1ATpGlnbixzoF1AXFFAXbMdA21KrtqGhSR1wpEGDfKyp+BeehoZ2pVbtwkBg6VJHtcVRvZd+fL6BxQQewzLWk8lXFVFuRaxmAjdzD0mZSaPs6YMyxoryvMHjCUd6GcP3DzTPvV7UVf5x/KZJm/eLLeyWlYGrTWmBIcgEwjwJHAFKMm86/ZqAGNoyVOAp4LVYSw3LG1sW5IarQa3wZ7Rfp2/gBmBt6eLKGalaZumdEEvR/Fi3NpusXpucXCSFbFl88r53Acvy5goqP2nOcTGWxWMoxdBfS31y0BZlkutSB8cjkY838/nv2aawyW93ELDxmly68G+Z28mTqi6oUhW0VZwlVdk/2xVIjjyV941G3Au2ernfzsJCAwok4Hmcd7f3ZSnohfP8bEnbu7QVKiw4TWKhcj1eA3nFjcvmnQ1S9qWT/tdFDfOIBWwq+hlJTBqcnCrCmMGJr5OxUDKIG06zNRSyeCQ7wkLh0VT1DUx+XBFMeUOsPfCalHUhW5cdfNUcfDmQ/dOXGOhLCLpo8MQrnKjjrCgzfl4gc6KOT6mkXOr5j4EgogiJJFrddi7yT23miX84RNq6+tOmSsvX4Bojox/XmUlEJW8nkf+Jl5Xdl6omc3PM3MGH05hEd2WAqXt2/PTW2RyeNIqMI/AZggXA6Py3YQfMBoif5v/f53MG2Vg3/m+J8qYVFbeSuhj8PZQ2bP04towTfBZkSDRoyJx4AevgbOj/ZYIlbxzxWyzjNFe1t7fpdkZGZ3JyzR+LKJVyYmCI+T6aSGDw94M854ImdXJcpetic6g8L69yAbhRpLe6dVktVb/s2p71vb5vs+Nn9hOo8cwiDlkSbPqmwDpDHsbmdjhtI3ZmH64phTM8BTxekAUDF2cNlN/rv1JSvK/t7up5VXPAXgPGjSlYDioI9QaKBv+2IA/pat8LqdBRJ09hpVSZtkErAqJPxzZN7d/Uu7GC1hzb6JRuHHFFgIeuMesLyoUl9fRUnxR5Z+tb7WujnIXn7R+xp+4nbtZdP78Iewf61wpsc/oDlPnbxVDm6oz/djjqk7SVonv9ZcoFRZx2rpXc3e+hjOxY9netZJ+EVPGueXrfRwGTfrXUlylFVpAUi9Ts1iUDcxpx+cVfhLG2MCmjbXJrQzaUcWNtNqPipMjnlfBJbe+aRyz6SAbHNGTsjE0KfH4NYqGP2COnoWj7zy+FS4JYqyMwuB67LUDI/DgR9es1m9cKeVr8vcihiJ1iDL9MIb7Y93FHndqSa1Ncj8eUynT0ffcOcYoOuvYCkhAnz/jeJ3VwkVoe/32NEojwKPQk3i63H/5dTZNciYGWYiz7+gTWz84hE134Qlk4e7qjsk6ZK7TS/iZ6JSZOizlULFOpbJLrkC0rhinWri5QfmnmdOxYfqvc+MWHGcZQGAtjzCQlWm0x6g1hV7QImusCvMlY6FssFH+dXJsSRyW4nlEpcxdN7DowoEWlW7eycqMTDmb5g7GLfbsaFb1r1b06TFyqCJt290Hpwn15mpCi/C5jpdMh7hgPETnVdCPYKZQEcWQP5py85uLWTFXZCeJ20z2lmCFyxflteHmOrKAkI+no9Oasg3+k3MUMHdOT0ZZaoziFovn7cyKqm/vDJZn7eyp8zVyicqJSSgwQVrzpurBKi2JVG8ycQ9/Mp4iyoQh/WnoF4GSqcqFcqV980EBeLUAfzJAPQSaQqiumautblxymIBJJc4GGr2Idi4KRHwLz9pZ3zOpsnTkPyPJEjQKjzWb4m+lXbpNjJHLyYYHRtST61eg17JC1mKOItyzqZxCQfhiWNX8Ikb32q2nWpi5A3x4LJ3DQWMcbiv9h27Bjz95ODmlZiH5ofp69enE5P7GpN6zrcL8iiY0S2eb8lEuZCmSM7M3z0E2Dft/KXTjn1c3X+5Y0LAWZMz5Cf3RNAH9V9rvScHDF6a7g6OJLf2TK/lPMVcCaBwkQ6w6PAyS0NMg2vbOBjaU2z8vHm+m25wjcBrOrJUr0f8RAn2cVdgn5M0F/D84PVDizJnzjp68dQb7sSQFTNomfF8w+P7tArmCSJkPHnIIommLGr5rizLFDgsjGVfxVSHwkcxRo/PvtUbiQgap6ZX2FqmIsjBS+PX0aXPq2ty4bnwrfpVNs9rq7TZRAZZNWt1UbCzEgcdXvdPufq/Y6WTlChntrgCbFgA2oJFL6W87X6s9eVh+a41Yksa9L1Ycpq7i2n07NlR7YocVv3U5PGslXAi+iOIxgivX/XYHZKdQkonPYV8PSt5Hz2H+y4JrknByaOL0ouxBgeMB9yq3nvcQKtgLZDw1Fij7FwntTT01RJoLzFl2u3SwlFAthS46gbX0B7uW5eD8hOQE212+AoGHGzuxpiKfxVEFIRnyrmcFTb/v/m61ktiAnSkRn3KQR8gYKdQPXwUWL8YaKx/ArrWY1KPZl11Wlyp6+oErqRbRAbd1r+lfdxAQSlU7fD69GIhU0OX/NW421qQg9+C3f68GvFqNZzuNnbEMWHSRlaHwyhvIMN+sLHvKXc1RNyEq7Di0mJqYRSGQtcbuEChcxPkPP2DeAofks3GUNfhLLeGPBpOlNOjuHGJiKgsJzcMbQ53/zpHvw3Cs9r3SWBR6dJ4tjbgGYjarypfu7fSHK65Po5zTvks0hCIQoRVzwrGNPG3ZArOcIHfde2/P+DBB9Qy10485Dtd1PxZB/yHLiBU5ZefmwCA9wJOaV6DVs8h7Mlj8Bi5oAyeLUENvAnCf5mz+9td/A8EdCw3aYDbC1S2C6addFoL2wLTBvT7h/Io6fNRconn1hhkjdNiy195Y5kTRk71fTrI1d1gegZ14DU3bl5OHffaiy7h70+OeHWH2x/bMJrSHrFsf83uLMtg/ff5ajYrSqT2rXGnUaf8LSBTB9KiB7BDE6g7PIfsly+QWfnA6xavde5U/c/hMXof0UMvkxnqoOp6QJH51zytK/YlnfrHpXfomT8kzXW7gvtIPlMKeE9EkpoaDVUa2oqSCM6KhGWimhoBWoKXLeCyFflFDQMtQkTvGW5+EjVFYzpzgiZ5hTQkGro1qsKYq7F0LylVDQCtQUJcgEqeVIuhckjlTmK88rLyr7ihfEtGqJ/ZX5yvNiX7GkWuIFZb7yvNhXbFp+cRebVUvso8xXnldeFPuKrmqJQ5X5yvNiX7F9tfyK0DdddobEf2ViKV+6KA0R+zqPcPtdedtZ8Y50R7wr3eVyaVfK5Rx54ix/5JxH9utHKJtcgWq3F2YVwf0nNVef1C9TTy6zPQA4Elfc3iuCd8TPZIsdHReAiZwos5zkEJAmtkGf4X5mAygDKwYYCc7bNtFT+/pWOXgOi4WVM2Zb5dKZGJ88Y8rkG9jjK+cwSIXStqnHIILoBIJxCQSMRyBg3EWmBeShiutu/+JMJHZHzdGdVChto04eQzNj4V53UqG0TWWyD+TpGSLjuhG6Yumg/klu86YbaiN8rK9HCKK0srJ/rKI8BjhfJIjVvkAQm0na2AgyltNI3XXmt3bSN+lb+I8f3U3ql8Hs9bhYqkGHO725VRuXkJFqede7Syd4hBqM5fPfpSOyOyfq3rmNZ1dP77z6sqM3mZa3sfQV3eOrL3q/z3aOHZkmYEdtIU9mjPJkxWsgrlYMAcXkd+uP63Q14f8iYcoBXQ/bAfDhu/GvRlLjnDOHDUqIAgIqUf0PyuV19d9yhu6U3P5KiDpyHxPAd/AHogVWVzAydxBaIpIyhZ65FisVRkYaWZG2hy2lV7rICfmyk0kOOQGO2mO5SEoXQbkw58KaC1Mu4nKRki7GpouYXOSFlWCti1x0TBfxuQjWTcvSiYY5aF83DHttiW0O9qKx54u9JcS2G7uTEcVnmOyF3QrsI8MOtW3bmVkxDCm0IZIMpmsuoFk2ZVDpSK9ssf/xhdcnI1esizRGMS8JO8pFRlr2c0252lQiS8BiOeGpjViDcCP3pX/3U9EgEpv4b3ckcIlpgsW9xrMRXsI2JRBpfyzewzMa0CgjqO8rEvMV2fF+X/lqqzy1f0zHaASBpm9lLppxsGk+fhFeQwx13z81I7G0tuDsa8q+IUtNIzu+0MuTfPQubTfJvTnHcCR1NidYN+6sqR40bpvy6BwJdN0aB2tjDWIqHeIL+mlFg+JieiOcuvcD/VmhcfLXzYkYTQH5cMH4nI8FOoSoiyxnDCcuh5Ceia2JRFGe1SXGhsbNzRrYSohICJwcWSThfHQM6S6y07Y97wIChDsSI6dNu4idXnVTKa+pjJZRANd8K+D/bqiCETAX5sH5XRcWjbV32ypnmtB99K7rTuAG98on0bQYCaBCZqyAHISpf3oW/ybNCa8NsWXSvURx+Uk0hiWZ1fupWvtSdjC/ZU+aRGsSo5MX4qJ1DCMnOtIueuIZzbda4QtUGp/3QEABPqCe7AP+z4Fta8oqYV+pkjLcsNi8MVp4PhC5IedDIOrQA6cpFnE7WRDQyrn8YCztUxY8bLXEK7HCKLEKlalWRRK5Vk3h1oNmBj90PFIRAToAjDAwyyipw8aI4aKxHPoYR2N741mc8JWeoryGWbBWbUbq0KRBoy4MclIyWgwuFj6MYtfRPxVjgDRrxqisdyZdzCXmeuZgUkcM0I+aJ6AoDwnktCAZSx8N0bE2EO78RyILzNmfAs1iejGEVGvRCQzRqqA51ssIVbcUr1OXas2a1AJMPWr6wPuJyRmGoyEdNmB5iIZJ7D96GpIhUxHDFI3d2aV5MEZzLzTM0Lh0LtN3atKqBWOpJiDe5xhQGHa2NeIFqLjbNnoSEl57MbzN4uLJnWbi61tbAwk/Oy9ANY1fjlROZ1Mz/SMfHb/dO72AQs3YU811CRLtQFYAJICNLpeAkIiYhJQHTyCBL1kFJRU1DS0dPQMjbz58+THxZxbAwsrGzgH4OdMpWIjQ16cj+l9atBhk/0a9/LerBhpqJFGSZClSpUmXIVOWbDkaa6KpZpproaVWWnNpo6122uugo4zupLMuYfSZYqrjlio3zTyzrbHD5gCzPDTZIp99MdcyM5zx1Cdr7fTNV99ttMdF5+3VVTcLdHdZDxdcct0VV11Toafbbrhpn14+Wsjtjrt6q/TOTH310c8A/Q203iBDDDbUMHly5RvurRFGGWm0scYossF440wwUZX3it2z34Evq+cp97nFNQPPed4LXvSSlznIIinSrHGYZdaZjqb1KicoU5BNmaOY8UY1x9fmLVi0ZNmKVWvWbdi0ZduOXXv2HTh05NiJU2fOXbh05dqNW0Gq6t0tTVIpvvygKxWtW8mfRYS3UgCSSJRUiuLkq50hN/yavzzm2ogqRicuS9FEqvXpbTSIq5u7pPJFTKB3a+1SfXXXGCbykklbcimKc1BAEmlJlFQyaUsuxfFz1jXFBFowpbq2uytW6hZzxuAYzhwu1Oe0pK6m5rqYNC4C7VHlSWPoEUao5uOZcaVCT8NylkjpDJaYmHPFOD9lIe4qXI2ueqQuSZ+egCnTDxcAAA==) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 700;
+  font-display: swap;
+  src: local(IBM Plex Sans Bold Italic), local(IBMPlexSans-BoldItalic), url(data:font/woff2;base64,d09GMgABAAAAAD9kAA4AAAAAobAAAD8JAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGoEAG/9CHIZABmAAhCoREAqBmUD3SAuEFAABNgIkA4gkBCAFhgYHiCYbrY0HmOcLDJQ3iPn26WxNyFEEGwcggvjHMyIZJz1y8v9/QoIaMgav3oPTLa0CRWAS4cABLqo6VeOKPvukm1HRXPc9osmTtT6f3AlFsPlio5/kZDbNR76V+k01JUiGIl7FhkevfJPGsvKUHOdNPtnLj1XRiWT2nUe+4iuG+QmcECDQF/sN/V9xC8tTf4+0fqr/dbAzsG3kT3Ly8jz8uOf7tfe5A4LZaV4ehTrNjGTSZ9LxIX6b7+5TgoGFNpixbJNh9LcbK1fNpitXuohk7VxlsCiGh232T0UwEEWJaAlBEJRsg7CxCnturu9c2Ov4N5dXKxbtda3y12Xy//QXeu77s4IxCRDEk5morEBbqs+/f/63zzWTXDDGM1b/R2BVzZSl4AYIMLjo//9+vu3ACewPt7ALt3AKr/CKkPWjvu0Mq6zIkYDJELhvXFeFIeFGeLRvAIOgoq4WBetAVR8QbA+8DA/v22SPZEUUwkfUnDkzM4PBYATGivqi7Nu8M24234yYdsGKWJezIl2C9IYgRYL05CE5yZd8vuqGhoBC+W7dlRCMclio+/wA7lhhbFMldVL0MNLoWc752BcAaqU2gPSBK4ah5izY+83c/jCQYFa31T4wXrxurvq8376y7/uayAZTOs2STlPSij0jUKh3VitggXnxAfgHIIi65XYH7wg3gnh0bYvChTVw/+zva2pd+6XTsRwP5I2HyFvlAVbV1h2Ab0SnvUnv/Va7++urY8lK0m4pYC9EdnljGEwyG7dadlltJwPoZIHB9hA7M1WLAJmp2jsgHneOe7wRHvdwPBDA///fm/re3dPvTCrF7KQW41JvPv019IHSl4dqtaBEKBjAGEn8sTftAyM9zEmZIRbt/va/3V6qv1iu8zMHHQYpIlLEC74QQggSRIbu7v29hzidtVetp04EQoT9x3Lb3WYGQ2SVok34rPoOLmBFcKtalJijQQg/QQg5BSJUMmKsNsRCHYjl9iLUDiOO6kKccQnjpZeIV16hXnuN+OMfJhzCBxMBEYDggIL8+tTW8pLU4hx5tCIallcsLC+C6zX92YXofWOssgR+OMDUKkiiN73hqvIS6P+n5GHSrpVmTy+GgDkZCpYiW/bHdVYPF46hkH2fj1/BDrwQkGX74oATLbeR2jV3vCogihzKqVzItVyovGxT+nMkM2wOjZwxeqjGnLF8IV70LBoXExdti0OLT7n0upSAXFir7AkOdkHw99S01K9Sf4VKoCSo4PGyoIaWpkxDq6H90DXQE9Bb0N9hjjAVrA02DNsKewV2BUbf3l7l5NWqGpmCGtlBb6KSA21LTu7NxFPuudQLqZwaXojFcbFm5oiGJMGOvxtVpWzpg1zL2m2GLyGzf481dFJd6MX3M4Ng+LQbkRlaoCVak5y9fjqhGtsUHChLWnkz3mS7wfHNmg9QC9rxXzLPuRcNv6NOqU+GsEfx0jgxofGnwaxiHluQvfTsVW2v23vMe05eoJD/op5wUjWZgTxTU9E37vLm6AZhWXqvBU9QtiUohrWoeR4xgQAAYJBAes5a1axbXsGeY/LAm7/iAhp/k57+WSLGqzEAu8rE6r4VfEBaEm2pL7nv47rznmLtE8tEv5OOVJfQ1nIQCCJkyJAhwOxxBcvYqkfWZflZtsq7OaSaSvJ3CdMRt0ibfImeiEKTFDn7D0x5ZmJhXlqkllF/FdghQmqiV1JzUuJdslHWRD8INQEI4HC7PvDtu3rmsXdcFXBAsAn2kFkDfcDxupmYVKQH4rkaAAQMAAwgakBKcETVpKQjd+ViiJqAQIZAQINgAWIAYGCsYlYEuO/yWqWu3OLJbjA0o6tJuz0kv9Sl4UW3qWoplAgV683rJGEASHcYpIbMhgIpXkQHYolfq1uFv9vRWoTPopZVgiLb6PfAdWtZk1OMYhSjWuo0S24OvjtLpyZm9/bbPOOdkLTQstsKX8JXzvc0x0JyBDqiCwOAJlCM7w8bxnFzsnjaLcmKrEVlNUGdPCY/in7ifhH9ygsgAb+IrjPnQSRj47y8nag6JeqY0CfXkHDE9rkA5V247TmLgQzTRRnFy7qnM85rc11ETV3ZfuvYnW3YxEHA1TuDVs6Xygzb1Cj3qQyDVE2nZ2sJEHPhAkOTCZHBkC44E4HGCjFkFUmTnnaeLUOxQapmjmAAJWYNenhVqON3lQQJUTZV06CmOTjYUDcNHh85bK1mo00+ylBiaKVUSjXaWHd1DMqSyE3Jk9uwUKawuZtwGxpYsGZNJFrIB7wA3X7xEiUuiWSWXKGuqa2nb2JqZmllzboNm7bsUxdMLkS8RJmUKlVpMIbKTLO0aDXHXPPM12ahRRZbol2HpZbZapvtrrrmhpu64Jnf/aOjq6dvYGhkbGJqZm5haWUtv7WK8HhPFanzUAsqffes5tzyGUBTr77k9brBrEfPiyctq/SmD5/VtKVKXs1HFfwhnK6GzG7cWThRlcaWkgNWWru4jMZE8Qk0eHQeJyhgEV856OagYiKHCettDNCe1I5eZBXbqtCGy/xXNZzhG6N3+tPCOh4lEUJr2y8QOjoCN5U+pRclZNucFK3OQ9sffEB399e4XJQGyxQR5+V2pbldotRs5wNU98eojM9VuSgJyF0sjtjXLSlHXSrFhfy+DUS4CFjokdjNfMGgrPKN6bZIv3mpQLE/1JuO4XZ1uOxt7tIYdHj9GYAg4NyGaRR/hq+4Mi4lMq0EMAJs5TakGUYtgMyjWpdTLAVCIgxgjrwsGC4SHBI+QkXOFW0UO+2WpNatmSLiOGM6QsSeK2Q2WhIhbk0TMLtImOHYVmNpy1yMaKZymfLvWi52VAJMgtVfIWZP8pAHDU/fKM5oEcLcsMK4UokBvwWq8oz6ptdFBFf59xoMMzIhmkfmoPxgwYgmcdt7AOtf7JAvXnctxN3MambSpMDvgI3v7g+ytlVZihWZwkPFyrUif3dhQmacSUIU0fb0Gidfov6qJU5LQ0IiFKwxS1VHdzJg6Cj1YbIdBKFL2MhCIhNIeqZFZbMxPBBQlQEFNqrVoUINd2etR7Z/3oNwM8NeBdEl1A50q2C8SBlA6PiLTodoXEuSzxeCI7iayIMJsc5DdttxubewOoRcEwyfK9h8LZsI2Ua2hyekxitjNPBHX8JjydlKnPbIggKD077pdl7hrvHcF7jYTOyfx3LOcdsNQ+skYQqmWctitVVDXVTqRattJT5nQZnQPG/TVZsFamLeAyQdekSS1JVjVGF8jdzD009IUwEA18iJ1DFYhSaUQKU0CTu6ROTI6LAwkqOnQF4biSlS1pCxgax9LFyFpWuw7haUPIgVj2LuMUw8g7aXEOsVTPEqZvsUNZ9j6gds+hEVP2HoZ6z5BUW/ouk3bPgdLX9g5k+M/YWqv1H2Dwb+xar/UPD/sgaC9RUCLok8nZYrOLaVyRCrqgtwPC9SyxtBQ0oQ71gESBIoASUTYJfVszloQM4FFDweG94zj4/BAjgAr1IjLIASpQUjBNSo1dXXBgEYEaAmaAQCMUpwruZGFtvICb+V4X4Uu0n+mQhAUNFha9xloOjRewDoCEKhyoS3PENzuIgWYf59aNum1mzYn3JpiqW5dYA7fqo4Z+48TGc9026aYmJ5dl2gKAjMLl5sJAyTMWphgzcZBCm4v5+kg2ZJsqzkrkZDGMxO3taPskhYCRUKL8AntkIy4HaBTSf2aJeO3nOq71SrwcFuIwW+2ZzZtaCUjGg/8IUPQAbqUHVO9B+jVRPNb9Q4ZxVmtjuKIOCJIQ2S1ChnfvqmWjnP9XQROCuTuRyk7KaSbfXIHDptCsCreR4FuN/BCM7mh9WXBlW5jkXiB5K85BzRcDt1u7TVgyOxu5jf0zOMm/mIclj4bdJ/zUKNmHqQqKv/EdFVhFvQQhM2S8qhNARPnHVxki5rTD0S3fiHYgk9fNqe13xvnJekqVMXngV+q1QTj0uNGYPYDn8IU1lRhYqSfckQmRhD9MalAD6XY+4CERhXPyFZToBck2OEuQpd0SUXRmgg92vNiqY8TyRpqze2+gGYQWEClq5FkEpbFfiUsS4X9G+mamod5ftp6xDy4cxZ668sAq7jdfvEP0iI0i4t0vxBZMyxwVokBs4ptIH8wQaSWvKVgVVMqGSxbQgQUKlkSuxWNXQgVqCexYOvSZ6rO6pbkoMlsWwU2XaN16dcDA1liwDC1tEBCT9lSXSRIx8UVjps03EeOhh8FJXEVJuzn7Qd1iRsR90eblKRSotoHYWA4kvIumpJ6jIAu9zC23y5gZNnMun+3/V1Dg1bWnoC5Iq4pTMiAWzTLThF1JEnpweLWpJqd8M+HVKc7gfLN+auAG70E8S451rOmfXy0LulhjxYTzqWmi4BXFqAIZN0JnJg6sDDjpCNhEsUERVCc+ZiSGHdzbYkWKPemR43+gbBqwv8fqwrk0BLauIVJmshObdpOCpZdK8KkFYxxWqpiScrxZLgOlAuY1KFCGrGv7PllAPwzjZZH5uz/MAXzK59mJVkopRLRXGQoHADABq1GKjLzM2LNMbTI3neUaQUcr2JSgYpr+dAxOVaWrmoZ8lMePMnDBnap6+MKyKKGdR6rDHfzVlUnk/K/iHAjntEfrIP46sh4g6nDySRRTJ3dcVIOK1k52V4MKRMUWVD0coHQRgtvVzJfP+Wnk53vGK0ERV5ICBllU0s5Vbwpov5SRjLTEKl871pEVY78LQJH3DmQGup5gaHJkFCdVvBpT98Doq1tcCYIiD26Zo4h6Ea2vcqNBq84TYcp0c20sRQG7CjhCgK4tKhbElhi/UBCZl3BmHzF5IG/Zx1mlUebT9dDrbIeWzjU2LRMFNmFJPIm6NLYTUPkrZm0gaXWGag2gWH9UH8h3EhnWsSSdUXwMbhJdGkln7ybcfLXmmx89CnltSgbgIb0yYC7TG6jb2zeskVfe3ohEP2VUADZpL1ylKRDq2wXUW+kSPNH0EDqOkA2QThKFDMO9s6eyaZoKxqo+hfOTN43AUVwoTK7hgBCmNXdgeubDQDdGMFWlxY40fwTV1QzUq8tvhwOOwmqwJREOnQv8rREDqzkLim1UiZZHmafAN84aYUFrpWVJxfOyKUON6dLUBvcr3NBEjtKF4mIihRtbwXBdYZynOyXXFmN6J4/8xHIp2VUYZGpuOXVebDsgEQawN06AGDHySpDLzcHhQy+wzP/EZ9vjkgiSavcJUCcwpIlimScpxZSOdxCa1FEh7xXY4miTCUH8+H2sdox58R2YD93qzB2KXlmjFLmIOwgNbzGLHrd86H5siRWX3sLGgjFZKCc5iVGZnwbQrWCrUYHOYSDErSeOkmoEIXomnVFpE5eutODzSQSmXC2KJNzEcuh5qD4FiiP026AXQPHCW0lH3lhJYG2proaKGrg54e+vpYMcCqIdZMMDDDwBxDC4wsMbbCxDqmNjGzhbkjJI6RcoKiU6SdIeMcWfqORCEF8oQgXygKhMXrCBdBKBJFopCIRr4Y1BWLeuJQXwIaSEKx5HhDY01iZDKamlIyNtWMuqdKCzOtiDcxRxsrC+OtLNJOqgPtrEXGuhK13ib03Gwbnu1AkR3xQjvtJaJGkcModgSJoyjWiTzH0FQX3/CuS72wOvfxikcw/rGJAABgigC2EACNQgsB4FiHv21PYPqOiBc1yZAS72OaUOwzqMzPArCEtOeQYGyIZx2HJ1hZI1h36NDYkbFDG0q7eur6GsQatx04cZwzcgClY9uFOcQq6gq3iVPS7w12wGgCanYagR3711kDHBhuNDI2VoTfyjSDqt2t1AA0ArAzPAABqovBoiMbuZMg8i5gZmnvuQceZw0w4AhUtXgyvkTEZavpsrRRTKUS0NBC/ALGH2KVBqK/IikK9CW3GA5dYYkcmvZ1o/iy9SRgqf1egW4A25q74Trf+M6dqMZBADe6E9G6ESYWadZ6Wyz1NSQjrjQRpQtHZ0G09MFWkXeJMsNmNIlIkdCkYERFk44JAwkTE1Z8JhKry/UCafvouwUb7sPcA0g8iIJHUfcYep7A0jPIew4rXornes3riDew6k2seQsTb2PVO1jzLibej0984EOmjzD3MVZ8irY++Hfc0kHXRdPDDX2kAR43RBnhPmM8ZILbprhphiVzLFrgaUusWuEBazwhd9Kfyo9cEY6voWhnGUvhZwYOtVYWiAaxWHWSI6TZnRJnQ4fMmkWLOfURfNhGIV8hWcmAHehUzT54P7ONnA/7CWu5kLrrQVElKHTtV9MYKWCPlG/wgdpBJeaNkC3jhQMRdbZyYOASu9C6iJZG1qQoqwH1RDMHpy8AsARcekpN6dpKg1skz04xJ7yjPQIcvXmCeDvQF8NA6sEIklza8EdvZfKsVat6aBhvXp6L9DSuzT2CCkzmGW7Vu9lNQKxVWTbDLleq6TJxN6PtbGChVLrtS0gkxOR1ovM66/G2d+Rcj5z7kPYAsp6TjFHrrC7oos7rgi7qvM7rRKc9xidAyteSugWx0d8Kt4juHs4SBxssLKAPsq6KeFFKgZR4f3M9QzQxKCyaBgAAYAIIALwALxECVnIAsGYNbx1vzUykwSAwiYZas8SxkTE/195onfx0VVApAGrURkDVRBrONdgoxhsrwm9luFfV2DwRxF+j5ioIsOwq1XGRDXYLxqI6tzwwkZf815xqGxpo6QI8NVUOW4XP4iJCLIlKZzBFYtuud58HPOc1r3vDm97yNseLm26546577nvgoRfI2DpSkLGbrgI33PPEKx988ztAlia6xCi4UMKKINKooospQQlNdBKSlpwUpTy1ac74TM2szMviLM/abM7OqHMkJ3IuV3IrD/Isb/IpP+fPJlMB1acmJZRWTkWVV92SWipveGOb1IzmtaSVre/oTuz0trat7V3Z9d3a3T3Qzp7qhV7rnT7qi77rl/7avweEETLigRmkwRi8IRkFo2gYRsBQILEC8R0k9iD+gYQPiFSQ2IHEDcQiEBeS9mBO2OF4cslm7X7UX65HCFiJoRGnyf+38dkb91rfRBPw18Z8zIQCnhEVR4F5/I5j22aI82dyOP5Kq61fXrvrYQkWfQol6rYwFeuCwO1gOEpL8WYKTZepfu0zmMLvXnJ2qnue5SnflR5HPcBe88vPg1gYScFWqEgyMZI5GWsyb1O16TXFZL+La8mtt1fE96NJO8xBEDkmYOkoGWvPfPaX5HT1U6neaBNN16pNu5XW22q3AzqdcsE1dzzywjtf/PQ/CBEScTAhhRFeJClIUQzfSv79yLBJSVYKokx1GjM2k6PKnCzM0qzOxmzP3hxKF5JFVSMZC6xgio5lM+twodlWdbzxPGMnex7WnhlHJhWsslav10NV9WiC4ZBaR7+NEebe97B1elaW5CIpMIgKG1L6D9gQHt7AXgZjax4fu50KVOwqnqLZaVQ6eIWkeA/Wp62rogy+QZ9R+bFcdITV0sii/Xt6a3Ij2QgTS4qVzMVkU3hp1crHQgv5WmudbtTUeujUpaeXXurjtdf6ohhnXAT/8Q8vHMKHDj2wNzgQHA6OBSeDM8H54FJwNbgR3A7uBQ8j0A2j8+HF+2h5tU58i1/31f1qWH1pRZcSqcy5LhW+h1d483lXXFGshPOVPaXF8P5/IDge9LyxPTcdA28eKi7H8H8TwZTstXj48O8H6gkqmkgmesJgOSasOfLW22ABQiUhIMIfGI3XVeWWJ9U5qH+FM/VTLiiOX0QWR5Rp01CbSw08GmRNGKOsiTz0VoNKVR7dgmScExmxBgPhnjD/dC2LEN6grH50c9IhKhmsK0Df3j77DcqSEItuTOirH6Q6jRACWuGVVGDoDEbY5550hoA+E/9Q5/1FnfEHdRZBXMDUcc2x3idCjqJCr6T0AqE4byErI2wpsjkR/ONvgeKpmBWqW+rW0uaGtLRdiW5finJl6Hd6fVv13n0JAo3Pd1ZPslTCI3wQhuQUQliIuvgQjY+fU9dewIU+VnZ+NjL+nc6vFFkNgK4gYLiUAR2j4RqwAwDHPUNkhA6br5UC1zpGtEgixpsC8gzQlagabIqCAQbYEAGyJQYBG+JEANieDIcQrKSZlshS1gM90XtDh3HYlENT0IpoFlolbWNmT9+Qm/6jBSuRWVq3lHZ/T/TOALPFpnk0OU1Tjutyo4+hmZr5Z+dsmdv/778DwP++8MP73sp7i+4Vfaq8ewRAHDdgfbZgZ4/rsRTgffCBM86Cj50H8KmL/pnBdNEKDxHqvrRGfOUp+MVzwG+Qpf+K2hQagJsJjAWXhwL2T5JS/y4p9Y/T/q+czmCy2Bwujy8QisSSfKlMrihQqgrVmiKtrrhEbzCazBarze5wutwer88fCJaWlVeEwpFoZVV1TW1dfWzdTJw0ZdrstvYVy1euXrVm3Yb1Gzdt2bx1245dO3fv3XNg/8FD6M+66rovR5b17vxpuMDkhRgArqkB3NhorXpM5h7gpqavGsaOzT/WdfnKjZtXr+1zFQ8f338AuO/6Fxg/fdyMqTNntajmzsPGxUsWdZ48XQa8X28iQDAEhMS4U2sVIMsBdHXIVrDWc8CGPwDjEeiVgALo1CoGF4P8HkpjoAsYdJKVpE0xiRAw6PlKXFrNINZjYBUMBPBIKt67rbVAQp7OwzxZiRhScSCMFV45gJEKbxIxaggiLeKDNYMhQ9Kpd5AVSYI7nhZXofwRjiBnnBP7mEcCWE6xdxaV+6NxKRHDYZE+CB3K5rXBYc6wJE1PD/gZ/2WmNs3HtEkS7yKabZuVSRas8vSj2M8xevicOk77oht020W3yPqd677fhD6bj33loCxor/1ded1n3GM/tZyF/VaHwLuSOt7uktV+DlARTK44KKfS1xkrPmWaUpG/nF9+tgpyGMKgayYt86MPV+tYCAyHQ4VzaHDwbSl4rXnJUFrldlrDPNdpVcrk2qAqVnMB5Ls9NqTMlconE71vXLJMgoOYbEoCI3OJJs0P1WBFKsVlygljWzP+qAPraE85SzLqO/+c1MpV+T5NsBc8F/ht6yz7S8dQq0WROnkSPh3nc8fQ5mrXuZf64MIfh+rcpwXW7cOZWPKRwzKNBjTCUYlS/yjnJz4l4NFcnZGbrAa3n/U5zcVpqlAu3/B6EAGyNw+89WWTS43Nz550PJwKO1Zui4obTlHxhKjzwbbxe/xCslF2XNgS7JmP5r/Oud4b+z0w1mGlZRpfxNMWNeMwbdcLlGc+CB6CxRF0nsQM9y78Jjj/KEeLy+yQh+Xotbu2zMYkphs6iWMDmalwgrUzZIltbLE4+SAieYhmBdBT0SBhShlqGR4kYxAa0FXScy+f59M0JWA9HPJBbZypjW5v6LpSC4hiB+RM0Gu7tZVpH81b78ga7FbqwAMNGJ8Rufx1oioYOVXqEHe0+CCSHa2I9/2tQVNXtD0pz9Bn60SIuwGLEZTwT7cL8+W8sxvLby9vKzFgHM7Wo1puLcIPWwXHsd4+Xmib0Fpn8cW8+f60PLGVBeXwhRQ58cppMkjp/4wF/x/D5QWSYW4Bd1agjf51AXuLq2P/PAFZzSV1joYWct8RDkv/B+qlDWvd0Coj8CCukB6mAQ83xgd3zeHhjomAVXrZFUWZAzssRcaCvd3B426HhxG7QsECvDQ9RPONOUCyZdEyI3/kthotuFmXKV1msVwCumGU6qH2v0bbiW19FtG6sl20o1afcw2VAfaNPQ1TcSI/g+51pAKv5bQFIEG8sIqu856QX0zLinIBdrtcE0xVYMUP6+d9iEP2hgDFO2otd3LUJ3rNVOfnye46eT4CsIvWVdFaRJfQmKHXk+Pq82hE0oymf8CZxl6y2dqR3ScFCcM9Q4vG8aCRIZii6T2o7hfpi3Dy0D7IhNZeSWeimQCiGc2HlgGj5EFEFlStCq2Cd5kp9li/0gO1qSBta/5kRb1swQIa+9q1hZ3SjNqJ7zK3AyxT1tWr8+xEkxxpsrHWNJM744UMIloTInUYMTOHeKfUh14PDXusWhgjUvL0uJjV441xprnFEXU1PIRhpBqmbsPRVeqOGY7Dj9FJ0Bpw4ASO7zxmQmvqaouhQ4+h3q08Xa7C4LCmDfhMaycwBxzPYHF4fZbHQytAxNU6RTtROGBqi6cjOGDIhgrW5aHT4ianFDiUKQpWZqVM6rZ21J8bib2/W1O6zgu/UNkayMj9j9NKNLJVppftlbvQc9+8ez+fZFeuRxdtBo5M0z85KfyDvRtB/8O4pQZWfhQ7OZq87hynJ7/146CO+aP8kDckO+/pNEToOdfGlVmDDrI4OYRtnbTXuorHTomkuymAkjmb4SbkkFFgcTptTWCeUApcDLTZ3njiokNfhFnRoCMlKXM/wpFl49C3t2j+WX0FnU2qZOknmSMGGonhzi+wNYFMxl7eg8tx02++G431H9iw/kYwvS6ZBEPXIaZUBd3kssSsGyZhew0fhNUXXl/H9by3C5eWJdGlzL8ntcK2x/ljz8QHUw40zSyqR5++ZKGaJFcoFJ1P1KRpJ9qySU3tzmnvsO5dQ2SAijHvNan2m/hyRI2FYKRZCl6Yjd4ne+/E2BXXXDNfekPvdlNnHikygCyLEUPs4WtsD5Wn/ophmEeo+WUqxSBIfxLH1kF8PZ9PPr2wYoIcUMx5dBmUouCTy2EO18EM5Z1jj2zg3BFRD2AT25zQhGV7LR4XFIICyoGzTVhKYDuRpWmd4+SOxaa804JLUDr5czfjc0thpuD5IqBHuGYZ+TCIaeSp3g6RXSkYJsPsR0P5FYNu0QyxcnA6YP8z7KU8b1IZRiInPAo/pP1+hSiGJOSkCFvpeCQhZjcqh0jHFta2nRqntog7EuGA2oyhRVjNCtvHj+Vonjotns9dE/v62hSDyl4VentDev6XrNHIvOzBVEriJBdWVpBKSPQ1Xx9L6WaU9qNXhi9NeKCmtMRB9mtAlwtDmnVaPF6QXHPrL8savexGGdhccnALMfKi7Dv9mQy6AIYcHmQnnIiPJHAlF1P2U4eVxxIcve6VXW+WTzWL+cAtt8BJAlU9dozFjSMCWG/3Cz9HdlZF63ld3lE0dZu2JITgKKooV0n8dOsq6Qv9K+znN1I4MU/v7b8h2qKzzuTqjU+9lq6MWydxFnTom7WK6R+O2hnk2YJY840lc07u7BAQmGjv3bR/w6RGSx43/RY84Y6tvSpsika7dgxDzp8KhG2GuRZ3ohy3RCo/ZX+wEGv8tNhSmYjFixyWtI7N0DJqIyVcU/S9Lsh/SJjLKZNt9kbX8L9c+8zeOVMI3VdVG5F25lD7Q+sWFgUWXTb/yiV45UC3JM7sU2futXb2yav0Vfw5XXO09YT+0sRHppeLtH9t61YDYQWCRu2ljnZOWczo37JXjgJ/bSTaAB6ctfB+UuZAn8gULFtvWsvMVFiLxv8mHdD6K5Wmu7P0nJbmREc7pyiM6AUwAa9TcbCktdw9l6xAkqm/cuhmXV5wEDeZQvqniDFG/XO8hEvNU+hbJoQv/v3/3uGVQUZf5uC8XiRP8nR+TCA6Xlm8hXNjd72V58v5Wt9RgauDR70T8Us7h/smU/vAk9oQmMhHuwdr+fKQo1n1XveUzeNpckNcHngLR9IyRtBi/jlzM2drzJvrLDwhlE3m6DFTzm+TZqHichPfKE4ykyac9AwM2gkrznq7S1AFd0ssOs8QC9BzIjLRwrHJBeD4EVGvZUUzJ+ZNn6njglL+QpGtCyeQKOJTLa07Wsox4U9oYSaTRx+ZPLu6ehpm/cxDFfb0LwQ/MqmwtHTCnL3zjzS7jAg3UQjNyXz0z9Zw2twwuWbPBlHJkU8dBVkdxaEkE7PdZm1EWN/XRQ5WgeSCCBzvbgO26OissEQGvbWINtIpkc8wiaL7Y3mQWzYxwj6bqAV3PoiSNm9kxe8wgfPvfxa41YFLydsGkV0VkVGibKz+QVQmqEX/56uzXXwsxEGUhF6yISHYCcl8LLoIOaOTWoX/oeOdU+CdnhslZ8bsCMX/qkzDU5Cd7Gh+7fzhhA0K9G3nlIWxQKSIPYwzIkYKpWPehknKLhdKy/rUTS2jSUXa8w4Lajxd6WdjMqe/d30hVGnHpHtzrzATWcrodfA0jEGbGXSEilSRnJwkjCd3w5yg5vFtKUkZB65gOApNuvzCVofCKDJCRMELlCKAwuVMujy06Itp8Hz3USJ8ZcBdUYnTPfpLkB/OoZwvNBxwVwp/Az1WGH44o5uW1lNlKykXsU8+BoPtApx2djy5aStcWTmo83N0aJuH/Zgfn6qFqFW/DmjwrXBF4weWD0D1zQwi++rW4+ibiJ6nAho+FWFtSBN/6w6qju8yHK/E/C5keBRO9xf6LaxmZn1q0nZ+hQPH4OdqZIPV5aSf7KzT4bxghVVEdb4eojcgoz15dXyvMFgd/OSDH/RDgbyKoI1Hch8PCzblVPbc42Cbf6ccxBccVsvWkzb/XApmFYnFigRKYy/zB1X00KSDxv1+dLQywrnJdY5sXBRVHiqXt3X+F2HwilpUzzUrPHjRLrYQb/jYwC8T0qwcEd32USlRzjPm/nSIxXoz+xd66SACYx86jl3gz0K1bzrUG8VrbSgAy4Xwn912xMOHvtZ+PbD/2331wmw3qNtlsD5vsILi2+H8vYG17b2bt1jrIt4GVVcir1ECSe/1vFxiGTue72VWo1uAdrbjM+/c11WB9VM7lfL+XTbSuZWCsweN1PhZbXhzp9G9B1wvYZ09jBk4zDy79PRog+VzQiwhTU046Ohd3TFbYiw8VZ+b5iLEngLP/xPGuEcP0JwhQGPO5wbSBKeewLGZfGB0uZ4ekJppKpNIXMioKMo/5F8x5PNW1VUKz8RhX8kQedtdlGkBblQhRyrapeWfmUCDGTpZ/Vn6iUS5672bTyrMs5gh8OyW5dhve3855TNyCZx1ky0++kudFCIx3PERZAVB4nqKTSgmO1UmvyFvS5cCcA8WztVgyVD6pzyehfWnP9qGO2bNFsl82EU32bZQlSsH4tS4dTJWmVXXSjcpXOhy/eE219OX1fJLC7GZMHa62IEdAXTCmAy3tPHkscrrIUy8gjCW9dNZDTUTKLQF6vvp1+3qEn9tQ20BO+b0dEpsKi+6mXZ4wHn6mkJ1fpLAyOT9IeDWJvdmN49vB7DM9r6lXd7CqcqRwcZr7/sJBnyVpaZKTv/1+aQkGvftfRibUMmJOZ3tQmWf/IVZAiuTf0ms2Hx+pQG9laZbuKULpT894pb4tABgoKfB5462enKgywUWBYfq/C3GMBV4sfxxptFf/Qvsf4FdL2D57CWtbHVcdnkhgZLBekN0OLo2ldQXIxTAKBuFh5UB+1crvGzGStWezO19SzNuLy4jXu6pBLEkZOhiEnV35kbM+5uI4yDSgRl4/8j9+eRzEYR21WYrkrt+HAEbn1G3BmDlsqMYRgb9EoVX/0uf/IevLDcmv76j0iugupd4hGdz3D0/ssrv48tG3CPSspBooYtgqcmpCEwPtmxWhy0LhJGAfMjJXTArKDvhYPJUO9mZqcG6L2sxJRaXixabZbmQWyniU4shiR5FKi2dTqUVWrJ9NRIaQsEOmFRVJKU+zg97dB1w4wKbHaVhRP+pzDQXc8o3cnIuNj0j5DW6zDTmkqEsKzYtVQsS2YfvBg/vaEkkfImrqrSleTvBvoSA8+3HvSyrqc2SC+mR2mRycuCtKFVXGhy1wQ3OQhhqK/ko7YV5MnMi5lTC0NtI62kHgCxTXck02pjt9mrVnrqhlWZP7WAEF1iuLMud6yHZQnXZPnS3BJexYkBr03SPqCSVG0NgX+LekunnVtTk76keXGOKZKCXWeqCORW5NXJ6uv41RV8kATATiav4ZfmUrXCzMZy6t4h+105pLC3pxS5JTQP3e9LW19jt8lKG1kprs9UW7KsfXmUqkwRRBv7/z4zoX3LIVcFIdXYA3V1DoFP+2oWlLX/vi8DYUuzCNM+KBeARDaKhrZtIrCvEQQ76dnQAgh0KVb8bwgyVHB4twEo0/4Gs7O9uVLjICqKlcJyoucahpu9xDb8d6w1KBAMLmK8MPy6TF9a98vxbL1GF+6f2Aoz7aPZpAH4ZGHgHWje2/WPnA85IavV74xOJrU1uyDP3Ph5jHIj9/HFo7VdrH/vb1Xs5KwFFprySZrHwOlyVyj11C56z+KpOwrzcFq3JKUe15eMyl/efYhI8zf0xF9beH4tquLV2UyNLu1P+t2fpJkbKoK06Dfs1fTM4dbpH97cwSyMeihr4+WZCtW6et02ZaENgoM9tzjgcnzo1F5/ngEPrXmskp6mnJsRFu4SGe7vK8nZYkgeOjxYvNqxz4G8Yt6qQbe4JbbNwVXproYh2F/tl+NaFboGUE7RqGxk632Kpvq2m939K1f/ZlO7CxIiRfGsXX8wJOyxtArBP06dZd2x8Fr8s6ecIkCTK9onliKYWndWe7Q2dmCl/AeGUdNqtMYZxYKSvF1Xk9I2DU8HEehwcmQvr/X2atb0tAVZmJWZSMBm5GfVgCW8PFA/FZ4R+G9KsZyTmYIyf0tm7KwqBdlfD92nbv19L713n2Fn7OO3E4zlKLUgoERuObKxhw95g7y05o0gCT77DL9uWkItz5+uxWAFkbaZ55Ze59ZVTl6tyT5C2GVY22p9Hg8pfan8w+iG2GZH5GqKtBNbw3MQgKD6HGf4/Zhgc/6GpyHw9wgEnOFh2GjJFAv3Gay1hu3KyTdxyzipjXUQhL7RpXanIysnSnVp0nNBCPP8DM7E62z/4oagKO5hlJcjgTC7Y93DSFFCwv5SWHhmqmi/KFtwB7zKFLtwwtaLYxh9yVTTn69iG3JTvfEOi6UecMLobGbHlsT0C1M3m4v0dMoaj17HaRp1scslAaqrA8RXsT6jsHmnXcwedkXalkWLMqrcL+WyDX7KEEE7GZUA4UwWMY8IKs9TQUQBPiP+zUtVvyxr8Mgd5kmAGJ2XkTfs92Hh9449WdNwKN/w2I6+l5bnZCr4NMQhmi3KQXmWqQOZrcLi8f88Owea/sMEwfp8th5o4RgmLaDtTRTcSTittIydZfnRnp+ghXNDwjKmmG/LxUGcOXbnixMQB9Kf84/+5lIUblRtN6PJmwScNkiyI2vnV1PlnyJ2graTYYDPmmRSCz5ToeBXvLDOdksJ7X1yUjV1MJuxIQa2vUWZNgjdtbCEuXYkTJcpI+Jel22z8TFaGpOyAgccEi+CTw84si8vq9Durdr+7uyfN/ziFXoHZo0tWHPjkk8DXi7FxtwvnE67xOYlTk2CR2u0tXTS5ZKBkJqJtOvOxC6Hv+u06bbENkfpW0KUv0tlKsF027hvLHs+dhfNgsdtTUra4bmMXF4q1cLyHQBiHaBOeOdag7PqUwDeZsXh/m503Yg83yLQ/351GWUFvKaY/twZCzeBUsy9ZMDxFRbi6OzSMSaHEiQ9u4kLkN89+MhruirynZw9+JWzwvWYeBU9czTRbpe+r8sAnmaZusTgcrN4rlq3EZttftZnT7BY9G28uC1LUxQ08fnsX3GNM5jTuyVHCIVk3VlDA6dHGNCxBiXCh4yxa1IWMrCROtWPi7VpRndsK/voe1A0zCV3C6qqGUGyjX8I6vc2IMisMFhA3wCdy5hFvwsJvVs9vyoEDJXwCejH5ZahhS+zzlVkXM85Ci3dHPx//Br4BcQJ+HGreXDm/CSgeIuO/byk+AV1xYtujnP4/tuiPQlccBVvgm4yx/xEuLGH7MPFYwimYyJvPvg4NXwcidFwm+g4d34aOy0XJ6DhYu5b1GguBZ1+UZLu8mF7x9kneO7PrBEOoVq/wpg3/4NQHEMwDHoyCFXzmRbUCJQPaS7UZrItclVLw4OSHI+hSuKbBzEd8zOWphxRs8VJWyGZhKNCPj+z6/NcxQNoxztVmoj6N6H4/CCJaifonoVMpZmRgsErNaDEGalSHUG096C6R2XC+s8C6P1JcMHcKWlWUXa03pqPae2BC7Q1dPvz0MDIqARTC2A+9ypSt2EEDG69kV9ssDdxif4tW2O8uKOGrtI4SNP0ydnAzhfEa4VecFbcYsDq9pN4aS6ir6iUeUi6pxRk1ntpKp6t60rv0GK1t+V+uO4TNTaet5lDHAVrHCGPr8WP7kOF9WTYzdnuDbocvG3Ime+6Rrv2s6eCFdrAb2Ddrb1l65P5NmH/ygVfYIprjZBlJrmljwIJBzQUJR0AlCQUW1EOVTVCgC5rR+Nc2M4QfTnnlHK1MXNC/GZdMEGn2jbWlFtS7sUV0A/e60JJ34MeoeR/BfbTgvTDzJiqVTnOWC5rRu5mnB1RnmjpEbj8/bqnUbmmLz5aUN9fuNa9Rf4m6iRMwqqLr4yN5hbToiSBdBqimRf4q8JbyjPjbeCNfRq/UWYJ8qdul/65BGP2azBiuQXiwmVBCNo1U/yQqnufeXgd2O7Xk/xIyIN89xxFcyS+qMIaMCmxqqqSQGmXO7HHxtPpggRIhoR3kni7XTGAzk3NmUYQu5zho9tHnbJiBi2oS+Okk34i/vZujZIW/LmPk80zDU5ogNVz7rq6Gn6Zz67XkUucj3VnC/yDKLyCjzx4iOgxL8wQkGz4FjcfPgUufYfKaMQDqZX95cSlLRHUNuygCa2lqlUBhyGdMMec7wK0ztBfM0oTJLOm0OM+YFD84LHbgc8onKsPH5ZBUZAyJf7c+SOE61Noid6Fcqjc+tHAPgmtCyocEPCRrGQplVmnPGykyvVnKZ1x9nf6lU1VYvMX/fcdPOpBOQifJ8RCylIfwAIOpTDx8Ma4F+NdnP5ksVoqL9ztPFnQKRYcqOJMKWZ9bD+5BGccP4CxcGStsMddzdZWoVt3GJ62HXWdWAeY+MZmf/PCPBYuuKSIfYdDvIuGvlgWFLSZ6eV4ITSgmEFradcDkQLiDwptQe+neqo6dRSzn2XsE/mO2lJZ7svjEBrLHjBc0j5HqoZ1feAGbDiGRCdRocPasTjXMWs2rNuWtgyik7ykemqm5+aa5necTSj3iRN8u1xzBzBZiwAaLLVSf7TVO6gaL7p0oPBEKJWeUJIJSziMiGqKIrokl1ao99bqOPrAmSnMP9wDxzRdmXKEjG+LTdf7uGXoMoMgUuNE/+6o95aat/yB9MnU7nHMsJxUSHRySAaEF/pQ6quCHo+z52eguHpsWo7AjI3L+eHtwY4rUzYzk/k7X7bWPsRUMXOCQHGEfXa6PcprDvvR5Mms1GTP23gA4JbFEoqGMVFxWmru60FCQaM+dDG5zYfpdkA2yUru6mqwqCOKn7rCRDDPC6QmJ8hKjjY1bwJMIY/3A2UDK/W8XC5KTsKl7ysX/WSnvt2X1f5Etn73ALiV8Pqe+dFmwH1KZ4qLDbUGs62rbrqDP31Vg7Re4Yd+X8lRkQ1ZvoSCws/IEhIhI5UwpGTuVvbdri7teuQK2pSYfKHFy6P2PaozZDakkIe3xxYL35s39KoX2RQ0uPX9euC1cJx0Lhtq56qaegc5iZnuxNyiUKI3q/6UP8Go2dqj+qpEmf7/8+ptRRxoUf2P9wu6ze0h5afxJFuUD4y/b7tEhvhSQUWlFuK6D4u6BU1cvngCgSisIGjtvxKH+dAsWWmx2/bOOqF6vUVY08XtredNz77nOnFv4p83nnlF19ryQLQdbEYqoVyXPOps2WXEFUYbRwYp7q1Q7Yn3P6b1kS+qn53eH8bIG89gt4ZPKLdhAepsHUW0kNkJXbAM/dqtpBzLnUMjPgC6hC3J2QjNDXJXISQ6TAwVq3ttCp/CwZ6CkCE9NlvH7r/hnC1Do9QpoOkFZvPrBH2XzvtuxX3Nhipo4qILHZJ/tBLjrhMZdLnVD/1i/Vb1jF+CL1fZnB/vYW6fprhjn6FEQnNibdrkijcsn33OwMoIhqnlwFHIULrB0LWcynlAASWGs59bjaB+4Co0WurR6CDDe5PyJTZXQnX4BG7sB6k+Y/n8OtuHi43X0jACKSVcRlM+bvz3QuGfUeiqOTHMQan4F7/7PvWrbgPm7/RdT0+lH6/gm7+siiKTOtey5AzzvZyJEg/yIzw7yo8/XraFJgIvSHXvwy97ayavevLZmJciYnm9Rly5ZCFiziX76hyOYd2RZjyADV79Uih+Ks22iLCs3CdY+GAWiTEWUaXSwu1wNxbub4kt1prI+/Wjces2uUAS0HfeR4adZ1qfI8F3uHSnpffWJ3RHv0KgTDG0VP7Kc/+i8UfyoQUMLsrqhru6IhmbPrSdWQ9rWStdC0qryYuClz/z+81XSFP/uRbtT/NKq837/11/jygNOeshuM1ia2UOL3YxK5MaMGwg62YHdO2SCHXCX20SbDKiAW+GGbGeF21WOjUfzWrSBXWFhjPM7M43HKVa8WPUewl3ndH5wfLGGH63PjrARuFSyvPYNoesYKLKlc8AVdi9qMsAeWhDm+zBxj4Z6pmpra21pTvl0GePM66fu6cPE+2iHwTsmgejN5Sg5Niw2GNnCBcfIdpNHh7Ksiiw0Bku9ooLelpPkNii4y+U2i4m27QaiUPMs1yWCS8nnJSmEVNQsErt72J2u/egXcMpkNNt0AqpDZ5DmTq828dTdl4yRHwxvo4WfCcihw89o9vwpbBo0h4ltPudA2HGB2Q03lpKmadmBV6kgYTJ9IBAwxpOjQ8RcaO0Bvn6Ww3xPmDJ3lYKt2vcT85gwXMJPI/HSUQsEgpGW2r5+TQklLEXeFmarzcJFfuLgvnQ1mgMW52fj0Jx21cowPJlhOf+qSZfY0fdIxu88h0b9Qyj3XHEkmHi1IiTOxV5zHVgUIIYDHrddTLdcvf+JZ6T71/JmwdW2NSs956jDpW3mLPVyrd2wrsnk6uff8UvBuePJmmX/K+H1+nVBljniPhPjZhT/tebF5nT+YI/9O0zPv/DrcO9jLX9Wubsrup1ZxNBb3i0Kf15yJm0l5m+pTxnny6fTu6czedswL7x5UrjlMWs8WFmXuCU7XYKuXO895q4w5Fyxhy83Ulpnu7RhdQbjPRIk79u3KjcBlQ35+OVm4JLXVjfirYGQgWWyjwEaLg8aDMVUeu4GeB/i7/sNqy8NxLgNeJCwsDTFIBvY+LCyu7UM0PRdq/7rKEZVqkj0n26m1bPj+dJJpBqtEDoX/BetJzG4ziHJCqEOtOa5JolQhdA20FZLgzc5jm75H/1vZu6elvmIVsZ4jKPzwf+6tugb08PRMB7jaA9oDxDrcm5Rs3wBZl5fh/V1fVM7eAPHHDNFh/V1Org2x7xNh/V1OggOv1kIKJ1jxumwvq5v0kFkjlmow/o6HVTPGf49dcjpLYYB89+3KNIYNt40+vQOnwM+tus/Bm/0T4xP9E+NTyVyQ69HJjF9ZLKNI2+ifxM83pmem3dnBRjgAAAAsHgf9NcO0XYcMuRuh2GbmSsAXFp7efQZx6kJs7h5dxaTTzJ73SrI17x8qDSVRLo3L98YAePUqi2w33r/Xpn3r7wnjov1Vw91/Y1DVbx2zPSD70maroiWQ0OdwMIJ5F1mND5r+gcYmv6FGGGhTzXMbt8fKv3mt+4sh4Y6hThTELxSBgx1Ag2J0FdAujLNyIephLX7tfoGpnhy+dWvhfkiwtg5VJJBlmuRDTeBgf1ohNB+HJp+S3eKO59/4jL+MdIUIm3IAFdbijLkVEIisp35dPatWEDSa5haP4rS6Y6wFU+ZnMa7sg9zUsts281ZUNaFfZTe3g7rM8PrrD1P9uqclh32sJyagbKObypr23ObbTpXznj0YRj3mvehtU4f+G+fybwCvvooWAB++Ln8dPzRmp7j8SIHQ4ACAov8/wPGK4HY/3ctksXYmOoLyS2d+N3sV3D2Z5Vn0jZ6jiqbf8ZRSTtCGhjSSjc4sTm6UWLGGlqPeTnTeEXBMnfnnrJ8GtGvEbplGTZCVJakEV6NSB5L2oiesXOMfd4tK2Msj0b0yX8MPQ0GdP1snUbSUf16hKQmkopJekG/XiDJnjkpDrctJPmbZND5CdhnImoJCTOPvmv+qUb8VgtajcyzSeXGTK5S4gZNTcxYkLvmYPUvlNWtrNnZYJsXRlo7/XwgpcdPgTSxua5m80kVraUtyIKaHXWGttFNH7K1DbvxfNHA50vG6eczmgwetXEtwM4Dq3eh2vP5N3/eTU3amWVC77TPy2UNqP9JzB9FsaufbXvnp/br6W+1K6bXYKrDoH8uCF139o0YDt68Ee3Shs5KQ09xyjnFExnf6f1GzhedaGgp2DhYe8c1og2i151oNBhxanVONntk54e6D8X20TZfiUM3WUCiCMCN+yIhlAcvYqCVVBwBJLDrx/xdHOo7zG4fWhZ2RAqwKAQ4BrBli0nLAtVX26TzgTgCSEBiI5LF2XlRv+EIU9LM6Y9CNazfdCpMOA05MAkKYON25zeQbKRuEop0bfj25tUKkK4NT9THkVUGjoUsA4NvngHV7CcnMuf/w8Rxb7u+rZJ2xrtq0e5F/CVqPZ+0bq7b5F5ZthAmj7xEPVPLL3/BZeifWj3TRicsXqLn0yjmo8TNV0mcX1KLxh8/GfNnaucXmKk2lSsJUMH7zObyJgm2ZZKRduv3DIEsh1xcsTiIsRyseas6wSvuJIluDD2rG0vkHIlQ4aBxwSJdjUsRpb1xaZJ80bEyy7JT29dCB3A+QCNhaWojJbGzkTHYrUaO7lE3ckmyqpHHM0d8fT1Pu0+LUkp1yuXLlaeSTHe+uulLJthwIWQ+7XJ5c73JDFOkiCyUrGDY2Ray7eq8KIs3PM4rPc8SXfqj/3d9NP/7RPIyU/Fbj1ykN5lwRbLVkomSrkQFBF+N8K7sWllUrKQCOFypIll5nKhSuiL5MuFZy1KvXHk0mcAevHU3IGaLMlOwmq5XjMFm2x47y7Up0xylTo7jlYhwKs7xiGR5DJakWoby7Nrbd4V8pUrISqDw1EV3xB4SOWhVknVeZQnZvlJ/Pnxk5qqUyqb0zoRfxHuFH1UuH2ECKODRd8yPgeVXtBc9xMr7LsymAApTA/OQLOO9ZjlAcv2jk8x+PIFIIlOotGsJPv8sNofL46uoqgmEIrFEKpMrlOoamlraOrp6+gbXoDafUGBlc4unFFj9bTt27dl34NCRYydyW5Bg8qujQchfcsKEixApSrQYseKw4iVIlCRZilRp0mOwwngTHDTPKxOpTLPEOivjYKo7xpnti69mmG+yYx74rN16Gt98t9wmp520WYZMs2Q5K9spZ1x0znkXvJbjqksu2yLXJy1uuOa6PG+9N0WBfIWKFSmxVKkySuUqVKlUrcYbterVadCk0V7LvO8ozUYb450P1G7aalvG6Jb7bucs23E9X9vtsNseXXba5bhJNpT9HXLYgSqz6ZHdx5Tbkfp8FVU1gVAklkhlcoVSXUNTS1tHF6kiYhL5pGTkFAoo51BPu1SKR659pIJVlF8T6OYNFIAhBg0zampL9WPLf5hoslrTxpMxc7soa0GdiWlpX62SWNegVJ6BhcxpaezIxwbDK5CGG2GkUVN77YIhhho0zHAjjDTqLns3tTd/lYRFscahwWZG8Ft1rNOMUN1fZrpXRqu9q6n5k2pYfhlkRngx5CFDdfYb1aa+XBuznPTH1WFKweuUR9W5mbAWWzkREJGXHZE0Xc1MVCwAAA==) format('woff2');
+}
+
+/* https://fonts.googleapis.com/css2?family=IBM%20Plex%20Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local(IBM Plex Mono Regular), local(IBMPlexMono-Regular), url(data:font/woff2;base64,d09GMgABAAAAACicAA4AAAAAYawAAChEAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGmYbiV4chmYGYACEKhEQCoGMfO5EC4Q2AAE2AiQDiGgEIAWFXAeKABtFTxVjWxYz6A7A/uhUrctRCGwcgNqDlSjKBieW/f8xgcoYrpOnFRS8QIHjoHdmGozv5cqN5UngfebN9NyndmXJjllctNCG1rQfXYoKzSlz1ENtiyUsiSRjt3wd/fkdv1ipTRPsckOhVtMyaK6i+fu8TXz1jD9CY5/k+s/TaX/ue5MpNJ00KTSVUkipvessRGY/xAzRnDWQBAsmIWaEhJhAxDZmZBNCMClQqNAiLa1/qXy585pxd61TMbj27mivpSZ6VjH/U/e990r2h3OsedXubz+XVANAIkt+9pLXmXEmnvRAz61UNCGowiW2TDyPP/Y7930NBU1i7ScSI4mFaBYZjVLwRiXi6x4K66REYntD83qj9IMX55IB8f/4B3ru+21SwZLVJrxk4Dyc7t/rT5VavnveQoC2gyzp8vyDMGZrh81zkCHBgf4VWNdC6ueID8VgpFWm+ogRY5SGrjW+o0Qn+4kQQtDa/bSu3613oX01KIGhSzkcgNEepNWbGRROsIH5Bg//9057/7btY2aXmihrahsozuIxjxeHGGDY8QA1ov5/f7Paf0PeLIwzyqw4I+VanwlJ1qT2olx//Pd/+MID8hOSACEidgiHkQ+ZOYFkTT3xP8mae2VS7naiVbV1oUW1RVkp/+DvueqEv1HrowYKbG4QlKBEM9ubCUUIndnSvAWMAu4ItwG51Mcrvi9tvh9cinXFspATRKdy3XwZbkbV3yqPBj5gM/4GCGANaAUwNnypRcihR0q1IDPNRFZbjey0EzntNHLZPhFuOwXhC49ExJpswaMJAxHnskUQAAxAAEtZKvHFLycMHA5HtTYD5bhj7AgQCgkXQLsNh7RMM2CutcmIbAkYS+YD+VREbrcc5aF4kWr1MdBwY00203xLrbbRdnsddtJ5V2O+vuCaO/StL/zj74DaZE1ymIjRYydIlipDBZVWXWPt9cjQ4EY2vqkooQAoyQAoMQAoGgCUSABkKszudXqIsmomvycjRkH7E66kEo4Lsacxk9Bfzhafhg+xxv/2EXHxXfTB812MOV9iALHUkkEKOXPQ8+RWyUtAC/+DacH3sI8FIgYPeQWIuQQKBfT601rxYnbqVrNb2PLWrkhuA6MAogANkcQR5VAlTmyetDOIIbg4obHrkCSiC0GPZDYrIEN4d0gqLnQQTNDtoXR5lmob6PEMM7uXIwGsc7gw97Er6ytu7Iq586jlKaRFwOULYegIJ+LTycJLlr5EInG3nQQuY3SiJ5YNIE5MYciCAiiFamiEdugBBhgMI6XxYNhir1h8I5dsm663Uhe4VJKjvJmVRXATFJEYb191+NMyCihH/Ue2gMAfuBEEdCfDWlpBzHVfE5AEgPH8AElk3tEJIwNmJBhkeSRUINdPUmYNnEEEcO1mOgj7+9nuUm9QO/RaSYwIEtVgvAuY42yy5ZAK5l5syHg71vIdDr0fE1FmcMoApKJeR7Gd2B5YKvERj5wTwCN4cCHbhE+Fg8040yz2QPK42d8/tgQRGUwk2+593BJVSkLFJlLAoEilRp36GGy0yWZbbHWswMnwBowQPVmGAyNETZZhwQjIybJsMMrAnowJmIwxSc4CGOHzZFkmGGHyZFkGGL1IltolqIlQQRH0iwh9uaIotrSImHhkiYkjiqGRQhRJp8QBTZEiK+5wBkIsFDKN1UKxFLWK8SheSi0Z8XEjiiBykCFTFgys7Xsh8tDx4QEk/MjDyNTXZY+iKbOsMDPz9Ep27exCqW8hVQg7Wz2g2GjSjpRIX7HMSmWhYhzBNBF6+hEi+5AVzrvI9Afg3SdE/P8LIITU36BbAFiTnQYoENBq6yYCAJoQMuWeKciYAwhGhmQJsDGeiXD+nd31vT0W3Oftr0QrSUqOMlTZ6+XttcRbYzIRADYUKxJZ4c48M74+mKVWopRE4yJv+WtU62/37pdfdEf/9/8BwH8v8OHBVmsYPnDjBABA6tvigghAx1RAT39Tf7cccRTAXcdra8F9J512ZuAnzjkP4LmLLrn0lTG+dtf3qfsV5vPdUTtwAxVgqvp8BLypEhHR9yJT70+mPrL0vyyFSqMzmDmsXDYnj8vjC4QisUQqkyvyC5QqtUar0xuMkMlssdrsDqfL7fH6Cv1wIFgUKg6XlJaVV1RWqYbpaq3e7gnFY4lUMp3N5wrFcqlSrTcbrU570B+OMLgbxd06N40q/u19MNOHIUDPEQAAw1js7EmJGgD6jbtXT57hni92+/PlcOy6BONHrzeAUc8uYapBbtSZLVaT04WlgaB/tt7ywM3RxQGAcOYsSVDVZAEADQMAmwGoB6hvAKdfAOEM2A+wiQT2mFyyn7iIoQblhrKWxLlYpzoElFsRgFhSyclUENlyiybUQR0PsiqyXot1Til8xdf5vs1aB4oINm7t5O6BtSOrx7BSfgPaNq6K1OQkl+irNxg/i7Mi7ajIbvtXkLHqnQmMIw1+3QBL1YVzSoADnwH1eq6A6LZSow5eAcseM8+woQd8l6dJM4mMM1FZqdZoCz3ovewgrTpQNr4lKal40bvyEYs0Dt31YvUV2aQEsmfarBxgczOql0pTSinJB5+WZdtvO6wAr8SxvNYeBmserehRUUVnjXZiJyi7LOGnrRijjG/MPjOC7GRZkaQQZmvAVdgqgrUDYvmVcUDA0hd5jiKFSCVDcx0wbDBrkbUhA25nFYSZUx33BbwPLrf/K9WNNrSc0nhzj+vcx9xl0SEo92vkBiZ6Cp6h6P8TyY8f8DR7/DtxuqrOkpTyL0+6uyjS5dgFP1lRgBBsrUyp3xj1s6Xke6klwWeJmTOg8pjrPII0YDFsZAPPXesDBXkovlJFcu0t/tMprfz0oP5yB9uK3t0lGFr+hQVfKfFt6UwFr4S6JdhICHgHVJb+YRsQwBstTTdLmOLZAdaOYUpES6Q1ripPDPonHq4zPHo2EUj3SZHklPj5C5mrajmUSqFABjbo1ElfWvnyeXxmo4jPPEhfY+ljLL5Tun4WaZPTR0ib42QrTh4oFbYFRcx5Keb0CCX8Y4QFZVFp/D00to0gJPSNnxjFvbQ+fo7xujH7rBxwv69/Bw9BbP/aQyaWB2V/Bc/vkMTj4V5BD965wGdvKNRppSMNBbLrLKaq4Wd6tOrnR220SBufoOkKRCoONodzWaPyFYd6jhSqLU6VQJ08+SLudX85+lOtHmSm/NiN1iz2ttoAvcZ9HQEwsb9VZwzxVn0dZEd6mRhn5cHiwHe1l53I/w/jdQlD5WfL6p5ECJfvWTVqrGVB8UoHRPF41ZkeS4wNd/WQIfe5oj3e7F8X4LHNzaeg4XYep0TIhR+qOHZBKtDF3WLj8/keTmx9L9ndrbYBcntvyV52D+7fmWQB3m1esHRSyd52v1jMgFfQ9jVE5j15wP7IUBqMlUFJ4ywLiNoMdQL3VNS8S0Wrm2lkoaNnT87OGLFZgp5F41HRtCAsjEt2nm0UybjJcjHxfSaWOXMZu4h2zVhsA2AV87v3D44QDimGrcQSWsSh3vSFyY+f8AJg6VZBPWGPG+YhWyElTFkrqGvbWqCELmTbrPjKEvN6TXJLk2lOHHAWvMXlErsONyZMLVBAHBktmgVCAO+ha7GuqyjL2VUjs6h0qtrAA+rqvU6wh9I/h89OvyrlXujYQnNbw2XNnWxHmalLPSdAUIcS88HLNtz1x4qym+d7lGuT1mwraShPeFP7C0FceSrb83RAvLPRFJ7Qu4PHxsU+y9cObvBhq+B7y1CLxLz5hzzhDbkeQ8lMdje5J2yD7iH7st3ETrjaVDq8JR+UWfcIhBmTUz29Yl/ej+YZMjK61GIFT8LTJNNw0gd5EO9pmIxVe2q8m6kiMxdyUvCDwszc0tS0BOols+BFr9O9rXLJhM3zAQsToEpNqZFcBrJrlkpxBb9FP+9vrxRuVnxcnhGRCKsVqrmQwteVQ6kjRvUkmFLHTo+EiJiFyHKghqwDVFKabrMNOnXNgCbecpXtFb4/JE6rEvq/HP2DA+6fNzA56aUmZ7enBrMpT3zYWdi9lIG2/okNTzkxvTkhQffcxC20pMiV9UZABdaJPKRzTJioDbrF4a6NbU0G/EDATIN7hl9KhtDqQ19B0+sAZZx5qaNMOJ4wnM2ifXPWc0HTxGW3yq+z0DuomidScBuw7QxmjFT51mSQTzdiGen3cs8E3Y1C3dMW0z7gzKAUqdK3I98zAOoy8OKwxG6W8NnO0O8sPlP/PglqpEPaBX0K3oq4XkOB28BPuvi5dL/mzozUjkvZMg6yjjiU01Pg3cFdlKnrwffmbW/tiqfZb4CNfp3tKitQ+ZamInCD7j6U3JYKXlXE5qctmE6G9Czy6VWdv0KB3HPmJ8oTL4r3OldtiwjfuKByW71iU7MTFseIG1w4rNg9f/Qfd2VmiVnn8y799qexha+42s6PvTi7sszGt027JYRflEz5kqvZyr49eTI9YMysWxPHc+NKIqK2dFYryExxKlHKgkSlKIlqzTbwZm/LMGJxRW37rHloTAU78G0gWeCGTXXDRu8tSk5+RoL0siiCosOPiwozJvHoddL+AA9F+rw+4n/l8FaRAWKw1w1qOhW3hC/tTL66Ng7ItpNqTKvDEp/LR3eYURFLj/zJ2QYRbFR0jkUOlWOl8SO9zrRKOjbZfRkLAjEep9x2JWlOL+qLqo4H29i23iY7vwv+Jga+LQd0uk1S/qRZtReqknS8a/iRgcqUcw/2gmMMgraE1LIyuPOYs3wuRHlpZW3K/SMnN72uKa0/QWgoI1V2VjOviVan/IMrCqR73W/DCLVUi1tkJ1Jkf+JbDdoJiewu4mDisSBjsT5Rx42p9cWkSiQVCVlYbX71+bTIOdUvMU8sTMtNq7it9q/kTDl97V6VsCudWQIqjw0miLpZmhS/Ey9++wMori2Llak1JzPSdxwMdM+3DSRS9bFsjoKyc3P2Wd1oHy8FhyEGybk9N2RSYaPgxmKzRK9LreZyF4lqwF1Oq59pI2pU+cEFHigJvdfTrohjuulJZRT2gE68zEWbLB0iy7CE+8bEIRu5z89rrxcdaof/7PxHpQfYoN26xUma0e6qbCEB8IcSk+iYPUftTfjHShB4nitY3FMGyxWMOr7vWvynxzYipzpGiThqNbcUcSM6t4e5qdIL0fR2mMFpOxcg5VjkL4OsJmuQUhZ605vftJyomiZZ60Rfp0LCz5j5+Dz/gZQMW3JBVhcyscE+bkhLVs3YYO7RkM92FS3XQuuwGRSPp4UkUuGS+cjAV48KjUAhtquICJ4KGYr6t+WI2hfipViavnvNQCN8gFrGiyrZQn6DjetGkUyUIpOs1Xcav5ZCSSJH4c1/4mFhXHPiHZT2m4Ho8jBAAWWmRLjaQ8kjZngxu0tcGhVaStDFpzrx2WQPVSE2Ukzuysa0s4M6sVU4WHveK32xtRGlaJjoOhorC5Ne1faWrl+RchbppIo8Xy9GLUMa+y+fHZ1ibrOPbCyDbS+anwwxD0qzlVUVpcFIKhlv2mtkW6zRSpyi5avNtd+l+7qvoYewAi4cf4lWwbtGdVUloCTFFOoTqU1Wn/zqUY0p3ycXT27lbZKlLepk/4syUwRtXidV3bW9prsUQle73mC1sNDl9hVrF/B0HA8vv+Su/PT+fO6MHngOAFOyh10oRSxXC1t7nhyPib+qXPHDCoB7hEMdDR2NoUmvcyOwqdiI3PHVAN9f/J/hm8wZ0w1fMy7axvfbRCGKYX+6gcy4QmSLQTio8gghVI3CRP+OSA00V5ZH1WvqIWStovBZL8RJ//epj4m2ikQLNTfWRddrxncKZxoSnu14XzBRNmRCv3+QogdragyFoQo7ajiH6qX0QYFIMEgfBHWSrMs51vVVg32wBP3cyxBcQuvMBGS2iYXddQ4UbqM7uMzj8ZlZDEr10gPVesoJRQ7XzIlJngh+zikeYS1G1SNqSD1GR05xx4LucV9XBOtRZwManpmjp/E3nr7GsHKSZBYtQJ3IcGaAYzIbuVsxxlG63LfZGSyop7TrgjqPZ5yVb/Ytc5Tt4zM3mBNiG2XLfCtcWGev8C3/Rnoamyyzu9Ye1KfrD2ov2S9F6yzoV33OnrAeoNSnD0GHTjtXHwgAM6e2phvBIhRMhQEnpnEaFM/O2D/NyhqAg9aVCJQluBnBAK57wknWWTFcgeCW7Q2ntbI3O1JgaaskJeDYzJ7kBySt0hojNPcebX16Zvp62ulPHgjYDomj+3qRuzdMH73bBrLPBB+d5uorZfFaPaTXQTqUHbeMXebEiSVeQh3elsfKNH09l7tvbRdI+NZm1YmjFWZ5vgISFL38M8Q3pHG4rswlZD2barLgdiIPhBfNzeFS7fdCBBnPnFY1+7+X76cbCBS726iN0TiNLr8VjJ8dsnMfjH/WYGqYXXo8YQ8S/DNKkRYX/d1bBc+J7yC5xWISfK2IosiD0vTj/nv5Phj6RLY6XaYYk8tlE1U1mGMxkyeAPLS8iK6CyDUaN2+WdVRxcF3zrJDLCHMrn+nn+BR6noPQQfQIxRT4WJAiNVvdLkuMxTqsy7sFbEweLZrmOHLGjh4JOGh1CfEA0caxuvyvYgbrYJW3rbypiV1eVbr2rTGvXH4rh2g7HyaqzHa/XpWpKtQ7HIU9XPduC0DmfFmizJpvMFi7GBcEsvrdvFm2UaEUGRZ5e3AShhHdIjEZvvbjU78XT9elLBCO8W58668+FBPaBoB6DHQNujpEOQCuduITq/s6AS8uLA0gqgxQosIgL1BZ9GfsuG8KhtuzBQIn1kswcfgUsw8iMupoN4Xq6XpgZJezXqSpxy5sGEtcoqwIsZQqmCHVY8KSsZZ81MIreWpL/ciRlmHqTPSYN04UJmCu8hY7Z82fWpBUy7bb2aou9wB9NXMhczWdvcaoNq4BtwsO/htMRef7Rz7csZWxVd7joKj/ebiuqlCrsnxG7HM4bWycjQERWejX1gK9WJYr1UsKln36Wi/9TZAj+F36zQNgQE+Z0N/Xxzd/isCUjcs8aiF3dyYOkv3eiY2tjd6JfvJg4shuC/lYBu4sEJT3758ysW/jRnQzZf9vVhge09TcVDxz4eEsEB7YZAs/ddvc/4RtIDyw21b71Gwzq8GvpajpbU4hvXXErg3bx/VPFlqyOZnrLeTuhsTTJNg9sbFZmhT0rOJADp/e+r3xdrEbbFMlq+EBWJIsKdYAYOMmySbj5ocf3OxH5REsVQ4s1zusMMnuSYaQR5YT8jU608aPNhAfqGm7BQ/AzYiSMcff1P3D+LCkGnQOwKMdNnCw7HrM4vomMOZ6uWugebw4qui3YcAFVjminc6BjuenRW/vk74pSTYlB0q+sWZsF2+wCgThgc9VdY0VFfwlrVrHGr1G+pNQIvxJugY86W1TyvQShtkpE4azJrnZ7pBLqwYaE4rm/7YkYxM8HDpQVOeP3sItX5s7crWZ+csE5KLLO6C6wWlhodbpMWnFCyxoVzwLon2Hp1ROrBoOt8qpqw74+HqLQ6niz7HF2+NZJtpKArVqUgsIjBoNj35sY9pAb3+vGOVZ0CIUtixAecS98NfuxDE8V5BpsQSZPFfSdn8N/j6xU1xdao9G2aOrS4OFJgjL+h34rxPPxDRtKC/ZENNgCLZ1/jh4RUy4O4G2onBOyXxk+fyiOaV3ay4EKrzdwbnIwFx/d+lFGESmvtpRWbMDXoYMLhuFcn0XUgHrbfEcxnjbBcf/GUvBrdnTMJqzUU80YAcgZ7a/cZY/Iu4JIIPpxumu8NMSKNfYb9nBwEMrFV4rBy/5k42oeLtI66vw26wNrrYR4vy3yRI9S1T0fQb+VUBJU0kh3mqmy0i8kCE9MMKqz2FmsGaB8rteCVJY0VLR1DNlCuMZu16QsPdsgdkJm0MHF+4TfjaxA1hzwSeo0YogU2ki1qjVpBqlOcCQO8r08OuLRo6AVl+cSw1Rc4vb6RIjP7+7ptII1viZno7Ee887vSAyh2sCTycgQStCDI2ZUq3WUGvU5iBDKoEZSgOpRM6chKEWz/6FLnHw81fXNBl8lykdsxuo0Sw01WI1gULjpgm7od1NEpleuRE6ueQkW+UzficQFLin2qdNbNZr2HvHx4dHY1mWcch/JD55Dk7vtmVzC7bHEndRK8xjabsI+twcvF5jz+YmjN6yZUH52QTHG4zW2mK73UBK12yTCKlerdvsYu8pVM3kEXjdKlX76O0AVeV2+1tbc78oRVX15Q6v2qKGVJir8kB2vRc42mh7MpMz99C61wopHJgwAMX9sQnaDeqmv4cQkD+Y3iNeSqVpQj3qoOGu9yyyAV6/tPr84Rf5NYfQ9d5fvcBj3F66HUKu2A7tBjKkXYXc28/h7jEizqh5WnZRYb292LCKTu5kd10m0sizTg6oRnrhtGkADloWZKjMpGqNmlQz4WSXWVeuUWtI1QFSyOjzwHY4OoyXEwXlCC/cmEeF956N5JNIzT4R9h6zGPmMcRrnT5gPPZyG+hiCTFZvlQn26G8egvqAEO0bK+spNxflalRONi/9yfK3qV5073MNjZ3zqN2RyjXXc8yCOb9UK6lqXS7rSh8Tadh2vdLV7gcm+NGwb4CmYCHsTNfOp9DTCXyQ4Gd/iWjC2Hov0gve7Ub4bBc9j5DeOuKsO0BAWAr2xhbtDRV5PD+TTG5Eg68vxt/XANS/owY+Vbqa1QGkMuBsLt3zcfBXe7CzwIdU+Pyd4Ayi/ItkmvfcIoIT6szvOfmuMHjRuR+p3w8CLmerAVqI51IRBDSz2ctoWtzqL8qMOJbMNFEht8YNmajM5GOI2YrPO3Fa2jL2Zs3vrtyuf1DvyexeJpLZyybfQP3alev6XQNiZk8zTwOYNxGs/5rPG+rLjqv57Z9M++C3bWmEliTn8eQSU42Smb95m/xiAIb9xPGMJgsMvjTXOBQZhzrKURj3l2Pm6May+NqeUaPqekrjGzXDdEifTvv6clztNz9tRHV7Anojctg6i1JeGJ4TlhcqgaPxG7qRn5CDqzK5V6Yb2TySayhIlHkbNJHPdtvz8g1OvSs3Vd932LSTlka603n8EmqiF3DaJd9DbftsE8saG8u0sC/t+fcSRwOxQabTGfpMneyiAexQ/0C/qWewrWxXGzIIJVB6TI62+0DMN8PMw0zY+B0RPIj0PWyzZXB5oWzuwzEXmPmfg5jN3NeVmTavWJBvg1HD6EaW/2Dsq5zvT91CiPdktH4/4EQjaWF6YvpC0ih6sUUDcFK0zVxvgDfO5eSNn3CStVYMl9O1ZXvdPRAHGRoDrVisEkc84yym2PZykFfZvJW+Ql+FVXAUoV+Nw+esys1nf5dLVF8iRuq4YEMt5VcM8pc6vmwGV+YWWm14t4v27Jdvm2el/YrXWfXqdUxF3w/sXVlxQjVrKzEX/OkanAkdQ4FTzDTgSDhDTg4LpEVkCkMSHishCW8rRIgUeojpRI8wkjB5CAGrP4B/gc1xch1cpomgwmKiMVi6HCz/AwNhAGck/fLzZXT6sueX6YOmWl4Ll9vCO64RoOYPHYIODTmVtPkY9DWxw5qcP7VhKNE1CptIplE6/D5PzA2iRq8S5El0yyvtx0E2henMQmaziYSOcytj9ovyrUIu/fJ/CA2OJXQWGOQXc2+f76IxRxKi5C6uGIiscnitlQqqho551XM7MEdzoFZ/tWHk9OrYE0THNmSUfwlI+JfvpVylFgqFLFxd3g3+E481KZxkBZwngv8wyk/kPtkYmnMqM+2r5MQfftyWWilK8lIZ6YQqcgbp7jjQZxW1xDbK/j9RB2mrRYBT6vRXBGC4wuFQejgQapdwL3CUnAvc6YEB9iCa7oKHcu8ZHsqC69CC8EWFj/e7TWteLzEteb/G9JY4sX5k9yhgmEBoT+8oytKAPTUlgzEys39m441NicN2rCTG9QDny+YECOrxlQAOumQkz7NNWbcUM9mH8LLCk+08fuznCp8a7nyzgmGh4Tv3ohDl4926A+EB+Nt1VXVNpaU8bNW6xffWSXsFEkGvdB2oH6Ej/w4227R+cZFnw636qLEVFRK6xyitxKkMkCEc1FqyjaWK+mSo727iRTAXnW9z2N1hd5FWavyJyVx/RjfmZ1cEkXsRxQt01By3p71NFpltERTz0140JHkXtW+oYZDENqUJccUgS8AIJmzPgCXyIV5S7qeIXp4QslL/oFqFEFAl4ZyzrbrEYI/4pipbJhhLEmp7RpKlFwU4sj+oelHgyivDjtLP7Zo9XFFEUxlJ5UolqVxhdNH4ao+8Q9hjqJhfbSot0cZauPCkOKu2TNe5y+hzuM1un8N4uUCgToSuQc+vfHPvkTr9cT5wH/K3ZodlOr55niX7oMY56ELMvK2bfvKvxemJbj0h6rXf3m34cJFN/u4ajRSnHmVKV9/GjZw1JYknA95AgrRAoK25wbGbAOjjs/LMwabgz8G6BHT9R7XyoLw8foZZqaUitp7TgMiB/awfmebUao06tYZp/pGVp+MREX5jLtthb2+TvXW2CkK81N+sN72L6ueKUSDtb/NU3J4W8J6pjtozDJR9HPHVibFa2DQ1BBwtZsWLbOS9WIFZhozCPcNmYp/hTu8LjK3B+t5MiEtIWfos+skp2vqDAf6PLcwvjlbfN0+8kD+sHWxQ5YoyjoyPgLaH7EB61yhJnwrS7v5z4X+9hHL6jcPz8HnDjafGoAlB25NJwH2k29VllnrgSZdcbQ+zgQ758Y3e7FnfLzFecHBUX57l2B/41P9r6wsNPFbrXknvP4F3CoHCqpQjp/7e/ck70USaqXGbbPWUxXnvmR6WPjTdm3EWYiXfThw500T69NWqW/U4yLvFCz6ekqXXzUCEQE2WYDIoRLoXG20kKJwM3v/3KhD8loyqfA49dy7yt9lZfHXiEZTu8yDcGpkWMkiLBWqaPB+o83h1Xvaeb/F17NmlUXu7R9cTDTi1Jk3YX8iiadIX+kMhIeM2R825zRismV6esjcuNm5vyq812LOk/EEor2u4HCL4Ra+w9adRxWE+Km0dFvtsoWnlPmn+LBbb43QWbBf9B3qtZNGHW5tcMiEuKzpLRqGJaOSHKdHpF7H8Wd9mV+TJPgdSuv9E/rqLxoWkwLyuV9lztvAmX8DXqUetQ4xeC3JrReOuDB5IcCdRcAisGp+1pdMSv+eUeEXMWNTP78i88yKxUQ/yalVGi4o+UtJfVvRvTtHikLf3axp3tUAM6fsIGhwapyF07jbQOGOqTj72X9lEjA5wajU6GZva8QZ5Ukpgns7PP80kSHcj33RQ2Ueh6iHCo4zojEeE7prx80nYrNgsLOn0wIWmJy7n1jicytj3JPLnxPZNDqpsExEmOT/lUBa0yUelDCohdm1C7SoXBxeMHoqqXmuiXEqBlOjVlnwQXTPsHN852FHB1sHFHLM/HwNhWMtHBzPLn6jkDnb83+m4NUP0F4XKQW/77t/DATLurlaxyXx8QJRxNZAeYrC/Ne8bvjYleXdvAgn96Myjv61LH7YyC8hKWll1Xdpbr5CnEHdPagPL9aE+hdQR1kmji3ruJMP1O4zVmAFyG0iNpnGjjiVU3u+T8WntC6o/yt/05E/LTUj9fu15pa4D/b4dIWdtb7XtLOEAq0x+2t5qJPLKZLa3OkirNvjKORXGAtGpTLa32nZIKCzb3mqkU9XsCLoDYOMruN1DPuwmDmEtM0a63UM0sa/MSHa7h2jClz+MoLDMCNzuIR+miVCZ8bPbPUQTpWXtYFBuOth8xs/nDWpHh9FoaGL5o89+rZydlNKd051Tzq+qYCV/yxh9dY3+auigosDNAx69iflsQiSexXc2WH5u+cXcT9F7Cy/Do/MPQB8tP7f80vLruZ/CpxbJDQFE9WcAVMy+P6YNn3RjOD2fNYDXHwH786A9+9Sd+kfDZ4O7dUiTZ4MiCSWzexZHpHM1ypaQ1DQVYGs7bWCZg/Ei0oHNnh1Aq9E0NMl4SnizuvwY2oGfQLXQPApHaAe+Am3VyAaUc2efLKH+OiUcodWpZJykHMzDAO3AWMkeYCuQdSD+B41x+4Qu0XMwMhkPRHPQGLdPDc9pAjYGNTB4YDDVbvrXFLVQp/gwkRa0TGlavys1jdt/GCtJa8JoBFjOdheukC7N9BQw+OY3rJtd5eUdtnHmlUu37/pYUZ4qzIP+2KdGTKOn1te2CzDLkozt2i7fff0bnV60CfZKesF9X+OZ8z8CMFdPrxk5FUkpf96KfwkA7+b4Fwjw4e/KtItvwEKPaADmGAAgeD/n/uhwsaJfpH6j4S3ljOnU8rH9JFHklfM6ceMe9iYcGsdazBemIKW/CIDKls5NPuyOTCCNyUVIQswq5rAuLzh7SmfQJIo5bHDLnoyOBiuFoNucKnhUfs3gLjBjNqNakzKNvGRztYRqcclRSodITXoNSO8RsRqzZLMH25xlzuZb5pnDnoa0WdFU10rzfVEdV9N5i5obrzm1JbwLSTrzKDyCZfJuUwjhj7ylkPpvDBAHHhlHTQzfVMvThP2plEhVJCUMmVVbvzhvjpOPqWBaCE81GKavvd3Y3eAKo7sq6w+HhfrGErvdSLblkWpBaZNLIdp2Suyzw9YO42is7Vp7OJ3JLbBLsrw8YOrGbhL+kAST48ym4kjN+aASRAANCxD1Jl4GydzOkxyc5A9TOjQTG9vNjJmrZs4tUWaBJh6zilXGmUXqbKm05ZIPoczTtADQCDATF3PMjK2jZi7BMbMgODSzijZ1ZpF/Zt+XtmJygNEAA40yWG899TKUQkRASI7MJksJhSEOJlGnPHqGvqPClodYYvcJuovD7fG60QG+iFh/fexb9vHa3Trqf6207jrG/G3JToTT0Mugu5G2wmWA/izhfHeg3FDXSS4ZMGIkQKXuehrGoMNg+F5G8wNE4RFTqtj6vJotGzNMXBjVi07WZ9tsGGyachfZ7kjFVBaijqSTTHLtWvEN0VtClRQFiUYeK1G6aOQixo5sAUxzDpSEjy93bRl5YFbWhekz0G0/sedVS488ekiwj/8Js74hvZuT3iopy3OCa+KzBNNQKeq856FcBu5rrpg5i7d/vEc2bNmRpEiV5i9CzKa/qnDwCIhIyCioaOgYmHKw5GLjyMPFwycgJCImISUjp5CvgJKKmoaWTqYs2XLkypOvQKEixfRKlCpTrkKlKtVq1KpTr0GjJs1atGrTriMcW0w1zTnLfanbfHOss8vWCJjttemW+Nkv5llhpitueG293X7zq99tts8tQzbp1GWhbu6oc9MRJx1z3AmP1XvilNP69PSjRZ4757wG33hutj5666sfg/42GmCQgQYbYpihhhvha51GG2WMccY6aZMJxptokm+9MOCFzQ59pBijq5dbnGnZjutVU9fSttDQtKSWD/1GxgYpSWlukrRepuKf4+UgGxYOHgERCRkFFQ0dA1MOllxsHHm4ePgEhETEJKRk5BTyFVBSUdPQ0m31rbE1t9bW3jpb9zzVGerslhmnI501lRiGzhToIQ+EEUUMqXhNJrNEMvPE217JDp/4SfJ+rGHSUVy05Ocq4JVjAPUIlScouOn1xmtyPMQzT/GlqaNexrg48i2hN5KTrh7g+L47mzlThmwl/u64Ekm+jiu562xhnD7rCYgF6bEg4EAqBKRIQMCCFHmQCgEBASlyywqcGMQQRwJJpJCGdISQgUxkIfuE+FmbRb8So84LpjGy1L8daHz0otU/ZdXoNmZlGP3EHRuHQL7JuCqpEkS/v+Fu6i8JJ7Z0TT6QFOnjECC16F/g6rMkBhxi/KPBBUm2BdkTAA==) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local(IBM Plex Mono Bold), local(IBMPlexMono-Bold), url(data:font/woff2;base64,d09GMgABAAAAACk0AA4AAAAAYUQAACjZAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGm4biV4chmYGYACEKhEQCoGMMO5JC4Q2AAE2AiQDiGgEIAWFOAeKABsuTyXsmAmgO4BfK0VpFc5GWLBxAFIDf+rIQE0ejJqB//+WoIWMPTgPtrQaXBpLY3ZbQ4icFj57SjMxaVx5uMZwuSx4WLBZW+GtxHTJe0IU/WozGxeKRKlEsybXz+AYblMG9Mf/RGsPljvFb252hMY+qbuED9qP9Wb2I6ZRGySXRHJJJDyTo9mph3bxbn+AbfYPQQSjwAKkBSSiDQRHCEb15iJ1GUyXLiJ1UZfru1v9m5v/brvM9e38nPYzjkMz9isogEuMD9K42zT1SpZ+tKdP1FyT6yIDz9Pv1859K223KVTyTwxpE0NonvDIECpNtBIqPt1DISWr1Ef9x+3mYT8AiTjZAgIfWnOTZpWSiIwuHk1KISS2hMa5vcvc7w48JOzx9jZ6MNEJnw2oQM+SA9DrcaXFA+k3dfOBPKIummtAptsaXAvewQyCoOTbHgon2MB8+5xPq6vrJ4QTav7nKm3+/skB55DnSBWEWbjdEmgWsu7P/8nkJz9Z4My8OZo94CzwHCSz87BE6GYPoYyHrLarticr61hoEqZKVgkWpkKKqsL//06ue5IstIsPMeDpxCb0zwaSj6I8eSEsSVgPK1Cyn0LB0k0jalETTn0PloxMYjQJwiFBOXSKWV26cusbgyGTdP4S1b+H06jdGhjQok77hzJURrPJ7U3AK5Dm9qOJANmARfVCRGEyQLBzQZigDMJCCyFssAHCXnshjBqFcNVVCNfdhfSd7yESiYgGZBKUDDIpSgEBBTBA6bvLZOWDXBp2+QG/N6W7FagHVb3twIcCB6SGlVV1sQgwtsuHQIuGghab3wp5DiLXNQgid4kkUatZp0mm67fQckEbbLXbQcedddEHPZn+wJivfef96m+vA4guIhIRr2SRxRRXYimll1XZmiC/ilWperWqW5M1U3NBhA/koCgisdzeEODaSEMczIhtkIjk60MdzwwxF8nTgUoogHQohelQCF2x5bYihWUYAdPiNvVKRvKvoQswPirDYJIB2hnEsnNI4eRCMYEPTUAZlncZIt+NghhCucteIDVw9CmAeP5NJxJJPrt1tFgrNahNoa1HGZugGiZCEVRBQXI+tACDD2HPvgYDiqEkY/gC0yiohYIk1hUtkQYoKIR8qGR0wAwogdzU+ZGiLaLVulUHuiADtLqPKwCQGwSZo0CU/VJIcjilcstHUagM+3gDBVAIRVDMJEeaxUmFQLruDjjmQLSBFQXQATpBvzLKYBrMgFmwDDbBPjgAh8/+cwjgdkjzhRzhzlpoHeS01maGf+wqguIns4NJNj10b62tE6j77R1twLnDG3VAeDixrRvkl4UTQQtcRxwTRV2GhGj5lQNpYiWj4pPTs0MARC+zdDM0IKi00FG+9lSuoBTm+UrQOAQdNCCG4CDQDQwk946Gz/QQtxLlwvVEshuy+u0WKfEGkvMBG4rLokJmsyFIK9eLQA5ZAAPlTgeLaoeO8jrhwiLsUQbJtXHrpkKkG7R4Jz0NSVKVEouOS0rLKodPsWrNuk3Vb7HVNiQCkOKR8mAchHWLRwTjAN0tHgGMA1S3eClgnAGvW3KgW7KZLAlgnP0HlggwzmaBJQCMe1DC65iMHoQ1HqG/1+bf40vDpSUiYxFSBtNWHqOHWOBD9Nlt4WerIR8FQUryyIVaoGNt8lg9tK+OUMmGHi7pCMc+s1h4CRIlSUbgeR8K8SEvCSD5V4bF++Ku+j4JSlSSkqXGu+TO8ZpRpdDnCQU+dyHARD6BNqmNIh0bEsETQkOQsPWeDWz5aHb+zMYWc6mIrUDjAIX47w8gCQK3DIgbANwOGQWohwRp7WoIAJpTGCJ0QQXjpwl1bD5KIMdM760S5fm8P/JYwCIZ9SyqjKql2qm91IM0Om0NPeH9eyAvUG0VfD4nfBlgJI4qpWqEVfT4b1Cs/8Rn8WpcFbv+h/8XAPj3BL7d3Xnj1v8rxusAkOgiKpEBbV7ZKBfgEnDluhuAW7f2V753x2c+p6W/uOc+4I2HHvH191T/g2eAX76huX+Auo0QUAG2RPMJhHYoGkHYb5Xu3y/df9L0vyyNzmCmsdicdC6PLxCKxBKpTK5QqtQarU5vMJrMFqvNnpGZle3IcbpyJ7g94L2+PH8gv6CwqLiktKy8orIKjh9RnFcs3wuiME7zrCjrqmn7cZiW+djPC3TX1jX9b/K2zpavJzXDaRT0gIY+AACt0+FWh6F2ANA248vq/nny/8Fiid5XQHMFxr/6/bMATLn/yDL3DSExmmEpUQLBuKl/Hw/uwSdTbQIAQcIIFyu0vtcCQDMAeB5QAxQdAZR/WyC5BvwFjBX1LHKEZ2j/t411ZF4PSVWkDjKZi6EjOUHAh4wtAoRIOcmaHEKzAMHaHtInhpdmcREblhEjqSRzTgQRFLiNwXVEXopQ8FpihGxIIymPsoVs2i3zST3WkZNkRE6wGQvOt22r7dk6q0RPjBP1CLTtiHCcwdGoI9JjOmIq2+l0i6MIR8VE/aawPbKfiA8QIqKxZ2KsKCbdK2ol6h8nh0Y4TkJE2tZi0UJfZKbhsRy1tzvqUmITEvbjtOibFbl4co4bTRDEgkcdnEuItMjuXiMTGWptb6VZ9qxcRORjI/uJhG3PSQiRSPXvx5FEyo3ZCcex+4yyC+2iLzuiKFrt2U6CqI36T3LiM4cJW4gcUVqo5pEibtvRxI6+qh3lpETSJhrdeLaHx9paWuysYFc4QnBhBNv9MyLeHSfD5GwxcSnE6ELcjyIWj3O0JdLjhh1fI4OUjSqqXmMqENMYOT0+d1KNJQNtIVLf0RxDwck45DvCeTfI8AyOltX9NRhCAD5+nQSOrt7KZLxqdkx1Cig1r9K5jMjG6CaDqtNUEkIFKZHki1f9oqqqfg65a8+T8sHNg3f3UmS0egGzZuTUueHqnPekho3CAO0EBeXQdBDoppHX5bTVWHghtrz6O3rP5JugNwT2nk63UU7QKxrT6E6DgarDmMG3kGP0OKpCBqPkKNogIXPQOIHhEhl0odpYzmqWFbOAzNXf/Ec3iE0EANCR08CVPgSDvYgyi0MktWGbocVB80Wcm5aZF3Tq/YcR7dNQVpgm3UFzJjAGGKWJ2hvwrQx79+Ug6EiiAdVHRe8fjzAUZKt6X7nRRQcDthgIejhEvzuS9zB3Xlh361XImQh161pItKSOE/rWrTbQoOF4ga85/ZKTk73J1BrqfHDn54+A0IVOVc9KfJ3N+tIR3zJ4pezujDLGFSceR/t5IsCPygNTO8mbL2natR99ju6uuLZBH7qhCp4p3bw042MPVqHb4I/B5MZnjrU+XMkk8O6iqrsqDmrlEdJekyZxsZUiY52//5zaf3gq/egbRzeJV8cdM9vdVyBVeNNPVOLKtOctgu8AH52mg9MNXrOWgSrxD7FVlYoymjx9+x0dlVsDVRx8/GrIRzbeE2CLwy44kMpln+XTKMX/blX0BDMhWxQQK2H4Q2yT3w1GF8jKrllP0sda2uxrMC2segMJ8i/GGC51EIfZdiEwVCqTMiQoNswzCjsa6PDoB7LcwZ9DhhAPRNstRAVZ98Yk8EuWn55gWQeVyYzhhAXmHjRlphUu2YaM2RKfX8Gisvj5ZmOtvdiaTWHCFqhYvZlztxjjwhE82KoW7YaEwC7uUGw87nyj3k2O1VOZSi2kNUlJXpmVMkgR4w/esNshcNCFza6KukA2Q/Uv/rMWcZDDhH6ZStrjDoUuVIySbmPahw6ChaVGl5kdD9OMASZ10LNUFkMNS7RKLK7L+rZF54whILP2yU6Jqq5bNh4DxY1Yl9lIxQKfzvaVm/mlW+ey3pJ3H+lBfCev/bzeQbh39ANqudGMw/rSLBfGghtAkHKWx9nSO0Ob1+dnzqbi9epv5m1QVjzfXqSDeksH8Haj5SFbwyBw7BinCd9d8g9OPmmhsQqMsmcJhKsV/UWcaTN4NGEUqt9PLJ7cCaPavmWbFzEWh6mcam+Y6L+baZVFzMlZeh2QaepSoryuBvhAiznPHuLMDWYqin8iyxnSMLgwVuPH/YaFN1Fh8OFZLfKCOwlgyrIoen3gPcKDNxzYHRMOnOpsNgbn6WirqA/R8vD+8W3Ajy6tDVbS4N6xQN12ggIYtHT2oShAm+FjvCEQ/MqZPYgNaAWKM7SykUM6KCW6rkb/U3Fn0FrVcxEQKRA76rwj3PHQlNpzJn0mFitDOSJrueiI7fju/ZGyS4DeApU9RYH5Ini2AOSwnSR0oKIcqQXS+vGdJxMnw2CgeiN9EBm+Ddu1D9QYLcpEdO40jbNais+X4YthRu5hUIR+YzrmNE0F/bRlJ0xGn6LWZnkfqABQaFhBF/pHi7e86yg9xDpRyysSLIJyb2Ny6GgdDu+0cNYIeTfvee98edpHXlxWm1XET55MgBv8xqa8MKdHpSPjuuqGE485l6cWAh2GF6GvXtBC1ZvUOqRh2DOsbGettL1Uh54onanmb50SNMdgQFden6Ll6f3huCrtNRnzFjMG2mQlTe5tjrKeW1Dj4sztwdRJEg6fcFsgeYap6B7NJfH8VV20ocmDiqhMiZrupMfgC7aZju9cpHiMvApG5qBRzdHecUlfIh1HD1QzGwhVg5yCqdRA+eiga3kReq+T9g4z/HOaowe0L/v+a8/r332dce/VQEKZa9lQjgk0tikzj8NQccEJKELklzCPzS0eaLNQNswSAgIHzQliz54YXlLO6FQQqkqevTlolbMW3GXRyzMHgVQB1Js5wkQ0brUYmYw1bZQK7yK+1AKkneTJm1R9BCkw0r3gFaEw2eRTxdLVxjC1MKBZQO+LDR4/PmSIccrkUInRAHnzqidGcshZUUGMtYJmVnUe/1RkcFZzTJhZXxWuv/3a5WtMVDQXyAHcv6vEoRr5QD9weVkQITZJaMsz8vybHJM3o9o45oiNlCMulrZMudeb9HDcYl9w9/tSJQxcLaygNaKyFGi8Lsg7QQ+JQVVCQ5ZqYB0N0FNAZra5yqmZj75BjzZlmLwKs3d5UeAEOjjXTQFlrzJYUBYidPFqYTN0A6BhfE3ew3bL3jl6o9P70Rx5Ym6jGbwNS5o7phrLJZ7R5ZKioWYwfbAByRzeIfJ2kJnepMGvRvX7UhIjCSEFmSwTJTV3AS3kfV9PiN7Uv3fuyXE8IEJczDc2VXuMmV3nHbCFnJ9d48+SKmT4byW11KbmJhyxGDHIpS3zZVCmWFciechxmZpPaGKGRqXBxySmlFbl8V+c3FO7EPOBo/QlgZGwEWsjtkCNS1RJgZnhN4b3h6ONOKG6OXCgU1ANXTWciXB1VS4p671c8jUuYdWs5VyQMwA5K0BCgxpKmWkN+zPe3UuX9GmY3o8TqYdguvRYVTbffvV0SQ0L8WTVWrnf1aQmBT/LDXPwykYhk9KvuzBVbdbPTtJ2tmTStPHcoAucIKVemPEUe4SC/bkCEfziBafQhmmQ0yfEBMr5vaCcADJzyTN3CFTE3Ih8Z8+nrRhlPdMRa8HPdQJ6Jjv1jusbiBFMZga2Q94G0aUMc+7hvQl9+eRBfr4ANl4SkAi76BPXLrEj7t0jJQxt3LMHHlEthm/ZiOeWeVN4F7TPRey+iJiDz0m7bNZZdKAksOThQ0picN3OnaGJ9M0+etlt+l0aVXZLVjC2BRlTlUpNuqrSX9WqIeOr0h/xcCvyCwKF7IJObbnafv/jnEZBBBqIFw3mNDg002nfS8cPSzbg82ueplj9r5Y+GHi47H5/PQ77EwqOF+7fDUr0H6NGJkeeqPHYPYD7U/3mxvYbTMHXIuk/5QUqlXJLobhFoVIvQO+V1vbZ0UVN7TNoVyZOHZmoH5lIK9614C22h3Yq+fnlf2SnzTtbUxFb0pwbaGiqjGzqbvyuUPR5oGLzuz01FXEl9a50QhY7h/WytVvXQgXHUEbojx56XPYuFR92ep3e6oIC1p3pwJz81CYGn9GUetQpje0a5HWdrDquwbGI9oca3I4QZVHRydnpJl3ZqrfUDFYayTwhk8BN+xsRfXXKI/fIZFtqaPRk4/cz1FkiB5qq5mLijrdnunHWP+dsHnZXhlXnapI7kzofzN6x7s/UEDEVfticOTcTDikd1PnqHmfpluBveX5jXVqPqd50oAQJ034LDjvLyqilAPY1vFDZcHDcj6x4PLhlPrmt6KKuwd61dr+G1b1bf2z2sQAlSEAiKiyuNQg/Gc4ennT47OzUy4WvD11caG+HJT8sNy8HXoQa6Aw6qB+lIXsRHtc/j48BvIilcy8cOKAvTddYMtEmL/P3+/8ybZ+B1jOMA/hE/AFG8p8ilE85fw+7bKQiZ/fjby3BKcD7d9Hj07MlWZxwvp4vLdrTLzmRbjaLAiS1pojykOIS8EnZIruubW69B2J3aZ3UMBZfxMvhDpUXaF4PZ8cKNSUpZjHDxqUFsjAn0a+lP1vEcmYqaklGhSfh3mVse6DZrtQqV/HDeBauzjID8uZrZyecOHm5uLd4vufVlTQshNIWM4bdc7aUQuW5UvfSfHIFo8huqWNaZO6EDy6/ag2c2ME9TFIvlWEkQzJu5fjU2JTFx0AUYapm2bIZdSaHoD+7vbjg1h0zv97n8okLtvcPrC2l0flOciPFLVWkFdnNVQx9r3KyPFo+XyEbXHbfRtj5m+nrWbNe/dv/rQp4EaYqsk1Bz+Hbc32XMVJLroFDsd0tIui0xYS7FBvHYMmVYi7n+ux8eo5NUUU2dss70vHccoWinItP75DJpAZ2DNslkbiWJ28AydEcwRy5Tn6XS1IjHzP3U1OKmQD8Py0+9M1iziYM1V4MhsZJY5Mef+Ne8K8oxw2Q7eJw5/v1OSEFAk00F8lMN66dIl3GmZ5LlCvyU+/TnAIuyR5ipiiybX8rblGp1JsKxRMKlXoLLnQ25fXIshoom5q66Rus5VUck6U8zWBNLZL3thjCdv7F0JnrOzt5k+gYf+0MI3I1NhElbWgRvsY5R4sveZpFlTepT5HuEJcS75CIH6ut6o/hBG/PJe6ededH7mFTsjgYW9hKcI3809Bak6/XZnagzTGZ7qzC9obayCeNSpw4VYxTuj5UcxR/CsnCPxSaS6CLWDr//MGDeF+XKn2kEyzHoSW0wlfLzASDtNw/1S8tN8h/27aEdojlOOkjgmnkq2ULTuzbx29o2VcPJtoMAd8sryFgs90Gz+jFaZyt5GnkfZxpwm5zZ5pma/K0ZCZsqMbOGyqnUWUTRIoSwkDe8TnnFyq9pJ1pjoNLaIHvZ0kJGmFZoDsgrbPIiCJZX/O7ifNhgHGUOTQ6RDxKvI8Hzo7BscGOq5sa/ht5IaK6PgyQFC29zTH5y0jTPxawtsravp0GSXRD/s3B0UEmxtkz9cjeu6wvV++D0tEhE38aHFaGXcXOqR8pNjar+kePBX7EnEvcNdoPH9+JuDt79OTwR7C9bZ5sFpcHpvgvxZy09U9NCK7RaJmb3ET0ymRMm853I+v7r8+rWCAkCxcovBB1cbnXlmtNb8bXnh4ajQ7dSLuLCdu+ujxi0f+Dj6XmmJq2Lkzc2RuSEeh57Pr514EaUThH05VfUVTMFilnCdJ2sbMjymLymnPrBtr7vH2SHH/5RSddXJfHvMbJjvRHl1TlSWg+m76aBpOMpkHTp9M40+DmyCgtM81Po/nTMmmjg7uz41sUWRUMl4tRjPIVZ++Gq2dH9nirOZ9g0j/xVW/5JAYld2QOblvoAFa3bAGZsKGzcLumyxMuSmeH4/0D94GsxeI2rKTNsXjztcbTngPqdmkHRtaha9982gdfvRi7usexTbEQsxQ7tm2zRl4A+8WA/Zxu2rN3+W44vajfXnPr/K0aWASrhVtflE/7+Nd11kj6L71dcTW4+UoQdJem/H8KrP1hqr76SgEXvhPOdIZ+7pPpncUeh3dibnceQXhYJlrj8mRtbFcXNE+qrP5a05LuZweYRneJAU/cCNpnQWOYIEtn5GVSpBZSXWYmqU5qyaTwjFlaYVh58K96aanSoyyVsuelr0ufB+YIQyXTmsGoMZkYNdaMSqY+UG/f22V48jFX1izzy5oVvLCYDtPZZjssLAszZmoHn0Z57ywOVmcFnwcr6gfW2NPsAqCJ6J+3YrqJXmvOLGVqtSVMk41eqedXYaVjeqGFPt2df69FUX5MvFiKuYuRNUFm9zry9p7tTqvL5z3SM9I2wi5tE9yGTJlvUW4wpyJ2RQuBr/8Jja2lsxjr0felbo2AYj/kTZJJNpDIQ2klrdOxa4UuVaGL7aLvA0wKMnd9FR15IfNYzCRVbkJSYAkP/6/gmDglebmkQPY4mC9YQk+mLxHwp4X70TQwPwsa0fPWuoCS9uhYcpZoQlBbWxCHWf0TLi8IzgxpY2oquUEqbSCnpjZSPt9J3tmjXrWu5y6U+D/69pOeUpUlN899IQ4Z3bitpE+dPPIm3Rlm97R07//4xpjq6NpncCIItu7h/4Z7pF3DPXeBjOpzhZ24lu6MLUB7KUOG5NYtXX3VzKV43F5C5+Skdysef/bhgAUVLJfw/sCL0Ff4kauwKwvUtUlnaHyaGdLkwwQtMli+UDhWSmEI3u9SHryZinCXcHT3kft6IlaHtcxt7GNJFrarVGbR+v09pyAtIn+m7K3PddfDlPMJpMTYe75I5skTa9K800o6Xc2cfxx5jVk0Wb48qQq84NoGTi8Dvyc3z/J2aU8JbYQxZeHpT3s+JfMLQn8ZOiLbYLRKm/43iYOoINw7i9xkHRMfwBwopINCIijIacxt4fpt/bqjZtq2iXrkUWlNuG3+o5B0OfTEu31KX7oVw7WqfBtP/HM5ar+5km/H8OyWSjiEHPozv9Gps9b3TKcU3IEtOY+EazH8tWCdRk5I6LmM/Se9BxyL7JtEgpRd75SLkTdjCSXK4tpiZQkh9iZykerdrhSBaJP9eM2ImLXgGWqcyl11GnN6FZc6jnq2gCUeqYGfF/XP7IeoF+OcnGrRaVys/DIuOJh+apdhVVxKsm1JEy5mir81q9AMX566oX4jNtMNT7jiJnXPvaCk5QmpNwHR1VoW27CorY1RvOu3djf/L9fU0awJ/tUkW2c/3ajtyDO9at7nYGOixG+TOZCxsPMWF4Nsac86x2cKGU6zoiRV7WpT+KpL2+q5Ir+YBHuOtC8NIzxsO/UR1jEbeM2SzYbGWq2lYybBI5WCzryRgtSrs1lSFyhu5r2QqWUveMkXB6rOQ62Huhq3tGxa2hK+rGVouKWh61b7e/h5ZcPMhhmE6wcE+C+kUS3D3mSJvJFyJrtgvZnE4sspxMOPc/EHtirfJPLkmfNj1zOzuE2bVnKbgE114ef8041TJ2VNcGGCgEkYBjMEAhlhsPyIQE6gMgUwVsQEXpypVeAJCKfkuoRTY5QzUxlCtitXx7dE38ry04xWRpFMLwtQgoSYssJDS+fm2oh/pmTxBYTsECsx3ehQk/zcwZ8JZHyqIzWBQora5ecOBFvEcDCPWilErQ5yFd/LND6FWxtPvcugLXzWRc5lG3J8toxhjvOjDWZeNO5qCslB4MFKxeW8STeVwCtiWYkUopXNZkrJFJbSNoaEmMagSYWpIRI3GU92S0JS396vSvVIKQtHTKewzIb7iZMJ+DA8IVkEq29JG6TAy+XYSDSSncNhSjuiOfc57HL2N+x/9eGnM7sPTzq8e/b7ESc40zfWB1eyaYUTi1J9l81YRFwnLmmvrZD6P5fKZHWaJCkpz5ZN33oMSAJiVxQqqjoxYdffXw5bKIqsCSoB49NnqMA5hixfm2nJ4Bmdmt3l5KTtcSF4CpHiA52mgFt9ZaoezB/fDIrbA3Ev+wEdo+mG5imeeJPxYgyaNLcK/v5H5KE9pvskEqaPs+YQydx9jzMe9wHvxnnRJtR8IT94++FGSMItiUKXhH9SZUlosMX5Zcd7IslH0gjejJdwLttd9tEERlpWh6qZ7nUDzxmoqC0sZD2QDvS7GM0cLaeZcdwYyK9w6ZhLCTeXbiJwEhVj1CH/lpJnfzUgcU8jdc/q4ZFtHRuPr+pYdW5jR1qCV6f16UDtYrSPjytoa65BLZEzZooiTz7K0hPTdmYzNzYD7/HKlX4/276uAngR7na5v0xhadYU7+B+NkV13/Ii4lNO6YYEn3mdfAr4DiPiCKd0C8A1OjSlW+6mFBG9UinRW+SmyLvn/Zf7PikX9G4C8At+uONgl6d58Qee6JLKQMuy1snWDo3pgDhJ8tia3DH18OW1sDCCFKLQsLxlvkIOr1BH2LGihBprdhu0wvshqPTsXNZnF5IKVIbfYrTMTAZpdHolYfpAXQZdEVCmopa+iJmpAxJJaloPA0eahW2gveZS+6nc12CKIUB0d+HmexGLzVjJWhnTsqiDRu3L8PXJHB6oJnBKEpsMLmabLaOcpjVWMa02RpVRTSqWmx10ocYpnT7wRJO/rkTB84r0HtlHX3/c/6lf0r9cOkOj1qyXyJZolJpDYPhn0tikXx6J+1KTU/vEySuK5hVVhUq7T2ptIQC1WJaYQyaXV1c4GVtzC66OSWdoctDR+J2fzGaY8hbqGDoruFxZNwkyJSwYOLl3LxctUKzIBMz2MbTdWFQ0qejc1nbYHcG2kKtRpq505oUjifUOR2Id13yBxV/LQHEdrrQrhxILVIbvYrT0TBphf2sloXUgkBZXQXwmWy57RnzdWOMYlXudSr3OpQLORiiMe7AZfoisCl1qJu6IHxjO0UzufrIzNe/ygcek+CfWUig1EwOUSyA5J2VjEj15Q8rti0OfO4nHLtTj4za+ldkIvZySFwlhAykrSCV562NSKdZlx3LonJKpcAPwi4kywaoQ4QHdX2T9Vfw9pXAK8J61qTMuwotnFxdltD2x0jTeRu4O63sSnfTemuNmG4U6NEuUKEwUsZimsJtpe5ojTdtW4WCa4NMiQ8V8GgV60z7eM7cmv2LOojmL4dRcRwkSSHld+G2k4SCvIViVeh9Amp25OxC83zMudAkzq0LC3J0F4I7IaBHnlLDm5QdY8x3lmyZD5sB3NaNbnfmDXLVVf/pp8fPs58VPT1v1au5gfqsT3dzlwIN33fMMw/8NGc+LaSWqZjTVDNCyq8JKURNWbRRlK6gCwgO3+1yJGOkenjr8VywuOSdN+/VX4EXAvk5cxiERSQ6Vst6GXM8HdqWuWxc3dl5+orHPVmDc2t7Y/hHwanMyivN8rOTEbXx5NR2m1HpGJrM+dVsyM5NRT/LEXQjHhl+Iu/zew8iRwFUn61WdvDzcmfES9p9qcnM7EkNiqnAJn0zMJnqMr55SdFkqIfvIE//ODDS0Ws0L7NjOIorpGFw8gWiikHqiMVGVeOFLydTNYlOWJJ06dA3FXEsTuhSg2jeU0/9h4xd8A9/knz4zNG8GcGrVj17/sCMrmTANH4pfgMcdzXCGRV7+PuNgWGPoOg9baJbL5A47CGqtWQ49vUz+5fLpWcKC3KVe1VX3KJ63RyzPsT4hOPDheAfhsrmhoK/G5pgX6mgJrQBerTlbyaWt/Q41ZKewzTKj0SxjU+xDqO/W0rjZStP1hN44TGxNYmJNLCauF780qVbqU5eUVDe1Fk43R+brcB2XZZHlSiKOTn1t8kLtnYo9XTkZF5qGMSNCMyo0eeQJFnppnTnWgP1iAqv6Spf6nUUgIxDJJgo7MI5ogooJgEXObUOt53wCq2bV072mU9og5X70drX7XgHk1b7wkgEX6J7RLh+2JvhExo0k7jgP0um9feNhA9dg+JbDjpnWOO0o4WkLEkynIvDzR8pvIvzSgtjdNm1p8VQ08pvXl1y/lWtCPAvCV0IsGmoX2sSBGoYcRJ6SMqbtkxUIx4J5APFoqCIPNjx9P91i4Tq7af30vmV3z3H4eWEQ9oz765ePbY15ohHxZccZ5xjHgocT8UjHGUcs/IgHxxnXYm80DG6VtKZKrVhq6btUh9iq1rfa6qpG1ct1+wF4VbZsp8lKdgBh2ZCrAaplQ7wzQ/AFwLKdkMLAe8smAglLTyQkx7I1DPDffcjz4pNfALFe7hezOd026If3+L3d/YFuB8xr83gVRUdduiA+3uX9/BPz5z3B5NP8ZKT9Sxq/2tvm/xhu/zcE3+K/Af827V/S/i2NP+y3pHdzEpAq2vwpwj573m/pMY2nGJELDRDq7wDHGda4n3Ot/q21jmV/bdI2x6LHKmy9ttSPuanJSDWQ+uQQwOsezQuXCT275fAZf55fwa8UfsFzdn3kZ/x51AuctFezI/486gHhQxY8iqHmbFgBsf5tg9kRf95NwkpUgGYD/jzCEBTwCpDfmD6w4Yjv6G/0byHYkN4YK7DhiHf1TisHblY7csS7oFr60sffkE5FsNsc8W645igGgCSbzRHvwmBcVS9DBNJGiS3W4siJIwBDK7PZw6XyTWx0AxvKbQB3Y99Cz7CJfo4JQP35BLXJLA4rSbHez/3l62vEv7zJsNcJ3Zatr20j7INpxZunFTH6v5gI5PcAfJ4i3wH49j8mf2+J/JUkDSBghABA4D935nijg7PgzRLV0YwLoQIpOW3RdVNhkYWI9qPDZe5jtN9S1zgQMbAkSwkKl0eGGUXHfoGM+QyyQuVKZ86TxpDLSexKY+9DnK48imQq2BUBRewMR2V69AbJ0/GwSRmIWJRXXGZfZOnpSA7J5LZPmCQ4VqX9kp/M8adPmAZyLKt9zchIJlpTJ9+gxT3XhXfNRTv1kU5EynER+rx/278vD3ZO4Qwnoky4nQqKi/5GHkrmS4pdOQ7LKZ1R0s4Aly6vXLhITyzSbN3bDvC+BUbYaoSFKQHTRmC7S/ajMxFYLdV1JQ45DdEyuRkFRghsxcJtakc9traNZ2cHy38Ny/6OSNEHgriFx0YCeJ45OGYiWWWPFhECaIYiaI3QxyIWeOPzfbTP16q07JQou52GctEZpHjhTMRH5UwRkWpnqtisnJGLkIe1zdPGAjAL4EQgWOwMgXHSiSR1zYnCTJwzVGJynGjUtH+U0eTZhk2HTlMM3q1Jg0a9qKTEJFSoHKxyUSWVbm+qEJVFq1ZULdbDUepiUKdM2u9XSwgWKMKL+OH/v4/kgu7OB7vSVczseSyTs6C+2h6t6kxGVYwO7ayC+ovytNZNpuZ2tHcAWHVoVQuuUm5+ACkhGZ0RuSQZk88RAuVJ0kamM4wz2Dg+MYHFhjYlgmrD2iiNSix/BLw9mlR0atN0WC7yHkqFMgj2bSKDjHz0TloiIlYz+KzzzIRVelsJp0hp6KnslskFVuiT7rOst6epda2tye5Ml4aES9snTYxTKyJ+XxVQQgC5uFwJDOw/12+hKNFixIoTD7cwhJLi/1YRkaQio6CioWNgSsPCxpGOi4dPQEhETEJKRk5BSUVNQ0tHz8DIxMzCysYuQ6Ys2RxyOLnkmsDNw8snj19AvgKFihQrUapMuQqVqoKEHeaa54JB35tvuSU222dnULDYlwas8ae/LDNkoWue+sOw/f7xt39td8inPnZYtRor1bqhzieuu+OmW277Qb0v3PWZIxr8bpUH7rmv0U9+sUizJi3atGq3VYcunbr1mKjXJH1+NNlUrzfFNDNMd1bGg5lm8/n3q1HvjuISNvrwxP8SZlq243rxBDJF20mSjgWICL+qGjOt4lqadrh+C34hjkNBCgIiklRkFFQ0dAxMaVjYONJx8fAJCImISUjJyCkoqahpaOnoGRiZmIVU2vMRlBU2sb1JPGid7xhikeeTphXQ1kMGwCNPPPPmcHZkFOkpkcTzKI+r+CTPPokjQUKfyrKqhFWtvRWZpKTTXjPBU9WLXXeHLMFTguloryt06+3rYOEru80ZBnbJt+10Nk2SbT1Nk13gLuR6dXlr7U3tqaeW/ClYKIjAD+GrEAVfAz8CIXxNlxcxDyNcFMMJgKRo3h93bVPd3cK4qmom9tZxnncWaK2Lnm0PjdUtvLeptbbuPu10WXGE6+fTT/GOuUm7+10Hlzew6wX6OiN9wa93fCM6u7ck+MA1J1U7JToEAAAA) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: local(IBM Plex Mono Italic), local(IBMPlexMono-Italic), url(data:font/woff2;base64,d09GMgABAAAAAC6sAA4AAAAAbVwAAC5SAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnQbiVYchmYGYACEKhEQCoGkNP9JC4Q2AAE2AiQDiGgEIAWFUAeKABvEVyVsm9bQoDtwqJ1Kac9GVLH+IYrKST/7/y8Lmo6wRbMD+06NreJEYBJSgXQbTrrDfHUq9I8atg3SLIeVQYw+88Nvjfi3J1hOf3ufvoWiroXR7D+voL8ZhJdHs+8IjX2S+wO/zR60fFAEJVRokRYLoyiJUjE61i6qdFEu6mo31+HCba5dn7uqbReTemw8c+cdhH8QFuVwGE1S4XVlbY/niTXW+4uIZIlijcSQGSIdIkM1i3jzRMKneyhU+t2VcHW35nw5AmEiTMsDAjX/1+a2FEHLTeo0aZWuW0COnDolZMe6i59cwPHHLmvCRQClNlFndGHZcRSVXCKYfpm+ARUqxA/NLb5CaC+arFUktC+Vha6O6kwQvYn5VU77hVu39dHw2fqlhRMgJNwzb+zxRqEqpUp1X+CrdE1WMiwxByD5v/n2OcaCoOcJne6udFapxr1aYB/6M6Yg0S36niHJpbFWK81Yvl3tkeVD7aH36L2HPpS996W1nxj9fz6ghUfmiDH6IPs0BA7SCBCer/1e7Tvzc4NgwxswNhMrkr37fmb/5gaACsivNa5sLI6vsDWmRlZ4Vd/G9vdgDCOZ+tMc4X/+cj8nRepGF7egNI2Yd00vizTSPEu7/4Huy7H+j/skKrJM5tmqf+cBFAAygEqN0LyJJUIxsUKxc0JxK4IyzzwoG2yAsttuKMccg3LOOSjX3IbxnVGokFHegIk/VpiwsUPBAli+sKi6kxh4YGZ/nJngt1i2NwJ/mXc2g5IoLY+qlhDUC2wDRM4KNDxv0Q6FKm/DeRoq5ywJlSuRaZSr1azTRNPMscgK62yyw16HHXHCOVcMuuexF9750e8++hwsioSiYggiJKUWKY6OmZNHrmKV6rXqNjlUiACACim0Ccv8ngATcoAPY4Cz/mdBA2GDNJ+BALk2r7RQAG0FJhXNhwEYGyrVn2kRARVeAxuwNmKaf60f7az/J9bH1tb3Zad/9+CD9T+DlcuKPk8MjUgsAkCURFT/srM5EHdoD74sRYK9yav23WwPhaK3a5vibxmYpgDU63nDiCxSvVbdJpthniVW2WCLXfb70lGnXPDJ69YDT70y6md/+ieAqkaRUTQsXGJyGloJDKzcMuUrVa1Ru/F6zLLAMmv0hkr3joVKLWAe5MAk6IEWbidMs01I8YPEAR3QZJ2QQDlUWlv5oMLaQLU23tp1w0IGlNusZe4BnLQ0jaYLyIFxEAVtkGbNTKyFgDxwWLeX11rMBwlgR1/50CiNCYKeJgHMsz2QtT5B7Bw4UmXjyVUkpHkBFaghFDQ0rGE5tnBoGNfcAk0M4L1eKEBalIAMilWQG2WifFSKqlEjakfjD/w9UABd2c/9DTdoS8y1DqRJcZ7Hja02sDrnIRzh7uMW/zS1An/Ja2kC6ffcCAL1StrUDpFrwM4QB7yKagJFG4qByDh5AAIqFj6lSAlMja+aYBqzDh4ARql5Duvu5+ZWRa5kS1HtdPjgAaXQwQg7I8KIw5tfeqLdDMXbr4VMr1PUwZIoNEGslgC2itNWQ9diVZCby4fC7bcAyFhNYErJX8V6m32e+diTvEHOz5ctByrt4dF87XmChCuMSkguXBwDO4985eq1m2iGBVbYEAQwaIIkGkGEhjSBaAThG9IEoBGEbUjDRiMU1IasQEOWHsoEGqGfQRlAI3QqqD/QiI5F4u5KGBQLi1LHrNgxvPYbEwOXhJo2xDKyRBVtyaLVaWVgpxF01CoYAosZJWfVi4v1UnFVTMAV2aokQgJpolDw/PhjYGIJUH3D0L7jCwLgvpw4Gg3eOaPxx8DEMnZ0ctXthLFFrmXhAPpwuffPHLIGRae4hEQ9e6ERnBcOjYHgmBbUJIMC4CKzzbj4qOmBsAuL+vwXABsU/ZehLgIAdCX6WAB8GHDtDlrblKIGdhTVp9g1mU+O75LzEoCixxhKkbETu7Snxwsj+pLwI/hxfBN0wn6BULBS6D82Jpqdb4vds+P2xwdmofPD+bH25ULaG6jyr/v6nrvLb/i/zwAA/n8BLx5e7Hix8UXjn6iRCwAAQBk5AnA1p+awcprcFQBXXXMdwA030wccdMsdd8V0Q+653/uBYQ919ZGgj7cWfG+87e3sHUBVZ56CKhDaNMKLejcRWByesC8p7VVKx5f+lxUIReJgSYhUJlcoVepQTVh4RGSUNjomNi4+ITEpWac3GE0pZovVZnc4Xe7UtHRPRmZWdk5uXn5BYVFxSWkZzJk7f+HKdZu2b9uxa2f/nn179x84dPDwF1998/WRo9+eOH7yFLRXVtU9Gr+1teFVdz1QmHcNHaBmFQAAGrdg99v0Cg8AoGn7cfnB7LXnL9y5+2B46N4AnDXy99lzAJjw+xBmHc9cvGDpsuVLVq+BVbd9G89dvtoGrmwAABQMIhIqXDnmEwCg+gMA9GSAGg4Y/wBwGwCwhwH6J3CRcsKS289pyEKOJV1dRA5V8JKGx+pRwoBdXqGNclsNdfQsIXM5XFWh1mJR9bBJHEn3kuJEWOCKh6eKKudUhT3CsS1yYLFzTcIsPHSR3+ywIpOohKup8HrVK8gcc22iieKWeCrhWgQTdTzPMGC4H8coFGICGCJM7VOEvuWgwcayD/hVvmd9iKKBIgqXRKl2ExKJqCGaJn4tZKbQh+8DVjLSy0hTV2pSY0l5KIuaOB7X7vyqXC1v/4aDFz7W5Xp0bbEAF2EWW6srV1iHEEOoT9FkLkciVTb4UEUpRf2T1o+egLmkVEYkjReiAc+wJcYIMb+XPVOjCFM/iWO0TZoYwxyVxtGwX6wJSibJDxiIV4x1zawFabx63gSRF7v/yiHv0z4LFiPRAIKZ6wa2D8CGVGXk8fUCuUIhC7tUC1KjP8mdl/Iqmx+FlN96Te5gI8GkplFFJr/qDGScVwp17b9XYZj3HEiqZUxXI5px/Yx9svYXD+VxIB2hINW5Yoo7ncA/GxJZYz2k8np0uTJ31msuL/r0d/1ikkuMTXLRRCsUasxObpQ4lfRNdWGEDOKA9zeKgDzpzzFW5yCgz7LBgXJytPBH7rVJQ+HhyKPzBemrgLeRvjyVRiBROHrz+ZypFWuBnqPAgv9FNWmAwLvYLCRgQxaO9DgxkUJ4F/su3l4lPBIjjHIlLtnTngQWaJksaecqi0HicIgeftgnWU31ZnEy6HuSnq/T+gMJ2ulkhegjweDdrxbnXShOEJcRCYZARWLLBef5J2azv9nFS2b2lQo/xCjeziyojg9vsSqhHAgOHGQQsBlKcK9jaVvG8BXdUOpoN4FV2i1WW8e34kCuLTWnoSpKruHhUTi6HP8ZITgyoCx5i56PFe7jCKubHcSaiRFgU9STQLZEoLXF/6OkZ+Qf9g+7gK1E7m51MBV90p3tkRfjCML/Zxd6wX+HwRv9fV1KIJvdUnU9QNSuf/BMkdHsqVFU/BDb1D6D3w1gCNSIOmfeu1pW/nuv5PThBUe8h/U6fcTVsUHrU4qEXJpDc23DmsQ45CahkLd2kWG/60qV2VPa6mgvKqGDuIywNjxAERun0t+vZmQdzOmmILXJ0lE6xcIa59cp6mL2wk2qn5HsEMTYGyYV9h3JyG3x6+Fi+igdHTwg0x0+uO0w4Hq+LXmEfzkoCCafjWO5QrjFUVYIZdsq6JEVzmYWDwOblhCI/G3WDHB/iZK5EhiATJmkeWqJ+UoQjbf+sqbQBJKAGxbFWI5TqQgRT9sxsOhR/fu4UuWwrG2wNzNjSM2+Xy5RmeAvOpWNi1ukd17LsSUkqbYqsP/xVGi6rN8buFcpQiRDwwjEz+KblEZBTGZxF3u91iMsmzMR4GOULHdxqcTW8sAQZIQtlxggTLRM5mfSmkQoKLNSkLVh+xJgnAzCzKSqmaN2OS5tZ7dnJ+8It2c83kVe+qrJtARcUurOfKiNapr40hj5PtHIl4p0NVPia8KFpYQTAIh5g2NU7UYR0NNJAuFhF0OcYs/ORDmaG8+X0cDz6aogh4GFVDd9RNjt8XVK88XohXfR1Qy1j/0L1yk2VnyACayE8zumrQurj5banic0HxRHpJxV6/C8DiGX9uxR5+gsWbeqqX5h1k+UeF+QHpWUXjhQ/I3Oc2fsdMjOGXiHucNlJkFE1/MYNDFk6xTE91cf7C18iBwStv4rssvFI7AEx0zGMnl4O9jRXKJOTyIPa43aTiX+gssqp+lH00M1QekQu9j2d3ZGDCn7yGcrxzmDPxa+kmI98UFyluF4MnokHb0TSB4AVKxcZc9MsRRpQ8w34qmI8CSkEQUdS2UoCD3qCLmVdfzSZtWoB+fP0TM506649dKUG1aP1qcPR2uQYl0pqeng4OjufDLE7KxRndofrgLuC4cJW2sXD2m1HtlMxiq5ezuYccZ4s2w80TyMAGO4PE4RGT80uTe6rkMKC6q+Saa8KvI/QorfNCr6hn11iZpwva0WNEGl/W6WxihdjQjvESgwY1sqs9METHmZjgcltj85CRYafwVOBGRmokXcp3GOjhpzWNb0kaPpU1Pw6kMnMzYbdhA1G+ZatInWWSEE73/Q1JUREHDQJt40ueCx9KuC3vJvVQCiYPWDBQK0Pi3UzBfEV1m8cOs/tcm3tR+nR0Jclxq01wkQQnUMRJXj1tbQI/bsSJQeS57SMD7Ehp1eko4WFgxncUADjw75vuAvjRHSuJkNOsIFPBDSclzXtGb8bRsSJCTDQICCvL4IxF+2cUE2A2Lc4y5ZQ72XNw1zOywb8YWrai/EWJielldBqxy2s03SPT5Pab7ovjxkCpX3e1n2ZeLKGnpmayE8BW9DHglcYzVFySQLDU16OyVGYKEhAqBXDiKzPWEKdruiTbS04HIyTGCsQ7eqBzXXUWiWS4IgYLhVNem72SJJFirva4xlIy1XOHc/OZGMHFUqovftn8W2ZREf02CInb359mVtTCZljz+/SF2+l8e1nb84VWFlbbp15gix5XH9OTtg128+iJrufnsY6jYNIcYH5V9OGfqTu4vRiAeeYJZj/ms7onyNmCXbGu0+g4yl40gY1o21gTRXXMJYroORsOhi1udRekMDkFr/5lWMbpzI8gsHGBK/6Eglf+YpdkiLfcjAMUF0OWOD6jfRY86jFLNEM+Ker4Lg7lC9SEWalsSW9WpcwRK2cUV5bKyvl7N9UFdWAI+xYw7Yb5DxcGa43NGkh9OaZPORlKyLRozRyUGkcBgPKZtmBj3U2OUXQpZj5jl7nGLhg6EsS6oa1qBND2O8cDGU8ovIwwClo5MHNDuURPpItUe30y6SKH0ss16RbloxpGCHkEH2FLDkku4vwaOFHdVjK9Or9upwfa5IJS+BqoUeiW69JFa9xwrBOWB5yV9WxG/kOP1QlxkqdV/439ZJlxglTmKKt7vuG7Yhq2TctWfOdCoS6nO0Uen4tPTJauhWhVWimnqiIl5acF3BiEOz+ICviKMbo20MLueNpyTODMjUf6luSSLPWVCJ/SPT4/2a390RGWG7QlPyvq0XzXR4cptglLENCwye9Fvi8kVLV21xFCx5cBa65dkjDz1I2TR6rsUlHQ5uOda+5Jh/3Fl9kXqyQf54ox+vQyZDskce3lc5TO1ug6vDDkPncpdN1fc5ZC0cLoplOs6DfB7qx2HaQB12zW5C53Y0dV7ZrSZCwNaWCZWJrXWIl8BSH8IYPG61YJCm/kf8ZPSrfDSNAXlCqv4oiKreNY+QW2AU4dTYtKlbf8OxyKvg6UwH1RbsoceCDOO2DgQO1UItyxFGCWR6fjyJcX6T5Inrpi5cduW+evx10+kNmhw5/cIVqxlPrbHdmGlnT3+itq9jly4GCZgYdF5m97OEbAiB9oWAUEIhVi3fjEZkj8LofiJqVdA0/nXgeQC9RolsWzExApBHZsw/SvlQLJbNCzUMtLfBk3UU2eyatrJaqBQrvMhgFO6xDpKL0xas1KuzagJNRH6lrAbWqFUFPZEnSG4NVi2gxanjxS0STdYamDp6RqfiYphcnEt0Pl6nqIiYJdHuEnj3qOSxnZfif5xamqDSqO9rQraXZC8hk33iCiidRShUyQlmQ0oGYVJBjX3I4sGUvmfokc1XUi3KtctTD2DZUu2T+62G0CKNU0hN+1seecu90Hv6gkxdgHAztGTU1PEZ1mOdDBMouSdW+UNflLg9YgzfvZ2ckFw95eBB2sN7XhIqJMadVUPCnMLpSZHLhm5mZls3RgcPiobgXNsCutfjr8QA3ifqOkhyqroQjp5d4Vq3SHS0ZmtwclheUWA9OXTluyfvGltHaWJfofUUBN6j/YUpicvJys3jPTwxJysmU2WVUjLJWatvUqlao5MaYrEiTwobinUSNVonEuA3cZK/WtkCgsP7okQgJWXf3ws1Dwo3BTzVpPI+n8wiP4nfsmoLMEepOMG1bNUhvgUX9ZvoIR3H4diTpXENYPHDGYcWq+ZOP7TI9tD204BtJ6rZps9meE60ECr1h25fN4cxFF5/bBHNDRU63uYGpVMrE3xrTMT8xLrjGnsWIvu4OpP+GlKnEabq4gqFy58uCnqjujhR8pMR6zQRahSRT2X/W3AZTjhdGZ9itoYGOD/8L46G9JO/mVwTT7QZzARENp4X1naZZ72tsJ4sCzf4VuTfv2tgOxJybZmfQSqkWvus8llNSUJZoN7byJJZCz1ZJQ21ud7zEF/XtIawwvrtHIXWyrDhCj4uIyPGmKl9uUfE3y69IAjlIvr7F5yqWfECf8PSHaXMQFeF1js+CaS3VHS7ig43h3M021MXV7dXZPkW5jhqojo3UTIzJFHMEmlmtBlxvY+0SfIYddC7mtJ4SXVbg8jOg0sSySw9+mVax+r+AdOTk8miYWuoyY3kpYPG4v51JfvgbaLwziWS/pL12M+OHn6cM3UT3QC9eEo618QFIIoe0fFUlr1EglcXsObzMDNsPPoMwCA1xRM6lKS6wAZVpcldpE5SH3G0Jb1ikm8DrU0r87XGuQxhvPp33FVUHIel/UEk/pcGOWK5UhxBvLZ91r39M2vbBhAL/HSbkoncXZZOpjgF3pp/4/m00sdHLYEv9x53ssNCbeykAH2InG3TmMyGu68OdIF4mTUjaTWTR5T/HBHrilzVzNhdYvCVK8z0kIFgQf6yofEYi9lpUInTTYnl4mRNip8w8IhRtnJ6LEdkzU7exKYRI3QxKRlICqQz5uWRnfNet3h+rCMZ6xjzom+QTeuwoG6P0pHxr4whUVmVJVkRghKTtUphkunoYXlHUlQ7ljNv8q25dpKRQ6VE6xL14Xd2G4k5UycCGimtaq1MS1hTPK2rZlrzx2pXemZy2UL9p5xYXWZZaVZEcInZWqWITLEUuhALi47E6hJ0yWcJzOxo1/hNt/Ov3EEsLW3wGdGmsZ2bJPb8Bo8/4YUmJUzCt3wsFiaVVngs3Oi0rnjC1HirUSlym+NrRdEp7nzjBo4AibBqjUG8SdkpaYltAh/ViwTRATS/FpBtWeFGvVf2/qQvrWrFEgtZ/xyE7Bj6SMmccY2QdJVsh4xOkn6YpP9w6a4HJNXNuHrpv0a2TftAeVOB0QfsXrPNDw6ls2ho5d1IndUQYeacmtDrYIcVVOY7I0SuKx7h39QK84gv/qZe19KlzxNqjawqQ4pvk09F6GJDbr40PtIVJGSlSL3lvIQOMyUTOzxeHRprywzzL5M5xuT96+XYVI6SkhBvcYgfsIPLEBtrbYDa24ug9Elp+Rg2yXyM6X93KMBOrQyKxw8yFM8ObuQwvGTv4Bjr0t8Fl3JtA82lA1urvDZk3YJtAy89Wdn2FFvWZkx119n/eUpe6qI0sQb5ZEmwRsx2sXxJkoWRvfLPFwyxLya7BN5Sg2pp8DvgIk0V0ydKSZWBtapyk6tEnawxBt4YV2hjphBOLudllvf4NviUaOP9rcnZVu7tsohwHT9GpT9gZcK+gX3RHsGkQI9mouILT2dntO3sZcse0UOfEkGSv9PhthcUyiC0c2A/YskP+SEVsaRK/ypELNPMEUdlyI+WyVoiE2BHFe7B+x6BMC+/Z0ohlizFVbxqhUFA5mfP9ic7iOKKzjOIF+zflz57BUn/PCbHCScTqZGJns4BT0QENeB4MJCR9IeKow6tnsM4d0A6kOPjU9Sek5VelU5Ic1ODjyxaxm/3n205+BmxADd38iTxU7txJdRjZy9+9rRWFnJkeT64T53Ta9ocao2Hi4JHCHdrcmsI4pHYIkfnQKUtEn84ss4O5oDneYTKPKdrPW4WRlkusQHVk1VSjKQyFGNS8Dx6g/yU68m3tXZPbj4cJk1s3R/7dnKGwF8uVe+Bqd8wR4eye7IJqePr2Z+/5V6ljIrg4mi3M5ptaThXkff11c9zmrNn/pZTq+mek8nXNY2rwPeo8rrl7d+mRJg0bdldjeQAXkhBt+nt7d9zwpI9JW6jAnPTTvXQHBkmjdipjyoIilFZfaeOHz5+3aNMcGabEzVLJ1up2XRzli5cnG6KK+fDirbaNk9wfI9YJN9d8MOAYandHI/zCli/6LQg7LiWljrD3O8xriG7eG1R9mxRSkNuQTaflFGb1A1XCwbcikIhghuP9BZm6wdAnTBgE8/ze07c9kWx3xfE8OHipY69AxO8dxA37AD/3ORFxlXYrlXNi0qFNVvScxPnJM/HNs6vm1NKz4WHKp99e3LNR+K2YNu3zDhSrt2mZsB/HxDb25BuxHJP1mQ9bJ7vVTHDr/cOkU683QuT5pN3SrJ0hK8+pN227uyHf8Rz07B/pK0gt+WungCoXYjlCWKBN7/YAiIOiOAe4kyrqIxkdUdXFRiMMbZwNMY7z207aUFS4jQCTybmabo1xMS/1qe97qG1zTbExVo9eYgFsXD8SHGROjj82h2bh3maaTW5PRxzjqkqMphind2fxziyiENqdVr+4wNRP2Tgo4MxDiiIxsojstI0dlm3JaNUGS07f/hArYH9y1aNwZNFSdsooJMMpqRY35D5v71v7Q6aa/CDFROyGSky1j3ptXtBDPfOTXFxjsxcf1rADymva2w1yzrtmbXqJMlvr1YKA+e7w1YJJqIJFHTg8iMMWdCNBfXFZQpLs5342F1WRMrxKkK3M25F0an7Ohvg/BD1ROD+2wmG1PXb6WX2oyTDUd/6dr0+7gDJcJvde4dkuFOoEN9vpMLQ0OQYc0bsvxpLhoWS5TcJezPbYkpLrywJZ7fHlhbojI6ZYBaG3jazLInDf3RqJK7Op6zE2bbsnJ6zOUIkiciROcvnXqiplmS93WXxEfIjot3hGkEQUb1KKXTlRWK5f0eFBrkho5u/lornsLQfufEHddkMSTWXJGYZS46RDKTss7UX9vyQn8GXTfAC2pDPMdLJ33Xm1L5+epn9PskgqmkW328EEsbBUZT/uXw8w6ZPsprimH/eTVPqfcwbzs6asN9srg7nBCh+Tzv0s0cc4mCK+mWSNFv+o9TyXCM+IjImj4BitKQcIRkI07fNvXHgek2RJqb6OyBnYazkNCwjWKHMkWESvlYpzmm8owTx1dbYPIEGiVH6vzszxNVGu/YLyGDy7f7+jMMHHMRnYdz0Cc4YCohIuJ3HYvvVGKwZZcrYcAdPypp8ZOXKSKMtO5fs3ChgehmMCXGhBgvYq+Bh+10jcKPAkbkwM6bwC6ZYy7tz3HV3LeD3wZf2M8tJhhHGfNwg7fzKYDfZlas6Wp+C5byNUpIBQRzNYdy++6mS+BRXRKh475920lfNBw6KZcqjqX5qU4nsQktdlYAkMJrC5PTLxZd+tyIznccGJVKfG5lM+BkRVYkJBGZ8wWqSoS5glo0xx8795j7JcD95SvyL1WWtqVL+zI+wZJ6uN98TfCu6szBuwGOMF68MF8cn5/AaYoQU3RO7//9UmyxVu7CodnKCOSRLSKSzIgqaSQaY5aW6FEpVi+IqzdHZnkBuPcPv/p2h1xExNlN0tjCIwrMzgz4I8+gt0RLE0q+nD3i71AUhWzK1jkw/Um1/EC5tLtQhFeO8vOOsOGoQIglnCeOFOdRyKQnC0+zv+kp/1msKjEIeZ+wir5RenO5JSMz0iU0TKeqD+ISX5r9bWUMJaDZwmFzvl6H8oDXc+i89a1aPlZJJn4C5mWZJ1jtcFm+VKEzh1oj5AUT1jsq3UlLerLd+2O3l//GfL+ONXvpUkqvK+tzODOKIBAVMHTkrLc8hz+atiDduSiU5qiyf4/Zy5878sOcdUxAJ/80X+wVi8NSEmDhCyfi96z9TDfVlG8t0BqksIOmriRKsl5/eaVBJD/WeSsuReGECflm2LS5I9fg99sJTkTBjf+STWrLrZC9cbvIVk+jQ/IEthcBbGMTi5jzxzY+pWI/97qS4/2xcfEHsn2wIZPHCTKyUs4KyjLyoKR2OfLPzSni7sesRFbcH+/eIlwQ7xdGWnSJu03lyNGJqTRK19juj8YSBfXGHn37Zi3/jT+1orfwUfSmMWp2klWufTtAvzjFnINaNAjoMImydT8irSC9dBuI+8RyRSZmCKpLRbbQyo4UFSYa8YG2omc360moOHHiS6HBXFPhHhn1NMvYxsV6sg9W2FfSUpL286Xf/2vueJVkGzO6A773yOr8um/I5hSLj+NZdi5hwW9M+I/qxuxem1zr0JH2fgBaWpnqoOSiMA7zjx0jGJTO6csZ3Yf/uKoGuJSTjsY453u85ECyNrzGFsj723TkFZ2iSX5pcbLWmOGhQZHonSUjRKkTDN7+YpD7f7x9jSLPSCEPXRfrSd7JD7x76pfDm4cNlX6WfD9fLH+LCy3pOlTcuiGHs5oaRe7XagbdvbInEZA2uMWRGLMyv6Il2xBZzkuREpURF5glSkkKzZ9VGIkqGx9sVHI2M8eI7o6kiWec0KdiOT3qBTLN/59qca3zll3XzCAiB/0rAu8kaLDcrYWL5POKlEIk2OaRrl93OoOACbUK+6r6HZVZExRsjVAQ0W/SsZY38vJkdhAmOkfzuqoW9Lt7ZeST9DTkGtHmiSwMLgmVcW7WNr0geTo2NdznZlbwrjEqK1BoTg9e+KYR7NJO1jsHcbOY7lAEpnMlsCwaPpvuL58CpM/4kgz/YW4Sr1tSJQwJNaFOQDONoZm97gQQoXikCVrwgs4fB4c81/MuXSfpLLNuDdskr7iFbQ9I/wtcGGLDiNswoSXqQdTmUTWJI2YKU2do/38SwrhOj2Jwp2adURYbTkMaX3YjEErG0bwMDhgnpjleq2NUhEp4EfSFKFObQm7S6kKendm2UCOuK2Ximgy9vhWTrDw07jRJgXO667g6PWLaUq4PcmWu2c6x/sDtaIP6tFOtVzt4IlL9kKQG0QJs6XlFk0xcLI74jvk41EyN882U7zCD9YT/vPR80GDK6edzEzQzGYV8kO/O8sCQ8KI22NQwf9BOHKXizHi5bW+sV2NqY+JmW5Kjk4lZILuSKoyJ4moBUUgpPkYwtWCWq28gi4fkTQsJNwk9ndzWjunZJU06PXw+tuWDjkl9ZlXslK3nATjLtDvm1d3X0Sj/139d/u6Zsa5mR0ALTpuzN7b3kgFMfMMO3AhGYL3D/YuiKCNlTO/YRJwWh2NM7l5/ZOWebfO6O0zvuHwFgELWRNTfKOtNaYnTtoRQ/tnaTc1co5r5QrcyX5MtM3PHIuGPSoaE0byillYBm7OZhLtl1No9D7PXBL/f9bX436KqbPYvk65nzSYb97N5ssuvmmxx8SaozRpJn0zUJzWbEoJeZfHS/G0IYRK1HVkglGW6+IdjOwHgk0qRLTm3NKMTeXcthENPtEm3l3br02AT+4ePnaNjmlHBNpDExjr/gVhXXiYrmBJG03ZKQN1H5u57OjOJFW0woHd5bZzLVhwxMpmR4thlErRwKjpvWuDNwL9mWKiiz0k9JmdzbkOmzHb6/Km0VaWZsPQzH1M98vdbPrtqqv4HB4Vm2YB3HSc2LTBVPteTXaUxKK0cS6ArVBbeY0otCY8Ld4R/0S9RlxTW6n0oS1v9onPLoE9Tof8ItMBW5yM7ZAhYxMSUu3ljsJLsmfGDwOUQSj/yEP8eXyMFqHwvidefNmh4QiJ7MK09F236HKVadErDOYtuqt2H+tCV4qMh+Mn8OatLKgbi7s9pvHa4/H2SD/KsYXHNjz5QG5c6Mtq44Gwkx7Qr5dQPJtFH6aTdiWtxJk5u5+eLMKnIJ1e6b6nbb0bAG0ei1ZtyIOTFK9N8FslmexJ4UXuZMCA9s2//aF7vZGrkgPBO7/2sXM+MkMTZKJrVaQCVpC3kTEctxPjE68Inao43wRBonOlYNs/7LXvG4pHNeZ+msRRCjV3UrA11hQwEy3mt3gNLO8sX5zWWfPCKYU8EOHyUh3tTnlKMYHr9XB5D9Vy36j8ncP3/CXnNFB7D2rsD68PwM47iiHSQhO6sK5oU8wXNeG8roU6Hq9eFX6ShsPN6x2J/FOF/t5B8N8URAj+GPoxHVHO0PfP7ceIP+u1XrBz5Paky0hwlDZszBA2TX6IEf9veN74MvOu/cvtMbA8vAIfHXLFRZEes3s27+7pB9ipgSgVgJKsy6I1MgAKkvnzm+WLLHPa3LmarRHyb68mspLGC4XiHGt/pW2muS8YVg/4gihHcrNShRz8+4XmdmwrRtktGcKa+m5EhGp6sYSbLZmOzZySpGqF8PxYOt2RixEUv2+PXAP3//mpW9nI8r/cn0E66Uvzwr+9fBQSg8l1L0VvnoCY8Re4Y5Mb2zaEZHhsBH0xoVaZKuDDxXoXgRLDcyhufwvOWcKKPTOx/b6ImVGfit+74WkV2dVruslkMi8jT7jkcQNKel9aWHyQ+4naTgVwv7FiqJoK+MijPGq3xTG76U38cIE6XX94b6cLbwgmS+dzxFsfdeIhqPZT+jxtcYGO4tkrwpVlE6oo2hQRnTf4LB7T35zHuRaDLabzaL/d/jYPTZCK1Jojw1mJt4oO0PSKyMrt9H6fpRkLgER8TKEkQ9Ip6Z6u/I1JUBikeeuh55+HyRRI7D7gjjhNsToHLvrg0Hh7LFz9VT1YcSaC2BezHz94KuMkK24fuOgSDmxQkMKo75NYOpX8dUnBic3sfpwr218aShqsDEcCMYK6PXh0s55u+XHMoKHncZWacbWspXauRBbk/EQU6zXU3yGw2QVxT0z+kh6bS0jj9m7WMnQ2JlTI9EwrFiau4ESM0xSVFxQuEjEqafymVIXDq4yGWbMHiMTCtfxsA1+ukYDo7+OkhENqG5ONoFeF9vkuc5w7NrwSvJurJ25rzR4HA1sGAbw1JWxKycIS3WKwuFW6QY0kJKkxcNLG4REHCpAoIoNwENgVhMUbg17WAQzD8/0LBTJ/6D2OS14vptyuM48g7tgQyYP5rN7IgDvxW1EXXc+dit4g3st/l8c7I6vBvqTfcW+ZOj9Nq3TP59C9fvXbHGyj2+uAlWRv/6Ip8/bBK9vX+lsKWh6c2uWfT+ZBXQ64eJQS79FOczXjHHUN1itCSPXDg/tXIirZHWVueXG00ruaI/iwk0CZD2AhUPpFwk+4JCWL0G1JK+WZ+UZ1t4zAdmA9DwQA0Igedjk1lqz8uE/YexBj4pdQS24yOsgRT272g/RbxF4q3hUTR7yPXl0rk+XCr4gdSJlsr15dKBCkonmpXry6UjqoGH96BBmOZjAYQ70fRcXy6d6wNUiHGiGbm+XDpQISHVV2czLQ6MVG439zL3KrceroDVyajldnMvQz2cczJSud3cy1AP6alXg8HjZFRwu7mXuVehHnKdjFJuN/cy1EOhU7eKqQ+kEsD4+T5Itpu9yrahekxPHVqqpe+hHQH34J52/y7iDV1OSH1yrz1Z8ItoIx7Pfoj4Y0o4Wu6fJOT+U+4/N/sD+08uv4RG9H/B/pf7T7n/kvtvzf5g+78PFuCNzkscwvf32Obv5JFx3RIzbwCY8tcAhnLbp73pTPnBulFgYRnL8ZvFFhqv6wsBdVVe6j3DOlR3NECf7xiEQgFLbD3fNBw6/Q0nz/T2g2eKyT5YqDyfEkqw/fYpyZQ5EwJsPw/Eq5jasUKos55eUvnn4kIJtl8S9inZUFoIsP08SH5VBKCYTQk8iMzY/+ywOgQqtlX8UswyY//zAI8VgcilejjmGw/QLejhdIhlFgJEsMP2oTIUHswQUlwQtIaBpVIAVmd1j81WTOnYO6A1tetaZaeL4Tt/Pe0pzt6Za+hwyZDjcnuWvWklUMU9U5Ud/m+u/kyed52v/f6D6GfUIoShjj6HmXI5hgKAdmE0ZN/BknbCPx/BjAYAz6YxnwOAF/8fvxnrusotewgPjQgNAAAFWpUoRS8ojH7nVaIaBaH6lxsfGIuv7ZxhCHLGrL2jtaFqyeoaREYMRhZaHx02SVEOOLDwQUOi1dqRI2fIJYIwpmWxdfcDatxEWygwWIg9caYwW0AaSa+HStjkYKMpU9fdX2M+EI1jC0ciCehB85YYosyRmM0GHvF4LA40CBmd0enWWGVSycCAAgKBRNBiV9JQA3yLAxpSE5gxchCE/WbW6WOFfW3Cn2+yL+tQvjBJZ9RO8ti3bpgZvc7Vd/kAe+/iolCMJZvh1cGzYOZekQ3ko0E3nhjgbQ67Ig9mEurgWcAIcawMAo0u8SDP/OpQqLgNbOJe3xaAsWO8o4v5zORG/MqSDDYbXUZh/ZpxrERlR6vOGP3ssi/dbiddS7oVXZsxnUTi4HGX23YRnOYOQ7xnkJesYZXMZyarWcsBVlR2cr90dDMYm5i/feygn828c1VwyZOUjSTioBqarLN47fDK46OEiXapLqVtqxQmDoVil0PDO+cwAoNyWH6xOBwknQ6Pll1nvQXkl1weqPQCgHwAhxJggUMj+9phaF11WNJwHA4jhQ5PnGl/chYtev52fIFShHz9JIBKphgBF1sPQIiRj6JZ33Dm14GcYiXiC4wZRzPpNdYuom872Hcb9PhvKJL/xqaTlzPxH6g9y/L5nTcHKoAHn8fHnnfX28ECHr43+UsJzkEM7PPsTr5uVYk0s1mUo/KsymGB8NwDdXh5nLW/8bP3gQl8z1ucAmB4snAzINLHFZsxeoZB8Yy1W/0J1Mnyq//Mcvm5PuFHB6YkUjJejRSEScxw0yG+ZvGr3fhydMe6C85/QPVmTE7Hn/Ov4/0ZJoIGYx/kfZ0lOF1G9beOOINp6/afI/JCgiCj8OaDyhcNvaWqyPb/qwIF4eDi4RMQEhELJhFCSkZOQUlFLZRGmHARIkXRihYjVpx4CRIlSaajZ2BkksLMwsrGzsHJxS1VmnQeGTJlyZYjV558BQoVKVaiVFkwsN0ss520xqg5lliozx47goUFHptppd/9YbG15jnvud9sstdf/vS3bQ646rKDylVYptJ1Va645pYbbhr0XrUht91xSI1fLffAPffV+sFP5qtXp0GTRs22aNGmVbsOXTp1G+d74000wSRTTHbUVlP1mGa6H/3smGGHfREcCg8PPfPojXievXj15t1HC0sbW7u+trZvrmG0z2wOM0bSorC0X0jLYH+DAquopKyiqqauoamlraOrp29gaGRsYmpmbmFpZW1ja2fv4Ojk7OLqZmNrZ+/g6PS0pNQjeZp+yaa7XNp3qY9tadelzWYyl6WsZFe1TwtTVN+5yNWN7QrvOK6n28p+LkrLCXfj2uMid5IMvqUut+7eiHyeVLsB1DYBjyq+h72OJPdTrZtZ7VeqLdDmwTJllM6YCm1vNwjtPDdcLHs0s8Dv2yD00NhDEaCRQs8VCg89D9AoQKHQ8/BSWauUlaxlI1vZyV7uMpOHPOUl76/nyiT8ljqXuJEmqDz53cWasWXuL3V2VS0hx8Qf2DVFUaSaXRjoQPFm+xN2l3/JAFUr1c6L9dwaPqDDN3uZPzmtJQgo6BcjZKmvhS4IAAA=) format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 700;
+  font-display: swap;
+  src: local(IBM Plex Mono Bold Italic), local(IBMPlexMono-BoldItalic), url(data:font/woff2;base64,d09GMgABAAAAAC6cAA4AAAAAbMgAAC5CAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnQbiVYchmYGYACEKhEQCoGiaP5SC4Q2AAE2AiQDiGgEIAWGBgeKABuDVxXc9d0OpMjPyzuehcDGocfMcEUUFZTi4v9PCVKOULO5hPI0tooTgXFdDikehp2SMPqMNRZy8feLPPzQlE7lpGbLz+UJRlMbSfUcpzyFtqfJvYjbG2H5Id9MW28kTHKElj7i/YGfW2+djI3BXzLGio3oJQMWLKgSRk6ipBRMFOP0wMw7o68xLqy8O6uuQr0MoZDB3f2zaUJVsiLYGCXZlJBVT0St/dtzj/wHUowSKECa9H8yqAgskGIVx+VZmNh40rGRWVubxdNk6s+AIRHAtTT/S9W8s/P/WEdAtLNy61TnOqS3+5YEThAPmoFm4C6GdtHiDIi4EFPrKkSOODin0yQPrH//G/epk3A3dlMXZtyOIFm6dEAtbz+3HLipbCVJ0RXojr7tTXxSl0qrdN1s/o/cEKLhGjfEY7fySlsQSf8mmtxzZhll1o4SC4UTbGC+gaVbZu837whI4jGqtic88P/9pfzf2XT6aMuQflMbyE4Ao+3NYlCDsQQwgMHGw+NYavNEChJIlaNMz6qWc7lfxrHwTE5NuCk1OaX2fza1dtYr2UpYhy6T6nJdrugmrAPAplrNn5V3Z71WtLYca9eyE8khh1jJvScKyQHm6o4VOUB4BNABloRVc21JXF5RNlwNpKNjzMZ6HxN/Fv35Zo6Q0jmLzVnn6K+Vvyfpi7jh3cG7aqrRcf4HUACoABq0QaOTy4LikAfFxQOlQDWUceNQNtgAZY89UI45BuWUU1Au+RDG176BChVFB0x4CsAk0khQsABWNAXU42Q2QZh9D08RcPeGetoAOV3X1wEak+aK6Tiii6rrEojiezQ8utqhMLWPzENQOeVyULkAlUG9Fh36DJtjoWUmrbPFLvsc8ZYTTrngmpvu+8RXnvrZn/4PFkVGMeUbpVSVOhNN16JTj0HLrLHBsF32OwtUcNaFfTDF1HMCEV1SAzB01U+1cOCBAi0SM90BDbSnGOWDvP1X8z/Z4tKc80qXUfGnpwuDE4bDPQhEOkpDaz61H2sVEDOUS95DI5IzAUiShTnRYiR3iD4MQhSrpphWa52vn6iHmnxIoouP1m2MUR/wGj5UicK69JtlnnHLrbLBNq864DXveNeZyZnd9tBn03s896u/A6gmiopiKzBauWoNJpupzTwLLLLCaTbZZo+DjrrAJb7sGjeBSk+OgUq7YoYvJ5hHh+8H4zbnumccmvx0Rb3vlM/vNfUzmAC2RQ8aq8Iopeaewi3gJJT2aCUQ0oCPIIX4qaMai84JqwHyAg3ZFIXVW90YGm29EiBzEHI+USTvmSgubmI+JWKUqRa7pkGLDj0GJaxjbhmhYVxyHaxtwK9JaEiSZbLVPKVAkQrTNGnTY/D3H4UC6HrY8WMN1m0nLrOOV6Wkc0cF1RQnNgM7ROI+ddzet70LkHZHZzuofvBGAOjOzmjvgcRtYT1IB5OKWhtSYwUDKr35AARMAgiNRJkcUABQMlmNLfCgzjPNOGmGVO8x87Aq0/I0LbP44AFVOUjSW0QYNUnHzVO0q6FNQ5dCbZfZcc2lyibBAYBI9fAz9HC+Czp5z1Giw23AKdb1nEZzJLDTbmjc4uUpdRrl9NMVL8v/DDy2NzxOlEarYJJSM0pn4xJUoV5Yj2HzLDFpQyiAwRaleYIwwibyBH6ETegJ7AhbpCcNyBFBYERgtEXAk/Y/Gh+etNloPHhyhkW28pA0KLmMihfm+cXydvBPfNGUdJJDdDYTAy2R0THHmTyni348DIabMa+4ECTRTApcY3+vCSeKqGSuiUwmTbG4ePgiCAhJ4w70JDKiAPBPPWjsqbhTvglPvhEKePke3kGOh63KcgIcQN/5+vYr7iAuKamhIUknEpqi6uLQGOhT5wDNFojn4YbL3/EiqO2AtBuL+v8vwAbF+QDqCQCArqOPAYDAAEBWlE2qPGopqLA8NkQ/qCGdc20C0Ix6gSILcyLn8rAkjOyiRExIOuJA+pADEqlkpZT34gUMrIht1mCOW+8XDuMgRiTNOiFlX3uW3/b5Tm1i3X/0fwAA/nsPPnn9c9fPjT/bPkl6YgEAACqKg1UoumddhjWPh7tQ8aJLLnuvuMpo95rrPvKxV/GGm241u+2Ou0q9pzz3fT4aX/jSa/EVQDWrQTf6JIIDQjXH1HF4wlGl4/jScabpf1kkEqlMrlDGquLU8RqtTm9IMJoSk5JTUtPSMzKzss0Wq83uyHHm5uW73B5vgc8fCBbCwjr64SjNdq3l6+Md9/bnX3vP0PjYxNTk9Oz83MLi8tLK6vrmxtbO9sH+ocu+Cz3txtZ7g9u7pn/WH4bx59ALmi8CAEDbNdjzcW6oAwCg/fr9+nlja0+f+ejj23du3JzygSe/Hj0GgKEfd2HBvfkvLVnx8sTy1Wtg1cvNG0+dv9gNcOEKAAAKBhEZE668cAYAqAEAAL0KoOYB/kMA8Z8EYB8A6O9AZ8noOm9g1mlhXx0ZKjrCMEYCHTRAxVARYEZXL4pDB0V7Qhl1nQQPoQ5BoxS3Z0WiPMKiL6KeRtlARQTpgshGlMQajZ0YFRG7Mq2bQ1SocqIywFJo14ksSkUassgZ0TcVNXRYwZC+xt9gIh/M/cAXJZo6GVsh5zI2bm5CWbh3MjRpSNSAtCQkCuu4FUKySTIwzPGc2aa+ZUWWtCA8DRsxwHFIYcl6N7SivYp2TW2oHcBiiF1HtMKbRRf1Tv30x+Q9wuajbi4DKNEFgLpOO/UVaUwqTI0F1SE1I+pcQ/RkZ4xN+peE7z0QUI7jiiI3qzwmClQcg+44CKYUuC0bGoQ2y2aULlNEYRorQ0OHqAZ04ZPdhCfkoFgn01LwXCsmyPzmw93m/qhwVADBgAhy7+PqQEXoHEOoYUuaSaWAIrhlxG47A3mORnDVCeEGFb85AnBa8UTicADkhaZD8p+BB69qn36BnpiZge87t3BZHZ1QvcZyK9yVQZIioam0CryqF7B3xwbqI1PLmiDpmR2Gy1XtimFx0UGujtZc5GCLlofT87I7OqplzG1CyQwIaNuTGyYpuCOjKVXPX/idWqR/UE0BV6JI9ZHTzNX0c8STL39naW40sovHV0+Jy3BPpZYKWgge6CzaUYFUL6SBbVf1ypfO+wLtO/26jkkWtJhMj5tIPbYI+yZkh9wcUBs6EbCNACFn/RgXAMfdCD+aChw1UzwakbUVlpfltoyMthYzC4K7ULgCKt4Epqz9XMhrjcS7M/594HpcRa4aX3LjINnTkcRzFFeYSGBoGLFUX5+F7tZUvoqgPd6/btHDqyk64/YZMenLKXTcXWpqSNuTm7qCE3L3plNJLzG5rSpQugQXfwKhweZ9vjHYax9a0TRF3IN7j60pDLpZ+7Y5oy1bl6B/6SlutpiwuQ7t3CDZmSBxPFZ1+Qs3WGA9rkFKg0+V4C0/qOXF1smZ5dbm5Q3X76cWTOmiwpeQzBpxPpvMrNmDbTNeKGeDW2YZFNj1xbYK/u8XqvbvtUPxuHrMt1hmP0FatueaQs9vIHMLpNJda+I1fyJtAU60jjZrnzwrNy8FBWn9lyR2PXWkkR2TxlxMtUTJXmur86dhp7RY6MMmYc2NKceS5RUYRIikEVeQL6RDOzuoeL7l4+RFWdXvCUvxkqvXVDPpVNJYu6fjK98vkj4i2+W7pRolcH4jUjeGU6W5ZgYl9ZHAjdUqldQlP5TGZ2znzJAUyDcICBLt4R00ApCicPFlASM2fJ2jZyPbJoZ96+RmZqLcpTNvO1KHMhLWJoLgVkIXRornfoxI5wQBu2TIANhG2I0StGWSCx9F5avB6W0vj5NU/XSK5LcC1qcrp7qmQ6tMdVNz9dB85BBA0fKj4pwAp2eklsl4huPV/tuAiVhGNNgw9jsDyRTjb/Wb6uuImguLkXiX6hA8lqNUnfA7F/7wo3LGNyREbgPp5IMbo1b92rnMA8aauOabkE2bVbffH99XqT8FtuMVdxVIUcduS60A/xly493IAvbqYyiFjA5X8OVlD/ePg+zZ4IHWSWcd3KBwoNaxXQzun97XQVqSLIba5Iq5o+v9Yz970nqgZiBqbFn7/ZDHoOwd+b5DOzCR2P5uUawkv7WqBZbIUz/XEz1eJ4yEsTas/HMpTKxEeU4jFcJ1hQeWw9Ec0eZJ1s5b65tK3+ulIoZkU9M+vxHsQgqNF6Mu/6FaUI7OAl8NccYmm9Jv1zq2oyyGEu3Ds5DXC3Qza/IRn0aHbNJIXsLdlMSDhOpToRfiJduK9nh+GzdBFMIVxvye0PyTvNE7kaGX3kBywTVII2/GC6FOHDT6vSJ1ycl5KSN3AMdqjSiJpGsttfB9J7J81kCeQn+tQk93/PdoKcSe0cYCPOhbESzCyrm1Sj6Smqz4w5POzkadXCTI36MxSHMpSU4F1d5JHA8ZysLKJ/sc/gIm8ZTbFGTYsJtf8XqB447lVvinar5K2mLJ1WxTmRuSZaq5acxzh7ph7eXxu3NIjZuD4x2w3VHQC3MMdv7CDcVRClTZhPbdu1HEzEBHnw7pbVKOFca6WBUWp3+RGii/bLUhJQlPxYYd6Hx6tg6ggxvi7AhyM5lAhDuTP1ADttetIW5JnEw4rvWZGeYkss03R/byt0p6PD/Pn1FaMvqmtTI4wPVNUuXWmL18o+mBDpOk30HkSSHIbTomSw2S3fy6rUOu61aA1ICKhQWenyAf3BH+/pzvNRxwTsJ9tgfJy4NGqkXOxaqGxSxLiRKu6gR6+hN+kp3eFiujnyWP9Kplm28qgNj9p/K7BclzQp00kKvEea9YoC4qZAfHPQaIG2xZXNipC3ewtEmniSs6wv0c7Y1Ub2mx1eb9zg4Sbwt39Wn4xUVh82+oflZGjJbuX7JIccpZRCmEHaqq0AqMC2PdthZKelcSOpxzTDE7psa7VP9lEul+PbyJACnC7jm4g6uCAinzpIK2lgITGx8uuo5PibJ1HWj69d6cSE9T9mqUBq8OI0QCZRWgawL0lwT8uipbneVvWkLTXhCgDOMyuPJ13jkzyJLzeoUmd2XCFwtGNL4Mv0dr9wcMUlbNjS+x5m4fSBjAHBpN6xAEApG7lVflpfpMl+nJPGdQIrkhGjpzfhh8bTMjtyFqfPHrNCgjsh3O9/PBspFapu+E0aXV3hh5CRiofpyFboXv+KYh51nZLjorR9IpK0eLXP2oJcuW2WPcoOvYliKJRSHvBOzLdL6WXDIpHgM2qib8Sp/sAbhDCIxcpSKZrlZdtHNhWowqH/keykqIueaaZMnY+NRs8y1xb7UL60ZRIarCk/V8YrsgwrqwOo3JzDDSgZxJ7jWtzKJbfS6sARAU8IBf27aEmXXYCcEHfRyy0+K4kN3PCe231su7CkgKbZYytJ+FAlz+lBiFmrcqmKv5ESn3GuAbQ/3h5W79XiWX4sug4dkTMAiO4mJ027XOTeQXqsaMruOaGQqZ/s+9JenBUHteMvow2gFNwVLj7a95V73UZmMmy3q4CYfH2caIQfow3mA/S8Q7PM1itaxdlm9v1txtT+ImyltkyNomC1wltnl4WE9eBli95M+bRcnN3hm88LX7Ombhup6l6ctQ45LxIY2grslY08lPJTXj4LlIM5rZyJa5wJPFjL34NeciqXUMN/bSZmgKTkPhmUV++jeFXk6k31k4OFZBEXg2T0DZumzr4Eavx/ITAG0kvBMyN37leXyF7Lm7Mz7u0uPYEnfoZU86X3u+guwNx8wAy4hUHrBNuRmVua5efuOoFyECgB0xJmRajIMk42ZQaSbQu/gwM7Fdc1wHjaQKN756olG/pBCV5FFyiL3VD0WQnxpsWTfgUIjLg+xJ7YGalCWdl30BsiRinYJvO/gZPn6DsffIvZyL/9CR/Oh13t2r9yBJ+sQiT5gNis50P4u8VfPxn0SseNIij5T+JQnfWB17a1TtsYFrum+EdChFuc+fn9JYHlLpSwRNyAeMUOIiS1tOKgqhpqYSr+5A6qa8gxN6yuMyC/WIb8f9XUV7w5M+wF8Ru7OzdCB9IDb8n08Lj69ZlPQmmD3zMh8nMba9mpvjuAXoG7by9xjHYrt7dUP/TVOIUlmCn06pf9IK09OnWejNYohUysTnFZle8m/kRw2Oww3+x6G4wZQ4pvegR6qNGCAG3FcPJzBnVh5b9PxV63btIsfADne78lEhB6wq3brP10GNlVZ/ac2sq0qoJtTVrLrk5lpZV7MozWpLSosbMDf5+IDfoRxmw7Pd1RefW1oRtThKKutqXUfsiDzztluhZwhGfhVnps5CeJI17RZRBe80tZu1EnMDhG4jVAH19ZDf4Qfqz+af1qXtkku1/1j+1y8Q4tnJPqHRbDwOtJ3qYE2fG105fe5o1Haq9/lU75E5hi3tZoKP8FZiKGl9eeW0HEVpzMmkbbr5NaMDnURmUxerTejVTassxx88H3XwhotfGcxNiAk8LFOuTnnHYhtF9//mV55/6Vi24OF3kdtL2HAsaHN6HcbI4N8ORJ1QLFIc86oPn5gkx5u0viVZFrCe2XkhvvNsXXQIvUEx/hcKWEcx+yortVz/w1yF9DDNjiiEVrNblKCyCB5FWmILGzuqmbkXMPaaQLre//4qFdeM3rMOP9teRBwlSYXY+tQ9Sb13q+kRJBJyY+o76ZUY5Plt1fK2QomQLsICbkuSY16SA/Y+L9Ru8Cxsah9bUVxT5qo3Tl/EqJGImAmR9fGVKb5H8x8l+ZTT+O1wenb+OJtiax3jqzdnJneoHPHR0X7djmZyu9+wlC5vc5SuhitZ0e8c5vQe0tIopCMuOhwfPj5w/C17Nyz5jr80C4uD/ynGNVGMQl9nyl2rAIvFmHkL1eYCjzLSt3ykRLrTPdrvKTJXyDMconoz+bILe6Rf0zjWMHc0WcJK+s4YLKbgWMxuNlmS/KfEWwfQcwaOe2+S9kyVus4/+KbWulp+5wH8ylv07zHCt7+xMiyVGLM7LrLz+1DP7ASuwWLVB4Sm9sFwmTY6N9USMMtXT3eA4pWsxS4BmSDhqdUuOTVQ2ZL60MXQJQb5+/9V5pRUeJjYIXu+OUEezM1sleQk+Xi7Oo+1emItCRlJJ1qwNIK8Re/mzgQ1byydN7fm6Ouu98vZPeW8MemfJ3QCIqSn2k2Pid/+2RYtiXNESqJydSZ5Xb63Q5efFuTvmnasz/Wb1ZSc+u0sCV8l0qpfjpnBqFxyGFiUvqHZbZ6kZeVDPaGPbzjjewJlhZYyac/p3/5bJSqr6AOBMz5JUZfvaotP7zV90S1hGPQGPGCgw2f5lDs6qvrj92SOIxWolKGZ9b788uYCFv5IgiNREZ1nTWuQ5XR0VLrNnjJ7BL4g05UWJ/PnmsNKa3fy+y1iKlFGMFwvpjExYWaLhIZ8oYUBvnsVrKw3dOpGjro3eJC5zGgTZ3kmp8fnppchJ6NL2K+4ufH+p/zFN76IWG7bRKBv5s0DXyun9yGnF/VlrC441tjDFsamD5zxL/iLb34FZ78VrC3ClGvHBCy09FOpsvq37sTru6e8AmNjT6hEh7gWeWSvUJzh31YwPzlXdg0s7F2+TE9uGqHm6me5q8JJruSAuFjo1lIE4szp3bQAVoWJTdP5XBn8kDr/gkJ534ENRkWQMg4nyl4lKUJUD3ckOYrlzykKDqedZHYtGU7x0IpSukUIa9ZsHAPoWBO8zNxzxrFno3HqmnvqtIrUTlgGa6eeVdaW5k++LMOG062pCYjvbll0Cv1Zs3GiJUUgw8tGtEHkXDguqWZWCpZNkO5TWWLeAwllZt+ykSbt7sKBfqsrvUg8I8qtWR4lWOxFRNnWOlohq01iFyQ9SBH0vKh1owpV3WgTvDR1tX94/khz/M6i7pGMwOdf9tndHpqfOyKR0btarZ7roOybepczpBFuj9apMaK98SQFXUOZSHiXEhpkMNZAOveO7oPokvq5s0Oqff6Zg05/sk9cInZrlot4iwvQwrTsWpqf2SixcJOuGZIyrLNmz2S2/J/VOx+Wyd8wyFf1Tq3Sid44SbwjQFjta32P1jLjFHYcnFPBH2S3HrWG21ClSyJF6QaVvjur+zvOECCRgYqYd42Xl6Amdo7P334Ik7Rh/i4w2Z5asy5vnaeSY8+Q3m3KaSIJzpiS5/RN7dU/JY083cOO5sDTG2TvjbkF2a/5sRLgU8yVsgy7qC6rXPrKCiYc+RKDA+b0aloxZ6BQnjhlID4HQdE39a/OKfxJYFdlSmss1kpZ2oD6ReJAgYk3y4ulEaUebQGsvqLcQahaWsUsHgvbeYMqEE6kDpaVfJgU+KWo0O34tVT36dkVqaVmvTl5jX68i6ury4a8vBr2Jg/GUt+b/Mv0FAlDtkVRKLkEFErpeMrPVdVfVyv1aa8aZNPWOxhupqPKmigvzMkIxWS7h0yPppV1OqTalIA62ve9lTkhX5YsL8s1N0thn7nWvOqVeokzpPq6AvZU3psuGUWZq5OsGrsVyD+20rmXkoO0ZuZOk7mzi4QIzxEvLPPZ18A629SWiBriFZL3yqKaHXFTQM6fmq3fzlxBGl2/CLeeJFxctXtoy9S79LnkvrmgfMWwRNJOsrZPW7LzRQv/q8oOpJOY0+nt2PE0CO+ofps8vcWwM3qc5B0P7XxF+b7qT/jnl2TuvJMGztAT7md97TBjMSk0z8Kou9x38jKzDvIXk1fOG1DDw69/pD9qL71obcrZpHbT/4s3LVgMlHc5/Q84/fDadzPTPadLlPAGJa6KS3Pr3THDGaUlhuSM8R0ERu2kfV0SK+xOWzQjCvfskxAnpku4HnfwdR8t2ELRp2Rv2Cjg0+UTsOLzydQK3DOYL5PELU1k5mu9kllZZSWG5KxvpHzQkLzFIJCG/UApWs8/+XExX4KmA5MSbu9usSn6ckvDxpzy6lxyf8rhYk387rGNgkiqao6R+RZhyc6K9HVZ9/N50DFs5xISzZPDn09WNZTgNFj9tgYBpbe9rzkvfkZBYac2J9bBMt6Ux2x2Gcel7RgcAat+kMSLxUJaRXrmZ2+5efQ3DPZUmk3rwBSwmjdSE+HADdHR2sz4JSFH06I3As92srt3Ur1kS7E/8Bq7+xir/Ri7+7j7HK2w0AVPbuSFxO0l5bPOy6KOS2aO0svwj6DXJFFvLmbmxTtjZmQWleiSzXd3EBm1k74n3JFlQwVe0SD35A+FZFuhNyE1zT7WKohgSp7Dyna9ga95crOVuYLfovneQi170iAXezjk4o/CLGEp/tAXPg11EoK5WpsQx5T4jmrjn9vFhdlZlhSWuSb21iZ2t8GzHrt0uc+ZmaMqS4M7N6I/HpsR+ink6NpwJvjTSXa3r1LFqA74iaGo4jSYdOWaxa8v9tgsOU5TXnl5SWRc+2cBX44j5We7XGUoZiSMl0dWZRiEeoQTbPtseWHF/DRKdoYT5f1vrjtDfN/QF9cmtRjTTy/HUwfjVDtsuLG++z5B2TRWqiQ91J9aJOCR2V/QaW07lu9wmVKS3wQpSjFl+uvbtouT7BBZjJnkDLfNSwUiJdzb3+xSz/AEwvFW4qkltRkujlG9AiVJ9zTO1yBcfFRjbKYJsZNSzSiGcRndyJ95/+XJDA3+Epi0TfSzu4nCjfiY/LqARxo5URmH42+ccCm/BxSloEu9LuCv8UTrtJ4o3scN+YyzMr9PGi+1PS3mG3PalRO+AM4u1sR+H8Xb1udhWmj5WeZ4mc2qqxIAj2LLzEmna5LlDxawuwsRkpUzNC5+8xK7+5I+JnnjcG7g9b9Tv3sIra15EjKx93/IyWLMJIgxlp1v/2hNUTlYBXFSlu3fufqtgooUb9r82mnDKVZLtjWNpZJKvyxnd8N0ivFyAj0vJcnen5kXISIxP2YxFmwPH2bqk7qTvBHxBPpZFjtDmMesMcmI9vFG8fdsn6lCt3benz61WmRtX4QjyNqhlWJKz81hA7GXRon/isfalH1/JD2CiiW/Ma8i0+9MrLJLFMmmXBuDwAtacxIS0t3ZDAGhl8ZU4rlCIidIqFHSCeQ3x6oyPZq7PpnCkOb0E7gBhwPuLqTzPcEaHqUVt8VFqFGTWrY77p+F9dqAzRS5h76gwWSk5I1wBsz/nWMhQn98G6m0tMqtr5eZWEXp92g76rT8gLi0SP4d9WqEQIzGQk9zedr7SGTWzelSnFwpw862pduPMuveLswkRl55fXuaUG9JdxAiGin57PeErcdlXxd3vc2oO5IhVuA19Xk4b8m+9f8xEkLlcGBtL89Sw8JmnOxxKseUbl4vRF6TsPiA6tNGWxdXK5vdxN0uDdI+k9/EgeVvSi7V/ptE+dcZCJmyx/i3iDs4L9MfLstC2rOLK1PeYjZ3sdqWOcxXOrQzRptNaU6iudikslZ57CRmSxeYkOolpmThVNtmEQ/uUGQe9ra1aZTACG8ZJ82SiCNipzMbXIiTm6gqzcmqlSZ7w9Z/u50oudL4dwbbYjjKbHiJGKv5M/lp/gFmWX3k5h0bBREPtveCOJw06m+tzizp+eoPN4pA3Kf0ndCGm1Pjm2YaE5dnJ1wa16Le2zOmZyiH5HELQt9QUHTuZYT2sDtnj8xYU2Ykvmfc+teMOew0tLflx4BfkdE861XhVmRG06yPM+A6TR3lmFcoSknvkuR4S8udUcrYldH8xz9mCex8sy0u0+7OZ0elI3Y5e6lJV/gPluXxJ99QjkXqS4Trvjh6BE4vdhk0fuxD9PoBnZVWq3TkKZptRaalFaHRFHdazZii3KKcpMRySU62vmRBSyJFww/SvYoUlBmUP5Fdfnd5hVsb7e9wybV2W/rTcpXzilDc4CFbcCR8xEmR0HvLr379i6UItBdtIcY48w3vacxV2eVpEiwRF/FHFDLO+d2Vr8iy+ZJTCAyB4vN565FieQQRzdoWIRrKD0N3csx7xZzeKyYTJJXL3ppaooiLzi9xIRripZS6YnZn+q0bxBJCYoo923/Xv54a/U4V8jBCODclypLl5H8tlOGwKCZfMApvXE1gNiZAToHy2yujcg3iWuiJ1mAhsqqIwOY7EchLstNyl18In74levWIXNDS6EyO0QXJcr91QPUIPpMXSStcXNnnRT4XYfFYVhcr8qQ/GB3hTM1M96Yl6S3mufbYneCMR3YIsDgMfQWXa1dW7rdGJ5hzjPExc+6gbXSLMWj3ZFrjHtsN80li3k8SLA4TnaCiesCWVqztOdmdAcTzA5cnjXoZy2XhrcF8GJeqj1nzvt9yevEVdoeJy3wHj5vHqAf4TWUXIlFObVp8bZ6jRmnSE2/4+oYe5g497APltbMH+z3qhnbfx/LBj4WckwzKrvl1sc326CKZkyuaJYkozNfA5TyqOyC5VKAQOwdSGw1y70sAs8frD+SaogIVnhhDwlIVbsnVwo1YMi46BvGHh18+OIwsevJgcyIFAlXEKmNZpj0t2Xte5kxtZbVvEr8+oVMnYo5vfDZlnmB3RlFiBnR4j9o2QlHe2VhM+Kfr5EXViEwBY5a6npYI/rNMOxWqG20hhxb3HQQuC+Ie7FnhLt0/0b+8xt+/wijvKtmHVqwJ+JTKGc6q0tTyvofUPPVBSaSM+PvSEDkJ9b1pk86cXbOm58TcrOlZlxEkfVOrOEPNx0Bn5o3F/fdjx6oNHioO+JaxO1eyO12slr2XbDRX0JkRV+7NbIu2OdmdaWarujuZilPOTROwO18++KZtJbRTEq3mnOL2+kZVq4QmPhghKvrYp42yFJhSNVZpJcaYE59gznVliNKmhZACEIoFpNgTUSLS9QqlyBowm0XUyqVm7H1bGq0sg9nYJVaxGsQMtHDM3oo8IlsJfvPvj1iCcShh7IEflWbtrDX8VfFNqA/aWVFGrOqs3Y+/0+HGovPJE9U12sXB8h51TltPb4NF0WYtqIhPSnMYqb3V8aWCxuSlFfqneaaFT/bU7asxThcUmmxZG8YktHhyvG5A5u/L45Lod9XZEXi52PWm9m7A7LGU9oBdUjbh2OlbQH+hP2DPvMtkPcRSsBL0e+dqg9aEqSR6BNONdwEHMY6yr/3SeZ3hsVl1qm2BvhFLcSKrfeOYv5e+7yY4PB56OW9eobC/jQDLKdqbd3Fu9e0VQktBWcgnmptU6TUa1X3bsX6HQhtjMmaLouLrQogPJRQLKMrLYuHwuxXKTUUOdU2UeQN/sZyNzI3QcwRY0nDHJYbEB8h2fC76h1j+28DnCMsSb2+Cc9Q61e3NEGliTd/sTm3tGevJSV2/GRIVop+RLKFs38XzMizuTmS+8HKyREpUxQcvHxb4IqiEVA2XdTwq1lZxU0XtIWBXClaq6yJjjuQnWZ2ShKphEF2Mex6BQ8Qus/o+F7J+PeyUUeSCe9/5+fR2xwnI+fzESUcbfHngxAl7O0g3FTzQEQiuDQVOf7gk+Er2iIdjSlx1Sq93N9M7AHfLB2sXDtaCR713N2/ura3KyrXLWhfDtoWxrPSStEBImQo/jg/vrLv7qxnceWTHXmrgxL0OxedaSq6W7EjAEJr6K8BEmT17cn5Dwo6KvlGzV5/Hqa++O8MZ4ytLdmalPKGXf0HJ/YJe/lhwIE1tUZytdCVdmpPLgbZ1is+dmz7ZlKP4vFKPVEh68N6eYj2Sx6jjV2GbJkwTWEIVow6Et32+45UGjG/L8BaMz1B53Od7/hwyP7uny8eXTThHcZfYs6rnVozUJmGpeMnbJv1HB/Jdn742bGeoTIXcYy/UTLNML1lGr8AFChKhVv1N4cZibUGWiIITpBwNXvHgSUljd6ZrWCfJtk64vYPZ2IGch7wGR5Y9I45VMHJLoy9tq/hE4UYBjRiRG3m1JJmffpyIIWAF3zP8Pyxw63BJzHtBZWVHYk08yU12/AUX3hzwLflIjMWh6V1M/r877WKM1ZiReStWOBg47vnqVbIND7aG5LP/v9dxxcI5YiwRw/hQIDoUI35ZjMVhqDXciDH00UuPtOk2nRJ5WoSRfiXS+zMguHc9JX/n2bD0Y80mzZYizkzuCK55BOwNMcd+jq22xfrfForuSrB4DKuewxpe7yRo3v+a4jggaCJc7EQ0EwnCgp75kNdg/jtNLrLeO/zJrICuzksN5H7su8RVWNVR5vrQQ8FgsoCIYbEiru5AWD1QT7bl8xbgKHmrcdPA2pBlNcTKKaWY0mtCNkYskWUelCMnCJg1iFhbkKW8JGgQYwlYei33SkMvA0fK4CIfLoQdKHOf45RVbyDsI5UZWlTcQB3lesexXOY6jvG4o+dnH2cE3HFJxR25nHq843B99CU/gfrjgtimD9rS6OadeoRk16rjsY/Qz3vAzV/Qn+J436fomXiXdqNrF3mw6eceBnneXyt87epf+ZtH6/MNmnjsQ7QXLJ/v53opnNXnGIeP5Bzf/Bx74/URYV8/tYEZc+iVIy123O3SHUe/ur3n1dktZfQaziD5CcNf2D48sHROLm+OYUZuUavROrN/yVyqX3yIn9ApAPY4kB/DbAL5PGFhkVvak5JiVsko8eiRgCOYD9hNYLY2AY/LKBLa4wvK+n2ZbozDE+OJ/GmNLPPvRT0zEMjJx2mi2I8AZ+EcnIEzeS6vsmG/cBbO4Zm8xob9xlk4h2P6mvAtmk9QGBze2A/7qnAWzsEZPJNPtWE/cRbO4Zl8ZknWPclxArAP4P34efwiHuYv8Hk29hm8Hz/Ph/lTNvYOvB8/z4f5QMmLgz0GLeJBPEiBX+TDfJmNfRzvx8/zYb7Kpn8JhVtntsD+30Ez95svmru5MDHUbtynDrzhpZI3b1tvmtNkAm6VmbLarSsM5cHSZHlwYWRNeDL9zX/EfJoVyQD7KxKq/azaz6v83vx3NX4Ij6L/gfnfaj+r9g/V/qnK75P+a44FeC/XJg7h2+3F1pv5SXMrGzMeAEz5EYC12RpdvmBn+dXDYUBTadWWbxJfpfmbpb7PEweIMZHiMpXbAPpVjsH6/h6ceLIfHrjb4wfu7wruEGVZn6Ic0al+CPNx6woQ6TjCwXxcAMc1juUY5La5YPLya/z9EObjKSu4hJMK90PzcYEVCwD6JaccUUqVMLFs8iXAaiN1eGWVOFBdlqzP5hwjiq0SJpadRiSAHA9OGwYmFoCKcgYuO4wysezQ8UXjEUXISjaeDAKt7FTS2Y3GtfFzO9rpUFo4Xl1bpaB7dcnO1qlevqCcaN7L2C9rTRQHhVOR/MHvd3+jV94nARGMoheLzL4NQQFAO7Pz7U/DOSPzF1Iw3wAAj9Yw/wGAT/49OPyieJqcPDSDQYQGAIAC8zy40CdzUOy0NGB6CUANpAwE8ExtROxJa3f34oPtXiIPiq/7QEglS5OldkKR02cqfLAzuQgi00iTADWtcJIN7gEZo8hQKlpcCDFRNSH+98hDoZGh8kpQXMkVnihA1G+7mCQd3K9ep0y8Q9KIlDq4T4LmFAcsQZQai6zxEr8YptpB4pgZenKRX/dvxwjlgzggVliPKGbmiLEQxUYmWZaatMsmXAfsT88G94ccl+12pbdD9JfdjuwR1fnvgvhvQL6kxGJI5naSp6TDfYnXsAwSrG9Q4nB/4kupWMwBEdkpPmUd7jleQ+AHLvBCMpB8o8mI158uAS/GxSm1hlR6ZbnzZUM7mu4eMpgR5VZi7WR1T9jO2D4A9RAk8W5nRVYZFLC4zrtcT8L7cUxzySdOu2ipFeZakEctt8ui7ktWPriaAl6ULiHGLfje0e5M7Ra82Mm+4uWJ8H9QADVAIbxBeChPDUNeM53LvNSqIgoKzasFjeJKwYiJoGBFpq3gULKl4PFz9xmdsFLYe65OAoAKgIIitKSg8b1RMLLdLVjGpBYcfhYWPE32/U26xPyAXacuQ3q0ataiD8LIIEEKRD4bL4Rbe6aqk1OrtudTxKz1UrXxo7H2j7Uhf0sPMFMhmc2XXMon+F8NEf/1Uns4o/dPzXaCxU792jQahFieTh2KQQGd+NsaBxFvZ4dXtkWMNg1OevrUGYWtQuCTJhxfOHcJIQAjHZMM6bQH0UZa4NRKhgY+47wpwzZ5S+wTn2nLoX7ULvcS4mRoU3pGlFLSfUavViEVaYIKc05PQaPOBGE0lYdeE6bDd0mnp1dCval0BYquGkYbXZ/LzVnt+jh5wIV/xZ9CbfS2tl3C0+VzZhSiwYs/1iwjo8GLGzUws2EGZs7aVxwRCRkFFQ0dAxMLG2fGKTly+rNKJIpYtBgICSkZOQWlWCpx1OJpaOnoGSQwMkmUJFmKVGnSZciUJZuZhZWNnUMOp1x58rm4eXgV8PELCCpUpFiJUmXKVahUpVqNWtPUBQM7LTDmpDW+sdByS222165gYYn75lvpZ794yVrjTnvsJ1vs85tf/W6Hgy4675B6IS9rcFmjCy657oqrrvlWkxs+9JHDmv1owm033dLie88sFtZqunZtOmzTqVuXHr1m6NNvwHcGDRsy04hZ3rHdbO+wMJenPOcYdzjCUT2jfx5xz8C0bMf1mvE6b/E2Z3iDNznLIvab+hm8xwmFbZmQ94M6w9dDQYVTVVPX0NTS1tHV0zcwNDI2MTUzt7C0sraxtbN3cHRydnF1c/fw9BJSadcHVy5hRker4U5vrUyA74ONmXwdbALMZGazmI/JlYclGzdRiaRuMj45HG68CU6KZ2FoV1edru7vKyuRkW06Qj2ddX2kC/rB3H4FxM6ORi+rb4BWyBeMhZCRZpIVdXdrP/ug3tZBmDeX3sNlcOm9u6O1WGqJzCVIAHECAIBmAOAeAB4B3FGARwGPALijteYUtEColzlcgFTanXZDa+OvzeG0qAvN6GukQn+DWNlGutr+j5u1Ru5rbWto/KlcaWyAQhagT/AE6JnxTbkd/0gAkIx0GWK4U6mTAZJ6ZlcjNAVcoYjBqRAtHXoFxgQAAA==) format('woff2');
+}
+
+html {
+  background-color: var(--background-color);
+}
+
+body {
+  display: flex;
+  word-wrap: break-word;
+  font-size: 18px;
+  line-height: 1.5;
+  font-family:
+    'IBM Plex Serif',
+    serif;
+  font-variant-numeric: slashed-zero;
+  padding: 0;
+  margin: 0;
+  color: var(--foreground-color);
+}
+
+#spec-container {
+  padding: 0 20px;
+  max-width: 80rem;
+  margin: 0 auto;
+  flex-grow: 1;
+  flex-basis: 66%;
+  box-sizing: border-box;
+  overflow: hidden;
+  padding-bottom: 1em;
+}
+
+h1.shortname { display: none; }
+
+body.oldtoc {
+  margin: 0 auto;
+}
+
+#metadata-block {
+  margin: 4em 0;
+  padding: 10px;
+  border: 1px solid #ee8421;
+}
+
+#metadata-block h1 {
+  font-size: 1.5em;
+  margin-top: 0;
+}
+
+#metadata-block > ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+span[aria-hidden='true'] {
+  font-size: 0;
+  white-space: pre;
+}
+
+a {
+  text-decoration: none;
+  color: var(--link-foreground-color);
+}
+
+a:visited {
+  color: var(--link-foreground-color);
+}
+
+a:hover {
+  text-decoration: underline;
+  color: var(--link-hover-foreground-color);
+}
+
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: var(--user-code-foreground-color);
+  background-color: var(--background-color);
+  border: 2pt solid var(--user-code-foreground-color);
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: normal;
+  vertical-align: middle;
+  text-transform: uppercase;
+  font-family:
+    'IBM Plex Sans',
+    sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: var(--user-code-foreground-color);
+  color: var(--background-color);
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
+
+code {
+  font-weight: bold;
+  font-family:
+    'Comic Code',
+    'IBM Plex Mono',
+    monospace;
+  white-space: pre;
+}
+
+pre code {
+  font-weight: inherit;
+}
+
+pre code.hljs {
+  background-color: var(--background-color);
+  margin: 0;
+  padding: 0;
+}
+
+ol.toc {
+  list-style: none;
+  padding-left: 0;
+}
+
+ol.toc ol.toc {
+  padding-left: 2ex;
+  list-style: none;
+}
+
+var {
+  border-radius: 5px;
+  color: var(--var-foreground-color);
+  transition: all 0.25s ease-out;
+  cursor: pointer;
+  padding: 0 4px;
+  margin: 0 -4px;
+  mix-blend-mode: multiply;
+}
+
+@supports (color-scheme: dark) {
+  @media only screen and (prefers-color-scheme: dark) {
+    var {
+      mix-blend-mode: normal;
+    }
+  }
+}
+
+var.field {
+  font: inherit;
+  color: inherit;
+}
+/* suppress line break opportunities between `.` and `[[FieldName]]` */
+var.field::before {
+  content: '\2060';
+}
+
+var.referenced {
+  color: inherit;
+}
+
+var.referenced0 {
+  background-color: var(--referenced0-background-color);
+}
+var.referenced1 {
+  background-color: var(--referenced1-background-color);
+}
+var.referenced2 {
+  background-color: var(--referenced2-background-color);
+}
+var.referenced3 {
+  background-color: var(--referenced3-background-color);
+}
+var.referenced4 {
+  background-color: var(--referenced4-background-color);
+}
+var.referenced5 {
+  background-color: var(--referenced5-background-color);
+}
+var.referenced6 {
+  background-color: var(--referenced6-background-color);
+}
+
+emu-const {
+  font-family:
+    'IBM Plex Sans',
+    sans-serif;
+  font-variant: small-caps;
+  text-transform: uppercase;
+}
+
+emu-val {
+  font-weight: bold;
+}
+
+/* depth 1 */
+emu-alg ol,
+/* depth 4 */
+emu-alg ol ol ol ol,
+emu-alg ol.nested-thrice,
+emu-alg ol.nested-twice ol,
+emu-alg ol.nested-once ol ol {
+  list-style-type: decimal;
+}
+
+/* depth 2 */
+emu-alg ol ol,
+emu-alg ol.nested-once,
+/* depth 5 */
+emu-alg ol ol ol ol ol,
+emu-alg ol.nested-four-times,
+emu-alg ol.nested-thrice ol,
+emu-alg ol.nested-twice ol ol,
+emu-alg ol.nested-once ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+/* depth 3 */
+emu-alg ol ol ol,
+emu-alg ol.nested-twice,
+emu-alg ol.nested-once ol,
+/* depth 6 */
+emu-alg ol ol ol ol ol ol,
+emu-alg ol.nested-lots,
+emu-alg ol.nested-four-times ol,
+emu-alg ol.nested-thrice ol ol,
+emu-alg ol.nested-twice ol ol ol,
+emu-alg ol.nested-once ol ol ol ol,
+/* depth 7+ */
+emu-alg ol.nested-lots ol {
+  list-style-type: lower-roman;
+}
+
+emu-eqn {
+  display: block;
+  margin-left: 4em;
+}
+
+emu-eqn.inline {
+  display: inline;
+  margin: 0;
+}
+
+emu-eqn div:first-child {
+  margin-left: -2em;
+}
+
+emu-note {
+  margin: 1em 0;
+  display: flex;
+  gap: 1em;
+  flex-direction: row;
+  color: inherit;
+  border-left: 5px solid var(--note-border-color);
+  background: var(--note-background-color);
+  padding: 10px 10px 10px 0;
+  overflow-x: auto;
+}
+
+emu-note > span.note {
+  white-space: nowrap;
+  flex-grow: 0;
+  flex-shrink: 1;
+  text-transform: uppercase;
+  padding-left: 5px;
+}
+
+emu-note[type='editor'] {
+  border-left-color: var(--note-editor-border-color);
+}
+
+emu-note > div.note-contents {
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow: auto;
+}
+
+emu-note > div.note-contents > p:first-of-type {
+  margin-top: 0;
+}
+
+emu-note > div.note-contents > p:last-of-type {
+  margin-bottom: 0;
+}
+
+emu-table:not(.code) td code {
+  white-space: normal;
+}
+
+emu-figure {
+  display: block;
+}
+
+emu-example {
+  display: block;
+  margin: 1em 3em;
+}
+
+emu-example figure figcaption {
+  margin-top: 0.5em;
+  text-align: left;
+}
+
+emu-figure figure,
+emu-example figure,
+emu-table figure {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+emu-production {
+  display: block;
+}
+
+emu-grammar[type='example'] emu-production,
+emu-grammar[type='definition'] emu-production {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 5ex;
+}
+
+emu-grammar.inline,
+emu-production.inline,
+emu-grammar.inline emu-production emu-rhs,
+emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs,
+emu-production[collapsed] emu-rhs {
+  display: inline;
+  padding-left: 0.5ex;
+  margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production,
+emu-production[collapsed] {
+  margin: 0;
+}
+
+emu-constraints {
+  font-size: 0.75em;
+  margin-right: 0.5ex;
+}
+
+emu-gann {
+  margin-right: 0.5ex;
+}
+
+emu-gann emu-t:last-child,
+emu-gann emu-gprose:last-child,
+emu-gann emu-nt:last-child {
+  margin-right: 0;
+}
+
+emu-geq {
+  margin-left: 0.5ex;
+  font-weight: bold;
+}
+
+emu-oneof {
+  font-weight: bold;
+  margin-left: 0.5ex;
+}
+
+emu-nt {
+  display: inline;
+  font-style: italic;
+  white-space: nowrap;
+  text-indent: 0;
+}
+
+emu-nt a,
+emu-nt a:visited {
+  color: var(--nt-link-foreground-color);
+}
+
+emu-rhs emu-nt {
+  margin-right: 0.5ex;
+}
+
+emu-t {
+  display: inline-block;
+  font-family:
+    'IBM Plex Mono',
+    monospace;
+  font-weight: bold;
+  white-space: nowrap;
+  text-indent: 0;
+}
+
+emu-production emu-t {
+  margin-right: 0.5ex;
+}
+
+emu-rhs {
+  display: block;
+  padding-left: 75px;
+  text-indent: -25px;
+}
+
+emu-production:not([collapsed]) emu-rhs {
+  border: 0.2ex dashed transparent;
+}
+
+emu-production:not([collapsed]) emu-rhs:hover {
+  border-color: var(--production-rhs-border-color);
+  background-color: var(--production-rhs-background-color);
+}
+
+emu-mods {
+  font-size: 0.85em;
+  vertical-align: sub;
+  font-style: normal;
+  font-weight: normal;
+}
+
+emu-params,
+emu-opt {
+  margin-right: 1ex;
+  font-family:
+    'IBM Plex Mono',
+    monospace;
+}
+
+emu-params,
+emu-constraints {
+  color: var(--params-foreground-color);
+}
+
+emu-opt {
+  color: var(--opt-foreground-color);
+}
+
+emu-gprose {
+  font-size: 0.9em;
+  font-family:
+    'IBM Plex Sans',
+    sans-serif;
+}
+
+emu-production emu-gprose {
+  margin-right: 1ex;
+}
+
+h1.shortname {
+  color: var(--title-foreground-color);
+  font-size: 1.5em;
+  margin: 0;
+}
+
+h1.version {
+  color: var(--title-foreground-color);
+  font-size: 1.5em;
+}
+
+h1.title {
+  color: var(--title-foreground-color);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
+}
+
+h1 .secnum {
+  text-decoration: none;
+  margin-right: 5px;
+}
+
+h1 span.title {
+  order: 2;
+}
+
+h1 {
+  font-size: 2.67em;
+  margin-bottom: 0;
+  line-height: 1em;
+}
+h2 {
+  font-size: 2em;
+}
+h3 {
+  font-size: 1.56em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1.11em;
+}
+h6 {
+  font-size: 1em;
+}
+
+pre code.hljs {
+  background: transparent;
+}
+
+emu-clause[id],
+emu-annex[id],
+emu-intro[id] {
+  scroll-margin-top: 2ex;
+}
+
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  font-size: 2em;
+}
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 1.56em;
+}
+emu-intro h3,
+emu-clause h3,
+emu-annex h3 {
+  font-size: 1.25em;
+}
+emu-intro h4,
+emu-clause h4,
+emu-annex h4 {
+  font-size: 1.11em;
+}
+emu-intro h5,
+emu-clause h5,
+emu-annex h5 {
+  font-size: 1em;
+}
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1 {
+  font-size: 1.56em;
+}
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro h3,
+emu-clause emu-clause h3,
+emu-annex emu-annex h3 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro h4,
+emu-clause emu-clause h4,
+emu-annex emu-annex h4 {
+  font-size: 1em;
+}
+emu-intro emu-intro h5,
+emu-clause emu-clause h5,
+emu-annex emu-annex h5 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1 {
+  font-size: 1.25em;
+}
+emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex h2 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex h3 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro h4,
+emu-clause emu-clause emu-clause h4,
+emu-annex emu-annex emu-annex h4 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1.11em;
+}
+emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro h3,
+emu-clause emu-clause emu-clause emu-clause h3,
+emu-annex emu-annex emu-annex emu-annex h3 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 1em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 0.9em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  font-size: 0.9em;
+}
+
+emu-clause,
+emu-intro,
+emu-annex {
+  display: block;
+}
+
+/* these values are twice the font-size for the <h1> titles for clauses */
+emu-intro,
+emu-clause,
+emu-annex {
+  margin-top: 4em;
+}
+emu-intro emu-intro,
+emu-clause emu-clause,
+emu-annex emu-annex {
+  margin-top: 3.12em;
+}
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex {
+  margin-top: 2.5em;
+}
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2.22em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 2em;
+}
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 1.8em;
+}
+
+#spec-container > emu-intro:first-of-type,
+#spec-container > emu-clause:first-of-type,
+#spec-container > emu-annex:first-of-type {
+  margin-top: 0;
+}
+
+/* Figures and tables */
+figure {
+  display: block;
+  overflow-x: auto;
+  margin: 1.5em 0;
+}
+figure object {
+  display: block;
+  margin: 0 auto;
+}
+figure table.real-table {
+  margin: 0 auto;
+}
+figure figcaption {
+  display: block;
+  color: var(--caption-foreground-color);
+  font-weight: bold;
+  text-align: center;
+}
+figure img {
+  background: var(--figure-background);
+}
+
+emu-table table {
+  margin: 0 auto;
+}
+
+emu-table table,
+table.real-table {
+  border-collapse: collapse;
+}
+
+emu-table td,
+emu-table th,
+table.real-table td,
+table.real-table th {
+  border: 1px solid var(--foreground-color);
+  padding: 0.4em;
+  vertical-align: baseline;
+}
+emu-table th,
+emu-table thead td,
+table.real-table th {
+  background-color: var(--table-header-background-color);
+}
+
+emu-table td {
+  background: var(--background-color);
+}
+
+td[colspan]:not([colspan="1"]), th[colspan]:not([colspan="1"]) {
+  text-align: center;
+}
+
+/* Note: the left content edges of table.lightweight-table >tbody >tr >td
+   and div.display line up. */
+table.lightweight-table {
+  border-collapse: collapse;
+  margin: 0 0 0 1.5em;
+}
+table.lightweight-table td,
+table.lightweight-table th {
+  border: none;
+  padding: 0 0.5em;
+  vertical-align: baseline;
+}
+
+/* for non-clause-like link targets, apply a fading highlight
+   and a persistent focus-associated highlight */
+@keyframes highlight-target-bg {
+  0% {
+    background-color: var(--highlight-background-color-start);
+  }
+  100% {
+    background-color: var(--highlight-background-color-end);
+  }
+}
+#spec-container :target:not(emu-annex, emu-clause, emu-intro, emu-note, body) {
+  animation: highlight-target-bg 2.5s ease-out;
+}
+#spec-container :target:focus-within:not(:has(:not(a))) {
+  animation: none;
+  background-color: var(--highlight-background-color);
+}
+
+/* diff styles */
+ins {
+  background-color: var(--ins-background-color);
+  text-decoration: none;
+  border-bottom: 1px solid var(--ins-border-color);
+}
+
+del {
+  background-color: var(--del-background-color);
+}
+
+ins.block,
+del.block,
+emu-production > ins,
+emu-production > del,
+emu-grammar > ins,
+emu-grammar > del {
+  display: block;
+}
+emu-rhs > ins,
+emu-rhs > del {
+  display: inline;
+}
+
+tr.ins > td > ins {
+  border-bottom: none;
+}
+
+tr.ins > td {
+  background-color: var(--ins-background-color);
+}
+
+tr.del > td {
+  background-color: var(--del-background-color);
+}
+
+/* Menu Styles */
+#menu-toggle {
+  font-size: 2em;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 1.5em;
+  height: 1.5em;
+  z-index: 3;
+  visibility: hidden;
+  color: var(--control-link-foreground-color);
+  background-color: var(--background-color);
+
+  line-height: 1.5em;
+  text-align: center;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+
+  cursor: pointer;
+}
+
+#menu {
+  display: flex;
+  flex-direction: column;
+  width: 33%;
+  height: 100vh;
+  max-width: 500px;
+  box-sizing: border-box;
+  background-color: var(--control-background-color);
+  overflow: hidden;
+  transition: opacity 0.1s linear;
+  padding: 0 5px;
+  position: fixed;
+  left: 0;
+  top: 0;
+  border-right: 2px solid var(--control-light-border-color);
+
+  z-index: 2;
+}
+
+.menu-spacer {
+  flex-basis: 33%;
+  max-width: 500px;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+#menu a {
+  color: var(--control-link-foreground-color);
+}
+
+#menu.active {
+  display: flex;
+  opacity: 1;
+  z-index: 2;
+}
+
+#menu-pins {
+  flex-grow: 1;
+  display: none;
+}
+
+#menu-pins.active {
+  display: block;
+}
+
+#menu-pins .unpin-all {
+  border: none;
+  background: var(--control-dark-background-color);
+  border-radius: 4px;
+  height: 18px;
+  font-size: 12px;
+  margin: 0 5px 0 10px;
+  font-family: 'IBM Plex Sans', sans-serif;
+}
+#menu-pins .unpin-all:hover {
+  background: var(--control-background-color);
+}
+
+#menu-pins-list {
+  margin: 0;
+  padding: 0;
+  counter-reset: pins-counter;
+}
+
+#menu-pins-list > li {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  margin: 3px 1px;
+  border-radius: 4px;
+}
+
+#menu-pins-list > li > a {
+  flex-grow: 1;
+  align-self: center;
+}
+
+#menu-pins-list > li::before,
+#menu-pins-list > li > .unpin {
+  flex-shrink: 0;
+  flex-grow: 0;
+  text-align: center;
+  padding: 1px 3px;
+  border-radius: 4px;
+  background: none;
+  border: none;
+}
+#menu-pins-list > li::before,
+#menu-pins-list > li > .unpin:hover {
+  background: var(--control-dark-background-color);
+}
+
+#menu-pins-list > li > .unpin,
+#menu-pins .unpin-all {
+  cursor: pointer;
+  color: var(--foreground-color);
+}
+#menu-pins-list > li > .unpin:hover,
+#menu-pins .unpin-all:hover {
+  color: var(--menu-unpin-hover-foreground-color);
+}
+
+#menu-pins-list > li::before {
+  content: counter(pins-counter);
+  counter-increment: pins-counter;
+  font-size: 16px;
+}
+
+#menu-toc > ol {
+  padding: 0;
+  flex-grow: 1;
+}
+
+#menu-toc > ol li {
+  padding: 0;
+}
+
+#menu-toc > ol,
+#menu-toc > ol ol {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+#menu-toc > ol ol {
+  padding-left: 0.75em;
+}
+
+#menu-toc li {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+#menu-toc .item-toggle {
+  display: inline-block;
+  transform: rotate(0deg);
+  transition: transform 0.1s ease;
+  background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMC42MDUiIGhlaWdodD0iMTUuNTU1Ij48cGF0aCBmaWxsPSIjODg5IiBkPSJtMi44MjggMTUuNTU1IDcuNzc3LTcuNzc5TDIuODI4IDAgMCAyLjgyOGw0Ljk0OSA0Ljk0OEwwIDEyLjcyN2wyLjgyOCAyLjgyOHoiLz48L3N2Zz4);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: auto 50%;
+  text-align: center;
+  width: 1em;
+
+  color: transparent;
+
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+
+  cursor: pointer;
+}
+
+#menu-toc .item-toggle-none {
+  display: inline-block;
+  width: 1em;
+}
+
+#menu-toc li.active > .item-toggle,
+#menu-toc li.revealed > .item-toggle {
+  transform: rotate(90deg);
+}
+
+#menu-toc li > ol {
+  display: none;
+}
+
+#menu-toc li.active > ol {
+  display: block;
+}
+
+#menu-toc li.revealed > a {
+  background-color: var(--control-dark-background-color);
+  font-weight: bold;
+}
+
+#menu-toc li.revealed-leaf > a {
+  color: var(--menu-revealed-link-foreground-color);
+}
+
+#menu-toc li.revealed > ol {
+  display: block;
+}
+
+#menu-toc li > a {
+  padding: 2px 5px;
+}
+
+#menu > * {
+  margin-bottom: 5px;
+}
+
+.menu-pane-header {
+  padding: 2px 8px;
+  background-color: var(--menu-header-background-color);
+  font-weight: bold;
+  letter-spacing: 1px;
+  flex-grow: 0;
+  flex-shrink: 0;
+  font-size: 80%;
+  user-select: none;
+}
+
+.menu-pane-header emu-opt,
+.menu-pane-header emu-t,
+.menu-pane-header emu-nt {
+  margin-right: 0px;
+  display: inline;
+  color: inherit;
+}
+
+.menu-pane-header emu-rhs {
+  display: inline;
+  padding-left: 0px;
+  text-indent: 0px;
+}
+
+.menu-pane-header emu-geq {
+  margin-left: 0px;
+}
+
+.menu-pane-header a {
+  color: var(--control-link-foreground-color);
+}
+
+a.menu-pane-header-production {
+  color: inherit;
+}
+
+.menu-pane-header-production {
+  text-transform: none;
+  letter-spacing: 1.5px;
+  padding-left: 0.5em;
+}
+
+#menu-toc {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  overflow: hidden;
+  flex-grow: 1;
+}
+
+#menu-toc ol.toc {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+#menu-search {
+  position: relative;
+  flex-grow: 0;
+  flex-shrink: 0;
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+
+  max-height: 300px;
+}
+
+#menu-trace-list {
+  display: none;
+}
+
+#menu-search-box {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  margin: 5px 0 0 0;
+  font-size: 1em;
+  padding: 2px;
+  color: var(--foreground-color);
+  background-color: var(--control-input-background-color);
+  border: 1px solid var(--control-input-border-color);
+}
+
+#menu-search-results {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+li.menu-search-result-clause::before {
+  content: 'clause';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: var(--control-dimmed-foreground-color);
+  font-size: 75%;
+}
+li.menu-search-result-op::before {
+  content: 'op';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: var(--control-dimmed-foreground-color);
+  font-size: 75%;
+}
+
+li.menu-search-result-prod::before {
+  content: 'prod';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: var(--control-dimmed-foreground-color);
+  font-size: 75%;
+}
+
+li.menu-search-result-term::before {
+  content: 'term';
+  width: 40px;
+  display: inline-block;
+  text-align: right;
+  padding-right: 1ex;
+  color: var(--control-dimmed-foreground-color);
+  font-size: 75%;
+}
+
+#menu-search-results ul {
+  padding: 0 5px;
+  margin: 0;
+}
+
+#menu-search-results li {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+#menu-trace-list {
+  counter-reset: item;
+  margin: 0 0 0 20px;
+  padding: 0;
+}
+#menu-trace-list li {
+  display: block;
+  white-space: nowrap;
+}
+
+#menu-trace-list li .secnum::after {
+  content: ' ';
+}
+#menu-trace-list li::before {
+  content: counter(item) ' ';
+  background-color: var(--menu-trace-list-background-color);
+  counter-increment: item;
+  color: var(--menu-trace-list-foreground-color);
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  display: inline-block;
+  text-align: center;
+  margin: 2px 4px 2px 0;
+}
+
+@media (max-width: 1000px) {
+  body {
+    margin: 0;
+    display: block;
+  }
+
+  #menu {
+    display: none;
+    padding-top: 3em;
+    width: 450px;
+  }
+
+  #menu.active {
+    position: fixed;
+    height: 100%;
+    left: 0;
+    top: 0;
+    right: 300px;
+  }
+
+  #menu-toggle {
+    visibility: visible;
+  }
+
+  #spec-container {
+    padding: 0 5px;
+  }
+
+  #references-pane-spacer {
+    display: none;
+  }
+}
+
+@media only screen and (max-width: 800px) {
+  #menu {
+    width: 100%;
+  }
+
+  h1 .secnum:empty {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+/* Toolbox */
+.toolbox-container {
+  position: absolute;
+  display: none;
+  padding-bottom: 7px;
+}
+
+.toolbox-container.active {
+  display: inline-block;
+}
+
+.toolbox {
+  position: relative;
+  background: var(--control-background-color);
+  border: 1px solid var(--control-border-color);
+  color: var(--control-foreground-color);
+  padding: 5px 7px;
+  border-radius: 3px;
+}
+
+.toolbox a {
+  text-decoration: none;
+  padding: 0 3px;
+  white-space: nowrap;
+}
+
+.toolbox a:hover {
+  text-decoration: underline;
+}
+
+.toolbox::after,
+.toolbox::before {
+  top: 100%;
+  left: 15px;
+  border: solid transparent;
+  content: ' ';
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.toolbox::after {
+  border-color: var(--toolbox-tail-background-outside-color);
+  border-top-color: var(--control-background-color);
+  border-width: 10px;
+  margin-left: -10px;
+}
+.toolbox::before {
+  border-color: var(--toolbox-tail-border-outside-color);
+  border-top-color: var(--control-border-color);
+  border-width: 12px;
+  margin-left: -12px;
+}
+
+#references-pane-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: none;
+  background-color: var(--control-background-color);
+  z-index: 1;
+}
+
+#references-pane-table-container {
+  overflow-x: hidden;
+  overflow-y: auto;
+  min-height: 35px;
+  max-height: 85vh;
+}
+
+#references-pane {
+  flex-grow: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+#references-pane > .menu-pane-header {
+  cursor: row-resize;
+}
+
+#references-pane-container.active {
+  display: flex;
+}
+
+#references-pane-close::after {
+  content: '\2716';
+  float: right;
+  cursor: pointer;
+}
+
+#references-pane table tbody {
+  vertical-align: baseline;
+}
+
+#references-pane table tr td:first-child {
+  text-align: right;
+  padding-right: 5px;
+}
+
+[normative-optional],
+[deprecated],
+[legacy] {
+  border-left: 5px solid var(--normative-optional-border-color);
+  padding: 0.5em;
+  background: var(--normative-optional-background-color);
+}
+
+.attributes-tag {
+  text-transform: uppercase;
+  color: var(--attributes-tag-foreground-color);
+}
+
+.attributes-tag a {
+  color: var(--attributes-tag-foreground-color);
+}
+
+/* Shortcuts help dialog */
+
+#shortcuts-help {
+  position: fixed;
+  left: 5%;
+  margin: 0 auto;
+  right: 5%;
+  z-index: 10;
+  top: 10%;
+  top: calc(5vw + 5vh);
+  padding: 30px 90px;
+  max-width: 500px;
+  outline: solid 10000px var(--control-dialog-fade-color);
+  border-radius: 5px;
+  border-width: 1px 1px 0 1px;
+  background-color: var(--control-background-color);
+  display: none;
+}
+
+#shortcuts-help.active {
+  display: block;
+}
+
+#shortcuts-help ul {
+  padding: 0;
+}
+
+#shortcuts-help li {
+  display: flex;
+  justify-content: space-between;
+}
+
+#shortcuts-help code {
+  padding: 3px 10px;
+  border-radius: 3px;
+  border-width: 1px 1px 0 1px;
+  border-color: var(--control-light-border-color);
+  background-color: var(--control-shortcut-background-color);
+  box-shadow: inset 0 -1px 0 var(--control-shortcut-shadow-color);
+}
+
+#ecma-logo {
+  background: var(--figure-background);
+  width: 500px;
+}
+</style><style>@media print {
+@font-face {
+  font-family: "Arial Plus";
+  src: local("Arial");
+}
+
+@font-face {
+  font-family: "Arial Plus";
+  unicode-range: U+30;
+  font-style: normal;
+  font-weight: 400;
+  src: local(IBM Plex Mono Regular), local(IBMPlexMono-Regular), url(data:font/woff2;base64,d09GMgABAAAAACicAA4AAAAAYawAAChEAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGmYbiV4chmYGYACEKhEQCoGMfO5EC4Q2AAE2AiQDiGgEIAWFXAeKABtFTxVjWxYz6A7A/uhUrctRCGwcgNqDlSjKBieW/f8xgcoYrpOnFRS8QIHjoHdmGozv5cqN5UngfebN9NyndmXJjllctNCG1rQfXYoKzSlz1ENtiyUsiSRjt3wd/fkdv1ipTRPsckOhVtMyaK6i+fu8TXz1jD9CY5/k+s/TaX/ue5MpNJ00KTSVUkipvessRGY/xAzRnDWQBAsmIWaEhJhAxDZmZBNCMClQqNAiLa1/qXy585pxd61TMbj27mivpSZ6VjH/U/e990r2h3OsedXubz+XVANAIkt+9pLXmXEmnvRAz61UNCGowiW2TDyPP/Y7930NBU1i7ScSI4mFaBYZjVLwRiXi6x4K66REYntD83qj9IMX55IB8f/4B3ru+21SwZLVJrxk4Dyc7t/rT5VavnveQoC2gyzp8vyDMGZrh81zkCHBgf4VWNdC6ueID8VgpFWm+ogRY5SGrjW+o0Qn+4kQQtDa/bSu3613oX01KIGhSzkcgNEepNWbGRROsIH5Bg//9057/7btY2aXmihrahsozuIxjxeHGGDY8QA1ov5/f7Paf0PeLIwzyqw4I+VanwlJ1qT2olx//Pd/+MID8hOSACEidgiHkQ+ZOYFkTT3xP8mae2VS7naiVbV1oUW1RVkp/+DvueqEv1HrowYKbG4QlKBEM9ubCUUIndnSvAWMAu4ItwG51Mcrvi9tvh9cinXFspATRKdy3XwZbkbV3yqPBj5gM/4GCGANaAUwNnypRcihR0q1IDPNRFZbjey0EzntNHLZPhFuOwXhC49ExJpswaMJAxHnskUQAAxAAEtZKvHFLycMHA5HtTYD5bhj7AgQCgkXQLsNh7RMM2CutcmIbAkYS+YD+VREbrcc5aF4kWr1MdBwY00203xLrbbRdnsddtJ5V2O+vuCaO/StL/zj74DaZE1ymIjRYydIlipDBZVWXWPt9cjQ4EY2vqkooQAoyQAoMQAoGgCUSABkKszudXqIsmomvycjRkH7E66kEo4Lsacxk9Bfzhafhg+xxv/2EXHxXfTB812MOV9iALHUkkEKOXPQ8+RWyUtAC/+DacH3sI8FIgYPeQWIuQQKBfT601rxYnbqVrNb2PLWrkhuA6MAogANkcQR5VAlTmyetDOIIbg4obHrkCSiC0GPZDYrIEN4d0gqLnQQTNDtoXR5lmob6PEMM7uXIwGsc7gw97Er6ytu7Iq586jlKaRFwOULYegIJ+LTycJLlr5EInG3nQQuY3SiJ5YNIE5MYciCAiiFamiEdugBBhgMI6XxYNhir1h8I5dsm663Uhe4VJKjvJmVRXATFJEYb191+NMyCihH/Ue2gMAfuBEEdCfDWlpBzHVfE5AEgPH8AElk3tEJIwNmJBhkeSRUINdPUmYNnEEEcO1mOgj7+9nuUm9QO/RaSYwIEtVgvAuY42yy5ZAK5l5syHg71vIdDr0fE1FmcMoApKJeR7Gd2B5YKvERj5wTwCN4cCHbhE+Fg8040yz2QPK42d8/tgQRGUwk2+593BJVSkLFJlLAoEilRp36GGy0yWZbbHWswMnwBowQPVmGAyNETZZhwQjIybJsMMrAnowJmIwxSc4CGOHzZFkmGGHyZFkGGL1IltolqIlQQRH0iwh9uaIotrSImHhkiYkjiqGRQhRJp8QBTZEiK+5wBkIsFDKN1UKxFLWK8SheSi0Z8XEjiiBykCFTFgys7Xsh8tDx4QEk/MjDyNTXZY+iKbOsMDPz9Ep27exCqW8hVQg7Wz2g2GjSjpRIX7HMSmWhYhzBNBF6+hEi+5AVzrvI9Afg3SdE/P8LIITU36BbAFiTnQYoENBq6yYCAJoQMuWeKciYAwhGhmQJsDGeiXD+nd31vT0W3Oftr0QrSUqOMlTZ6+XttcRbYzIRADYUKxJZ4c48M74+mKVWopRE4yJv+WtU62/37pdfdEf/9/8BwH8v8OHBVmsYPnDjBABA6tvigghAx1RAT39Tf7cccRTAXcdra8F9J512ZuAnzjkP4LmLLrn0lTG+dtf3qfsV5vPdUTtwAxVgqvp8BLypEhHR9yJT70+mPrL0vyyFSqMzmDmsXDYnj8vjC4QisUQqkyvyC5QqtUar0xuMkMlssdrsDqfL7fH6Cv1wIFgUKg6XlJaVV1RWqYbpaq3e7gnFY4lUMp3N5wrFcqlSrTcbrU570B+OMLgbxd06N40q/u19MNOHIUDPEQAAw1js7EmJGgD6jbtXT57hni92+/PlcOy6BONHrzeAUc8uYapBbtSZLVaT04WlgaB/tt7ywM3RxQGAcOYsSVDVZAEADQMAmwGoB6hvAKdfAOEM2A+wiQT2mFyyn7iIoQblhrKWxLlYpzoElFsRgFhSyclUENlyiybUQR0PsiqyXot1Til8xdf5vs1aB4oINm7t5O6BtSOrx7BSfgPaNq6K1OQkl+irNxg/i7Mi7ajIbvtXkLHqnQmMIw1+3QBL1YVzSoADnwH1eq6A6LZSow5eAcseM8+woQd8l6dJM4mMM1FZqdZoCz3ovewgrTpQNr4lKal40bvyEYs0Dt31YvUV2aQEsmfarBxgczOql0pTSinJB5+WZdtvO6wAr8SxvNYeBmserehRUUVnjXZiJyi7LOGnrRijjG/MPjOC7GRZkaQQZmvAVdgqgrUDYvmVcUDA0hd5jiKFSCVDcx0wbDBrkbUhA25nFYSZUx33BbwPLrf/K9WNNrSc0nhzj+vcx9xl0SEo92vkBiZ6Cp6h6P8TyY8f8DR7/DtxuqrOkpTyL0+6uyjS5dgFP1lRgBBsrUyp3xj1s6Xke6klwWeJmTOg8pjrPII0YDFsZAPPXesDBXkovlJFcu0t/tMprfz0oP5yB9uK3t0lGFr+hQVfKfFt6UwFr4S6JdhICHgHVJb+YRsQwBstTTdLmOLZAdaOYUpES6Q1ripPDPonHq4zPHo2EUj3SZHklPj5C5mrajmUSqFABjbo1ElfWvnyeXxmo4jPPEhfY+ljLL5Tun4WaZPTR0ib42QrTh4oFbYFRcx5Keb0CCX8Y4QFZVFp/D00to0gJPSNnxjFvbQ+fo7xujH7rBxwv69/Bw9BbP/aQyaWB2V/Bc/vkMTj4V5BD965wGdvKNRppSMNBbLrLKaq4Wd6tOrnR220SBufoOkKRCoONodzWaPyFYd6jhSqLU6VQJ08+SLudX85+lOtHmSm/NiN1iz2ttoAvcZ9HQEwsb9VZwzxVn0dZEd6mRhn5cHiwHe1l53I/w/jdQlD5WfL6p5ECJfvWTVqrGVB8UoHRPF41ZkeS4wNd/WQIfe5oj3e7F8X4LHNzaeg4XYep0TIhR+qOHZBKtDF3WLj8/keTmx9L9ndrbYBcntvyV52D+7fmWQB3m1esHRSyd52v1jMgFfQ9jVE5j15wP7IUBqMlUFJ4ywLiNoMdQL3VNS8S0Wrm2lkoaNnT87OGLFZgp5F41HRtCAsjEt2nm0UybjJcjHxfSaWOXMZu4h2zVhsA2AV87v3D44QDimGrcQSWsSh3vSFyY+f8AJg6VZBPWGPG+YhWyElTFkrqGvbWqCELmTbrPjKEvN6TXJLk2lOHHAWvMXlErsONyZMLVBAHBktmgVCAO+ha7GuqyjL2VUjs6h0qtrAA+rqvU6wh9I/h89OvyrlXujYQnNbw2XNnWxHmalLPSdAUIcS88HLNtz1x4qym+d7lGuT1mwraShPeFP7C0FceSrb83RAvLPRFJ7Qu4PHxsU+y9cObvBhq+B7y1CLxLz5hzzhDbkeQ8lMdje5J2yD7iH7st3ETrjaVDq8JR+UWfcIhBmTUz29Yl/ej+YZMjK61GIFT8LTJNNw0gd5EO9pmIxVe2q8m6kiMxdyUvCDwszc0tS0BOols+BFr9O9rXLJhM3zAQsToEpNqZFcBrJrlkpxBb9FP+9vrxRuVnxcnhGRCKsVqrmQwteVQ6kjRvUkmFLHTo+EiJiFyHKghqwDVFKabrMNOnXNgCbecpXtFb4/JE6rEvq/HP2DA+6fNzA56aUmZ7enBrMpT3zYWdi9lIG2/okNTzkxvTkhQffcxC20pMiV9UZABdaJPKRzTJioDbrF4a6NbU0G/EDATIN7hl9KhtDqQ19B0+sAZZx5qaNMOJ4wnM2ifXPWc0HTxGW3yq+z0DuomidScBuw7QxmjFT51mSQTzdiGen3cs8E3Y1C3dMW0z7gzKAUqdK3I98zAOoy8OKwxG6W8NnO0O8sPlP/PglqpEPaBX0K3oq4XkOB28BPuvi5dL/mzozUjkvZMg6yjjiU01Pg3cFdlKnrwffmbW/tiqfZb4CNfp3tKitQ+ZamInCD7j6U3JYKXlXE5qctmE6G9Czy6VWdv0KB3HPmJ8oTL4r3OldtiwjfuKByW71iU7MTFseIG1w4rNg9f/Qfd2VmiVnn8y799qexha+42s6PvTi7sszGt027JYRflEz5kqvZyr49eTI9YMysWxPHc+NKIqK2dFYryExxKlHKgkSlKIlqzTbwZm/LMGJxRW37rHloTAU78G0gWeCGTXXDRu8tSk5+RoL0siiCosOPiwozJvHoddL+AA9F+rw+4n/l8FaRAWKw1w1qOhW3hC/tTL66Ng7ItpNqTKvDEp/LR3eYURFLj/zJ2QYRbFR0jkUOlWOl8SO9zrRKOjbZfRkLAjEep9x2JWlOL+qLqo4H29i23iY7vwv+Jga+LQd0uk1S/qRZtReqknS8a/iRgcqUcw/2gmMMgraE1LIyuPOYs3wuRHlpZW3K/SMnN72uKa0/QWgoI1V2VjOviVan/IMrCqR73W/DCLVUi1tkJ1Jkf+JbDdoJiewu4mDisSBjsT5Rx42p9cWkSiQVCVlYbX71+bTIOdUvMU8sTMtNq7it9q/kTDl97V6VsCudWQIqjw0miLpZmhS/Ey9++wMori2Llak1JzPSdxwMdM+3DSRS9bFsjoKyc3P2Wd1oHy8FhyEGybk9N2RSYaPgxmKzRK9LreZyF4lqwF1Oq59pI2pU+cEFHigJvdfTrohjuulJZRT2gE68zEWbLB0iy7CE+8bEIRu5z89rrxcdaof/7PxHpQfYoN26xUma0e6qbCEB8IcSk+iYPUftTfjHShB4nitY3FMGyxWMOr7vWvynxzYipzpGiThqNbcUcSM6t4e5qdIL0fR2mMFpOxcg5VjkL4OsJmuQUhZ605vftJyomiZZ60Rfp0LCz5j5+Dz/gZQMW3JBVhcyscE+bkhLVs3YYO7RkM92FS3XQuuwGRSPp4UkUuGS+cjAV48KjUAhtquICJ4KGYr6t+WI2hfipViavnvNQCN8gFrGiyrZQn6DjetGkUyUIpOs1Xcav5ZCSSJH4c1/4mFhXHPiHZT2m4Ho8jBAAWWmRLjaQ8kjZngxu0tcGhVaStDFpzrx2WQPVSE2Ukzuysa0s4M6sVU4WHveK32xtRGlaJjoOhorC5Ne1faWrl+RchbppIo8Xy9GLUMa+y+fHZ1ibrOPbCyDbS+anwwxD0qzlVUVpcFIKhlv2mtkW6zRSpyi5avNtd+l+7qvoYewAi4cf4lWwbtGdVUloCTFFOoTqU1Wn/zqUY0p3ycXT27lbZKlLepk/4syUwRtXidV3bW9prsUQle73mC1sNDl9hVrF/B0HA8vv+Su/PT+fO6MHngOAFOyh10oRSxXC1t7nhyPib+qXPHDCoB7hEMdDR2NoUmvcyOwqdiI3PHVAN9f/J/hm8wZ0w1fMy7axvfbRCGKYX+6gcy4QmSLQTio8gghVI3CRP+OSA00V5ZH1WvqIWStovBZL8RJ//epj4m2ikQLNTfWRddrxncKZxoSnu14XzBRNmRCv3+QogdragyFoQo7ajiH6qX0QYFIMEgfBHWSrMs51vVVg32wBP3cyxBcQuvMBGS2iYXddQ4UbqM7uMzj8ZlZDEr10gPVesoJRQ7XzIlJngh+zikeYS1G1SNqSD1GR05xx4LucV9XBOtRZwManpmjp/E3nr7GsHKSZBYtQJ3IcGaAYzIbuVsxxlG63LfZGSyop7TrgjqPZ5yVb/Ytc5Tt4zM3mBNiG2XLfCtcWGev8C3/Rnoamyyzu9Ye1KfrD2ov2S9F6yzoV33OnrAeoNSnD0GHTjtXHwgAM6e2phvBIhRMhQEnpnEaFM/O2D/NyhqAg9aVCJQluBnBAK57wknWWTFcgeCW7Q2ntbI3O1JgaaskJeDYzJ7kBySt0hojNPcebX16Zvp62ulPHgjYDomj+3qRuzdMH73bBrLPBB+d5uorZfFaPaTXQTqUHbeMXebEiSVeQh3elsfKNH09l7tvbRdI+NZm1YmjFWZ5vgISFL38M8Q3pHG4rswlZD2barLgdiIPhBfNzeFS7fdCBBnPnFY1+7+X76cbCBS726iN0TiNLr8VjJ8dsnMfjH/WYGqYXXo8YQ8S/DNKkRYX/d1bBc+J7yC5xWISfK2IosiD0vTj/nv5Phj6RLY6XaYYk8tlE1U1mGMxkyeAPLS8iK6CyDUaN2+WdVRxcF3zrJDLCHMrn+nn+BR6noPQQfQIxRT4WJAiNVvdLkuMxTqsy7sFbEweLZrmOHLGjh4JOGh1CfEA0caxuvyvYgbrYJW3rbypiV1eVbr2rTGvXH4rh2g7HyaqzHa/XpWpKtQ7HIU9XPduC0DmfFmizJpvMFi7GBcEsvrdvFm2UaEUGRZ5e3AShhHdIjEZvvbjU78XT9elLBCO8W58668+FBPaBoB6DHQNujpEOQCuduITq/s6AS8uLA0gqgxQosIgL1BZ9GfsuG8KhtuzBQIn1kswcfgUsw8iMupoN4Xq6XpgZJezXqSpxy5sGEtcoqwIsZQqmCHVY8KSsZZ81MIreWpL/ciRlmHqTPSYN04UJmCu8hY7Z82fWpBUy7bb2aou9wB9NXMhczWdvcaoNq4BtwsO/htMRef7Rz7csZWxVd7joKj/ebiuqlCrsnxG7HM4bWycjQERWejX1gK9WJYr1UsKln36Wi/9TZAj+F36zQNgQE+Z0N/Xxzd/isCUjcs8aiF3dyYOkv3eiY2tjd6JfvJg4shuC/lYBu4sEJT3758ysW/jRnQzZf9vVhge09TcVDxz4eEsEB7YZAs/ddvc/4RtIDyw21b71Gwzq8GvpajpbU4hvXXErg3bx/VPFlqyOZnrLeTuhsTTJNg9sbFZmhT0rOJADp/e+r3xdrEbbFMlq+EBWJIsKdYAYOMmySbj5ocf3OxH5REsVQ4s1zusMMnuSYaQR5YT8jU608aPNhAfqGm7BQ/AzYiSMcff1P3D+LCkGnQOwKMdNnCw7HrM4vomMOZ6uWugebw4qui3YcAFVjminc6BjuenRW/vk74pSTYlB0q+sWZsF2+wCgThgc9VdY0VFfwlrVrHGr1G+pNQIvxJugY86W1TyvQShtkpE4azJrnZ7pBLqwYaE4rm/7YkYxM8HDpQVOeP3sItX5s7crWZ+csE5KLLO6C6wWlhodbpMWnFCyxoVzwLon2Hp1ROrBoOt8qpqw74+HqLQ6niz7HF2+NZJtpKArVqUgsIjBoNj35sY9pAb3+vGOVZ0CIUtixAecS98NfuxDE8V5BpsQSZPFfSdn8N/j6xU1xdao9G2aOrS4OFJgjL+h34rxPPxDRtKC/ZENNgCLZ1/jh4RUy4O4G2onBOyXxk+fyiOaV3ay4EKrzdwbnIwFx/d+lFGESmvtpRWbMDXoYMLhuFcn0XUgHrbfEcxnjbBcf/GUvBrdnTMJqzUU80YAcgZ7a/cZY/Iu4JIIPpxumu8NMSKNfYb9nBwEMrFV4rBy/5k42oeLtI66vw26wNrrYR4vy3yRI9S1T0fQb+VUBJU0kh3mqmy0i8kCE9MMKqz2FmsGaB8rteCVJY0VLR1DNlCuMZu16QsPdsgdkJm0MHF+4TfjaxA1hzwSeo0YogU2ki1qjVpBqlOcCQO8r08OuLRo6AVl+cSw1Rc4vb6RIjP7+7ptII1viZno7Ee887vSAyh2sCTycgQStCDI2ZUq3WUGvU5iBDKoEZSgOpRM6chKEWz/6FLnHw81fXNBl8lykdsxuo0Sw01WI1gULjpgm7od1NEpleuRE6ueQkW+UzficQFLin2qdNbNZr2HvHx4dHY1mWcch/JD55Dk7vtmVzC7bHEndRK8xjabsI+twcvF5jz+YmjN6yZUH52QTHG4zW2mK73UBK12yTCKlerdvsYu8pVM3kEXjdKlX76O0AVeV2+1tbc78oRVX15Q6v2qKGVJir8kB2vRc42mh7MpMz99C61wopHJgwAMX9sQnaDeqmv4cQkD+Y3iNeSqVpQj3qoOGu9yyyAV6/tPr84Rf5NYfQ9d5fvcBj3F66HUKu2A7tBjKkXYXc28/h7jEizqh5WnZRYb292LCKTu5kd10m0sizTg6oRnrhtGkADloWZKjMpGqNmlQz4WSXWVeuUWtI1QFSyOjzwHY4OoyXEwXlCC/cmEeF956N5JNIzT4R9h6zGPmMcRrnT5gPPZyG+hiCTFZvlQn26G8egvqAEO0bK+spNxflalRONi/9yfK3qV5073MNjZ3zqN2RyjXXc8yCOb9UK6lqXS7rSh8Tadh2vdLV7gcm+NGwb4CmYCHsTNfOp9DTCXyQ4Gd/iWjC2Hov0gve7Ub4bBc9j5DeOuKsO0BAWAr2xhbtDRV5PD+TTG5Eg68vxt/XANS/owY+Vbqa1QGkMuBsLt3zcfBXe7CzwIdU+Pyd4Ayi/ItkmvfcIoIT6szvOfmuMHjRuR+p3w8CLmerAVqI51IRBDSz2ctoWtzqL8qMOJbMNFEht8YNmajM5GOI2YrPO3Fa2jL2Zs3vrtyuf1DvyexeJpLZyybfQP3alev6XQNiZk8zTwOYNxGs/5rPG+rLjqv57Z9M++C3bWmEliTn8eQSU42Smb95m/xiAIb9xPGMJgsMvjTXOBQZhzrKURj3l2Pm6May+NqeUaPqekrjGzXDdEifTvv6clztNz9tRHV7Anojctg6i1JeGJ4TlhcqgaPxG7qRn5CDqzK5V6Yb2TySayhIlHkbNJHPdtvz8g1OvSs3Vd932LSTlka603n8EmqiF3DaJd9DbftsE8saG8u0sC/t+fcSRwOxQabTGfpMneyiAexQ/0C/qWewrWxXGzIIJVB6TI62+0DMN8PMw0zY+B0RPIj0PWyzZXB5oWzuwzEXmPmfg5jN3NeVmTavWJBvg1HD6EaW/2Dsq5zvT91CiPdktH4/4EQjaWF6YvpC0ih6sUUDcFK0zVxvgDfO5eSNn3CStVYMl9O1ZXvdPRAHGRoDrVisEkc84yym2PZykFfZvJW+Ql+FVXAUoV+Nw+esys1nf5dLVF8iRuq4YEMt5VcM8pc6vmwGV+YWWm14t4v27Jdvm2el/YrXWfXqdUxF3w/sXVlxQjVrKzEX/OkanAkdQ4FTzDTgSDhDTg4LpEVkCkMSHishCW8rRIgUeojpRI8wkjB5CAGrP4B/gc1xch1cpomgwmKiMVi6HCz/AwNhAGck/fLzZXT6sueX6YOmWl4Ll9vCO64RoOYPHYIODTmVtPkY9DWxw5qcP7VhKNE1CptIplE6/D5PzA2iRq8S5El0yyvtx0E2henMQmaziYSOcytj9ovyrUIu/fJ/CA2OJXQWGOQXc2+f76IxRxKi5C6uGIiscnitlQqqho551XM7MEdzoFZ/tWHk9OrYE0THNmSUfwlI+JfvpVylFgqFLFxd3g3+E481KZxkBZwngv8wyk/kPtkYmnMqM+2r5MQfftyWWilK8lIZ6YQqcgbp7jjQZxW1xDbK/j9RB2mrRYBT6vRXBGC4wuFQejgQapdwL3CUnAvc6YEB9iCa7oKHcu8ZHsqC69CC8EWFj/e7TWteLzEteb/G9JY4sX5k9yhgmEBoT+8oytKAPTUlgzEys39m441NicN2rCTG9QDny+YECOrxlQAOumQkz7NNWbcUM9mH8LLCk+08fuznCp8a7nyzgmGh4Tv3ohDl4926A+EB+Nt1VXVNpaU8bNW6xffWSXsFEkGvdB2oH6Ej/w4227R+cZFnw636qLEVFRK6xyitxKkMkCEc1FqyjaWK+mSo727iRTAXnW9z2N1hd5FWavyJyVx/RjfmZ1cEkXsRxQt01By3p71NFpltERTz0140JHkXtW+oYZDENqUJccUgS8AIJmzPgCXyIV5S7qeIXp4QslL/oFqFEFAl4ZyzrbrEYI/4pipbJhhLEmp7RpKlFwU4sj+oelHgyivDjtLP7Zo9XFFEUxlJ5UolqVxhdNH4ao+8Q9hjqJhfbSot0cZauPCkOKu2TNe5y+hzuM1un8N4uUCgToSuQc+vfHPvkTr9cT5wH/K3ZodlOr55niX7oMY56ELMvK2bfvKvxemJbj0h6rXf3m34cJFN/u4ajRSnHmVKV9/GjZw1JYknA95AgrRAoK25wbGbAOjjs/LMwabgz8G6BHT9R7XyoLw8foZZqaUitp7TgMiB/awfmebUao06tYZp/pGVp+MREX5jLtthb2+TvXW2CkK81N+sN72L6ueKUSDtb/NU3J4W8J6pjtozDJR9HPHVibFa2DQ1BBwtZsWLbOS9WIFZhozCPcNmYp/hTu8LjK3B+t5MiEtIWfos+skp2vqDAf6PLcwvjlbfN0+8kD+sHWxQ5YoyjoyPgLaH7EB61yhJnwrS7v5z4X+9hHL6jcPz8HnDjafGoAlB25NJwH2k29VllnrgSZdcbQ+zgQ758Y3e7FnfLzFecHBUX57l2B/41P9r6wsNPFbrXknvP4F3CoHCqpQjp/7e/ck70USaqXGbbPWUxXnvmR6WPjTdm3EWYiXfThw500T69NWqW/U4yLvFCz6ekqXXzUCEQE2WYDIoRLoXG20kKJwM3v/3KhD8loyqfA49dy7yt9lZfHXiEZTu8yDcGpkWMkiLBWqaPB+o83h1Xvaeb/F17NmlUXu7R9cTDTi1Jk3YX8iiadIX+kMhIeM2R825zRismV6esjcuNm5vyq812LOk/EEor2u4HCL4Ra+w9adRxWE+Km0dFvtsoWnlPmn+LBbb43QWbBf9B3qtZNGHW5tcMiEuKzpLRqGJaOSHKdHpF7H8Wd9mV+TJPgdSuv9E/rqLxoWkwLyuV9lztvAmX8DXqUetQ4xeC3JrReOuDB5IcCdRcAisGp+1pdMSv+eUeEXMWNTP78i88yKxUQ/yalVGi4o+UtJfVvRvTtHikLf3axp3tUAM6fsIGhwapyF07jbQOGOqTj72X9lEjA5wajU6GZva8QZ5Ukpgns7PP80kSHcj33RQ2Ueh6iHCo4zojEeE7prx80nYrNgsLOn0wIWmJy7n1jicytj3JPLnxPZNDqpsExEmOT/lUBa0yUelDCohdm1C7SoXBxeMHoqqXmuiXEqBlOjVlnwQXTPsHN852FHB1sHFHLM/HwNhWMtHBzPLn6jkDnb83+m4NUP0F4XKQW/77t/DATLurlaxyXx8QJRxNZAeYrC/Ne8bvjYleXdvAgn96Myjv61LH7YyC8hKWll1Xdpbr5CnEHdPagPL9aE+hdQR1kmji3ruJMP1O4zVmAFyG0iNpnGjjiVU3u+T8WntC6o/yt/05E/LTUj9fu15pa4D/b4dIWdtb7XtLOEAq0x+2t5qJPLKZLa3OkirNvjKORXGAtGpTLa32nZIKCzb3mqkU9XsCLoDYOMruN1DPuwmDmEtM0a63UM0sa/MSHa7h2jClz+MoLDMCNzuIR+miVCZ8bPbPUQTpWXtYFBuOth8xs/nDWpHh9FoaGL5o89+rZydlNKd051Tzq+qYCV/yxh9dY3+auigosDNAx69iflsQiSexXc2WH5u+cXcT9F7Cy/Do/MPQB8tP7f80vLruZ/CpxbJDQFE9WcAVMy+P6YNn3RjOD2fNYDXHwH786A9+9Sd+kfDZ4O7dUiTZ4MiCSWzexZHpHM1ypaQ1DQVYGs7bWCZg/Ei0oHNnh1Aq9E0NMl4SnizuvwY2oGfQLXQPApHaAe+Am3VyAaUc2efLKH+OiUcodWpZJykHMzDAO3AWMkeYCuQdSD+B41x+4Qu0XMwMhkPRHPQGLdPDc9pAjYGNTB4YDDVbvrXFLVQp/gwkRa0TGlavys1jdt/GCtJa8JoBFjOdheukC7N9BQw+OY3rJtd5eUdtnHmlUu37/pYUZ4qzIP+2KdGTKOn1te2CzDLkozt2i7fff0bnV60CfZKesF9X+OZ8z8CMFdPrxk5FUkpf96KfwkA7+b4Fwjw4e/KtItvwEKPaADmGAAgeD/n/uhwsaJfpH6j4S3ljOnU8rH9JFHklfM6ceMe9iYcGsdazBemIKW/CIDKls5NPuyOTCCNyUVIQswq5rAuLzh7SmfQJIo5bHDLnoyOBiuFoNucKnhUfs3gLjBjNqNakzKNvGRztYRqcclRSodITXoNSO8RsRqzZLMH25xlzuZb5pnDnoa0WdFU10rzfVEdV9N5i5obrzm1JbwLSTrzKDyCZfJuUwjhj7ylkPpvDBAHHhlHTQzfVMvThP2plEhVJCUMmVVbvzhvjpOPqWBaCE81GKavvd3Y3eAKo7sq6w+HhfrGErvdSLblkWpBaZNLIdp2Suyzw9YO42is7Vp7OJ3JLbBLsrw8YOrGbhL+kAST48ym4kjN+aASRAANCxD1Jl4GydzOkxyc5A9TOjQTG9vNjJmrZs4tUWaBJh6zilXGmUXqbKm05ZIPoczTtADQCDATF3PMjK2jZi7BMbMgODSzijZ1ZpF/Zt+XtmJygNEAA40yWG899TKUQkRASI7MJksJhSEOJlGnPHqGvqPClodYYvcJuovD7fG60QG+iFh/fexb9vHa3Trqf6207jrG/G3JToTT0Mugu5G2wmWA/izhfHeg3FDXSS4ZMGIkQKXuehrGoMNg+F5G8wNE4RFTqtj6vJotGzNMXBjVi07WZ9tsGGyachfZ7kjFVBaijqSTTHLtWvEN0VtClRQFiUYeK1G6aOQixo5sAUxzDpSEjy93bRl5YFbWhekz0G0/sedVS488ekiwj/8Js74hvZuT3iopy3OCa+KzBNNQKeq856FcBu5rrpg5i7d/vEc2bNmRpEiV5i9CzKa/qnDwCIhIyCioaOgYmHKw5GLjyMPFwycgJCImISUjp5CvgJKKmoaWTqYs2XLkypOvQKEixfRKlCpTrkKlKtVq1KpTr0GjJs1atGrTriMcW0w1zTnLfanbfHOss8vWCJjttemW+Nkv5llhpitueG293X7zq99tts8tQzbp1GWhbu6oc9MRJx1z3AmP1XvilNP69PSjRZ4757wG33hutj5666sfg/42GmCQgQYbYpihhhvha51GG2WMccY6aZMJxptokm+9MOCFzQ59pBijq5dbnGnZjutVU9fSttDQtKSWD/1GxgYpSWlukrRepuKf4+UgGxYOHgERCRkFFQ0dA1MOllxsHHm4ePgEhETEJKRk5BTyFVBSUdPQ0m31rbE1t9bW3jpb9zzVGerslhmnI501lRiGzhToIQ+EEUUMqXhNJrNEMvPE217JDp/4SfJ+rGHSUVy05Ocq4JVjAPUIlScouOn1xmtyPMQzT/GlqaNexrg48i2hN5KTrh7g+L47mzlThmwl/u64Ekm+jiu562xhnD7rCYgF6bEg4EAqBKRIQMCCFHmQCgEBASlyywqcGMQQRwJJpJCGdISQgUxkIfuE+FmbRb8So84LpjGy1L8daHz0otU/ZdXoNmZlGP3EHRuHQL7JuCqpEkS/v+Fu6i8JJ7Z0TT6QFOnjECC16F/g6rMkBhxi/KPBBUm2BdkTAA==) format('woff2');
+}
+
+@font-face {
+  font-family: "Arial Plus";
+  unicode-range: U+221e;
+  font-style: normal;
+  font-weight: 400;
+  src: local("DejaVu Math TeX Gyre");
+}
+
+@font-face {
+  font-family: "Arial Plus";
+  unicode-range: U+30;
+  font-style: normal;
+  font-weight: 700;
+  src: local(IBM Plex Mono Bold), local(IBMPlexMono-Bold), url(data:font/woff2;base64,d09GMgABAAAAACk0AA4AAAAAYUQAACjZAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGm4biV4chmYGYACEKhEQCoGMMO5JC4Q2AAE2AiQDiGgEIAWFOAeKABsuTyXsmAmgO4BfK0VpFc5GWLBxAFIDf+rIQE0ejJqB//+WoIWMPTgPtrQaXBpLY3ZbQ4icFj57SjMxaVx5uMZwuSx4WLBZW+GtxHTJe0IU/WozGxeKRKlEsybXz+AYblMG9Mf/RGsPljvFb252hMY+qbuED9qP9Wb2I6ZRGySXRHJJJDyTo9mph3bxbn+AbfYPQQSjwAKkBSSiDQRHCEb15iJ1GUyXLiJ1UZfru1v9m5v/brvM9e38nPYzjkMz9isogEuMD9K42zT1SpZ+tKdP1FyT6yIDz9Pv1859K223KVTyTwxpE0NonvDIECpNtBIqPt1DISWr1Ef9x+3mYT8AiTjZAgIfWnOTZpWSiIwuHk1KISS2hMa5vcvc7w48JOzx9jZ6MNEJnw2oQM+SA9DrcaXFA+k3dfOBPKIummtAptsaXAvewQyCoOTbHgon2MB8+5xPq6vrJ4QTav7nKm3+/skB55DnSBWEWbjdEmgWsu7P/8nkJz9Z4My8OZo94CzwHCSz87BE6GYPoYyHrLarticr61hoEqZKVgkWpkKKqsL//06ue5IstIsPMeDpxCb0zwaSj6I8eSEsSVgPK1Cyn0LB0k0jalETTn0PloxMYjQJwiFBOXSKWV26cusbgyGTdP4S1b+H06jdGhjQok77hzJURrPJ7U3AK5Dm9qOJANmARfVCRGEyQLBzQZigDMJCCyFssAHCXnshjBqFcNVVCNfdhfSd7yESiYgGZBKUDDIpSgEBBTBA6bvLZOWDXBp2+QG/N6W7FagHVb3twIcCB6SGlVV1sQgwtsuHQIuGghab3wp5DiLXNQgid4kkUatZp0mm67fQckEbbLXbQcedddEHPZn+wJivfef96m+vA4guIhIRr2SRxRRXYimll1XZmiC/ilWperWqW5M1U3NBhA/koCgisdzeEODaSEMczIhtkIjk60MdzwwxF8nTgUoogHQohelQCF2x5bYihWUYAdPiNvVKRvKvoQswPirDYJIB2hnEsnNI4eRCMYEPTUAZlncZIt+NghhCucteIDVw9CmAeP5NJxJJPrt1tFgrNahNoa1HGZugGiZCEVRBQXI+tACDD2HPvgYDiqEkY/gC0yiohYIk1hUtkQYoKIR8qGR0wAwogdzU+ZGiLaLVulUHuiADtLqPKwCQGwSZo0CU/VJIcjilcstHUagM+3gDBVAIRVDMJEeaxUmFQLruDjjmQLSBFQXQATpBvzLKYBrMgFmwDDbBPjgAh8/+cwjgdkjzhRzhzlpoHeS01maGf+wqguIns4NJNj10b62tE6j77R1twLnDG3VAeDixrRvkl4UTQQtcRxwTRV2GhGj5lQNpYiWj4pPTs0MARC+zdDM0IKi00FG+9lSuoBTm+UrQOAQdNCCG4CDQDQwk946Gz/QQtxLlwvVEshuy+u0WKfEGkvMBG4rLokJmsyFIK9eLQA5ZAAPlTgeLaoeO8jrhwiLsUQbJtXHrpkKkG7R4Jz0NSVKVEouOS0rLKodPsWrNuk3Vb7HVNiQCkOKR8mAchHWLRwTjAN0tHgGMA1S3eClgnAGvW3KgW7KZLAlgnP0HlggwzmaBJQCMe1DC65iMHoQ1HqG/1+bf40vDpSUiYxFSBtNWHqOHWOBD9Nlt4WerIR8FQUryyIVaoGNt8lg9tK+OUMmGHi7pCMc+s1h4CRIlSUbgeR8K8SEvCSD5V4bF++Ku+j4JSlSSkqXGu+TO8ZpRpdDnCQU+dyHARD6BNqmNIh0bEsETQkOQsPWeDWz5aHb+zMYWc6mIrUDjAIX47w8gCQK3DIgbANwOGQWohwRp7WoIAJpTGCJ0QQXjpwl1bD5KIMdM760S5fm8P/JYwCIZ9SyqjKql2qm91IM0Om0NPeH9eyAvUG0VfD4nfBlgJI4qpWqEVfT4b1Cs/8Rn8WpcFbv+h/8XAPj3BL7d3Xnj1v8rxusAkOgiKpEBbV7ZKBfgEnDluhuAW7f2V753x2c+p6W/uOc+4I2HHvH191T/g2eAX76huX+Auo0QUAG2RPMJhHYoGkHYb5Xu3y/df9L0vyyNzmCmsdicdC6PLxCKxBKpTK5QqtQarU5vMJrMFqvNnpGZle3IcbpyJ7g94L2+PH8gv6CwqLiktKy8orIKjh9RnFcs3wuiME7zrCjrqmn7cZiW+djPC3TX1jX9b/K2zpavJzXDaRT0gIY+AACt0+FWh6F2ANA248vq/nny/8Fiid5XQHMFxr/6/bMATLn/yDL3DSExmmEpUQLBuKl/Hw/uwSdTbQIAQcIIFyu0vtcCQDMAeB5QAxQdAZR/WyC5BvwFjBX1LHKEZ2j/t411ZF4PSVWkDjKZi6EjOUHAh4wtAoRIOcmaHEKzAMHaHtInhpdmcREblhEjqSRzTgQRFLiNwXVEXopQ8FpihGxIIymPsoVs2i3zST3WkZNkRE6wGQvOt22r7dk6q0RPjBP1CLTtiHCcwdGoI9JjOmIq2+l0i6MIR8VE/aawPbKfiA8QIqKxZ2KsKCbdK2ol6h8nh0Y4TkJE2tZi0UJfZKbhsRy1tzvqUmITEvbjtOibFbl4co4bTRDEgkcdnEuItMjuXiMTGWptb6VZ9qxcRORjI/uJhG3PSQiRSPXvx5FEyo3ZCcex+4yyC+2iLzuiKFrt2U6CqI36T3LiM4cJW4gcUVqo5pEibtvRxI6+qh3lpETSJhrdeLaHx9paWuysYFc4QnBhBNv9MyLeHSfD5GwxcSnE6ELcjyIWj3O0JdLjhh1fI4OUjSqqXmMqENMYOT0+d1KNJQNtIVLf0RxDwck45DvCeTfI8AyOltX9NRhCAD5+nQSOrt7KZLxqdkx1Cig1r9K5jMjG6CaDqtNUEkIFKZHki1f9oqqqfg65a8+T8sHNg3f3UmS0egGzZuTUueHqnPekho3CAO0EBeXQdBDoppHX5bTVWHghtrz6O3rP5JugNwT2nk63UU7QKxrT6E6DgarDmMG3kGP0OKpCBqPkKNogIXPQOIHhEhl0odpYzmqWFbOAzNXf/Ec3iE0EANCR08CVPgSDvYgyi0MktWGbocVB80Wcm5aZF3Tq/YcR7dNQVpgm3UFzJjAGGKWJ2hvwrQx79+Ug6EiiAdVHRe8fjzAUZKt6X7nRRQcDthgIejhEvzuS9zB3Xlh361XImQh161pItKSOE/rWrTbQoOF4ga85/ZKTk73J1BrqfHDn54+A0IVOVc9KfJ3N+tIR3zJ4pezujDLGFSceR/t5IsCPygNTO8mbL2natR99ju6uuLZBH7qhCp4p3bw042MPVqHb4I/B5MZnjrU+XMkk8O6iqrsqDmrlEdJekyZxsZUiY52//5zaf3gq/egbRzeJV8cdM9vdVyBVeNNPVOLKtOctgu8AH52mg9MNXrOWgSrxD7FVlYoymjx9+x0dlVsDVRx8/GrIRzbeE2CLwy44kMpln+XTKMX/blX0BDMhWxQQK2H4Q2yT3w1GF8jKrllP0sda2uxrMC2segMJ8i/GGC51EIfZdiEwVCqTMiQoNswzCjsa6PDoB7LcwZ9DhhAPRNstRAVZ98Yk8EuWn55gWQeVyYzhhAXmHjRlphUu2YaM2RKfX8Gisvj5ZmOtvdiaTWHCFqhYvZlztxjjwhE82KoW7YaEwC7uUGw87nyj3k2O1VOZSi2kNUlJXpmVMkgR4w/esNshcNCFza6KukA2Q/Uv/rMWcZDDhH6ZStrjDoUuVIySbmPahw6ChaVGl5kdD9OMASZ10LNUFkMNS7RKLK7L+rZF54whILP2yU6Jqq5bNh4DxY1Yl9lIxQKfzvaVm/mlW+ey3pJ3H+lBfCev/bzeQbh39ANqudGMw/rSLBfGghtAkHKWx9nSO0Ob1+dnzqbi9epv5m1QVjzfXqSDeksH8Haj5SFbwyBw7BinCd9d8g9OPmmhsQqMsmcJhKsV/UWcaTN4NGEUqt9PLJ7cCaPavmWbFzEWh6mcam+Y6L+baZVFzMlZeh2QaepSoryuBvhAiznPHuLMDWYqin8iyxnSMLgwVuPH/YaFN1Fh8OFZLfKCOwlgyrIoen3gPcKDNxzYHRMOnOpsNgbn6WirqA/R8vD+8W3Ajy6tDVbS4N6xQN12ggIYtHT2oShAm+FjvCEQ/MqZPYgNaAWKM7SykUM6KCW6rkb/U3Fn0FrVcxEQKRA76rwj3PHQlNpzJn0mFitDOSJrueiI7fju/ZGyS4DeApU9RYH5Ini2AOSwnSR0oKIcqQXS+vGdJxMnw2CgeiN9EBm+Ddu1D9QYLcpEdO40jbNais+X4YthRu5hUIR+YzrmNE0F/bRlJ0xGn6LWZnkfqABQaFhBF/pHi7e86yg9xDpRyysSLIJyb2Ny6GgdDu+0cNYIeTfvee98edpHXlxWm1XET55MgBv8xqa8MKdHpSPjuuqGE485l6cWAh2GF6GvXtBC1ZvUOqRh2DOsbGettL1Uh54onanmb50SNMdgQFden6Ll6f3huCrtNRnzFjMG2mQlTe5tjrKeW1Dj4sztwdRJEg6fcFsgeYap6B7NJfH8VV20ocmDiqhMiZrupMfgC7aZju9cpHiMvApG5qBRzdHecUlfIh1HD1QzGwhVg5yCqdRA+eiga3kReq+T9g4z/HOaowe0L/v+a8/r332dce/VQEKZa9lQjgk0tikzj8NQccEJKELklzCPzS0eaLNQNswSAgIHzQliz54YXlLO6FQQqkqevTlolbMW3GXRyzMHgVQB1Js5wkQ0brUYmYw1bZQK7yK+1AKkneTJm1R9BCkw0r3gFaEw2eRTxdLVxjC1MKBZQO+LDR4/PmSIccrkUInRAHnzqidGcshZUUGMtYJmVnUe/1RkcFZzTJhZXxWuv/3a5WtMVDQXyAHcv6vEoRr5QD9weVkQITZJaMsz8vybHJM3o9o45oiNlCMulrZMudeb9HDcYl9w9/tSJQxcLaygNaKyFGi8Lsg7QQ+JQVVCQ5ZqYB0N0FNAZra5yqmZj75BjzZlmLwKs3d5UeAEOjjXTQFlrzJYUBYidPFqYTN0A6BhfE3ew3bL3jl6o9P70Rx5Ym6jGbwNS5o7phrLJZ7R5ZKioWYwfbAByRzeIfJ2kJnepMGvRvX7UhIjCSEFmSwTJTV3AS3kfV9PiN7Uv3fuyXE8IEJczDc2VXuMmV3nHbCFnJ9d48+SKmT4byW11KbmJhyxGDHIpS3zZVCmWFciechxmZpPaGKGRqXBxySmlFbl8V+c3FO7EPOBo/QlgZGwEWsjtkCNS1RJgZnhN4b3h6ONOKG6OXCgU1ANXTWciXB1VS4p671c8jUuYdWs5VyQMwA5K0BCgxpKmWkN+zPe3UuX9GmY3o8TqYdguvRYVTbffvV0SQ0L8WTVWrnf1aQmBT/LDXPwykYhk9KvuzBVbdbPTtJ2tmTStPHcoAucIKVemPEUe4SC/bkCEfziBafQhmmQ0yfEBMr5vaCcADJzyTN3CFTE3Ih8Z8+nrRhlPdMRa8HPdQJ6Jjv1jusbiBFMZga2Q94G0aUMc+7hvQl9+eRBfr4ANl4SkAi76BPXLrEj7t0jJQxt3LMHHlEthm/ZiOeWeVN4F7TPRey+iJiDz0m7bNZZdKAksOThQ0picN3OnaGJ9M0+etlt+l0aVXZLVjC2BRlTlUpNuqrSX9WqIeOr0h/xcCvyCwKF7IJObbnafv/jnEZBBBqIFw3mNDg002nfS8cPSzbg82ueplj9r5Y+GHi47H5/PQ77EwqOF+7fDUr0H6NGJkeeqPHYPYD7U/3mxvYbTMHXIuk/5QUqlXJLobhFoVIvQO+V1vbZ0UVN7TNoVyZOHZmoH5lIK9614C22h3Yq+fnlf2SnzTtbUxFb0pwbaGiqjGzqbvyuUPR5oGLzuz01FXEl9a50QhY7h/WytVvXQgXHUEbojx56XPYuFR92ep3e6oIC1p3pwJz81CYGn9GUetQpje0a5HWdrDquwbGI9oca3I4QZVHRydnpJl3ZqrfUDFYayTwhk8BN+xsRfXXKI/fIZFtqaPRk4/cz1FkiB5qq5mLijrdnunHWP+dsHnZXhlXnapI7kzofzN6x7s/UEDEVfticOTcTDikd1PnqHmfpluBveX5jXVqPqd50oAQJ034LDjvLyqilAPY1vFDZcHDcj6x4PLhlPrmt6KKuwd61dr+G1b1bf2z2sQAlSEAiKiyuNQg/Gc4ennT47OzUy4WvD11caG+HJT8sNy8HXoQa6Aw6qB+lIXsRHtc/j48BvIilcy8cOKAvTddYMtEmL/P3+/8ybZ+B1jOMA/hE/AFG8p8ilE85fw+7bKQiZ/fjby3BKcD7d9Hj07MlWZxwvp4vLdrTLzmRbjaLAiS1pojykOIS8EnZIruubW69B2J3aZ3UMBZfxMvhDpUXaF4PZ8cKNSUpZjHDxqUFsjAn0a+lP1vEcmYqaklGhSfh3mVse6DZrtQqV/HDeBauzjID8uZrZyecOHm5uLd4vufVlTQshNIWM4bdc7aUQuW5UvfSfHIFo8huqWNaZO6EDy6/ag2c2ME9TFIvlWEkQzJu5fjU2JTFx0AUYapm2bIZdSaHoD+7vbjg1h0zv97n8okLtvcPrC2l0flOciPFLVWkFdnNVQx9r3KyPFo+XyEbXHbfRtj5m+nrWbNe/dv/rQp4EaYqsk1Bz+Hbc32XMVJLroFDsd0tIui0xYS7FBvHYMmVYi7n+ux8eo5NUUU2dss70vHccoWinItP75DJpAZ2DNslkbiWJ28AydEcwRy5Tn6XS1IjHzP3U1OKmQD8Py0+9M1iziYM1V4MhsZJY5Mef+Ne8K8oxw2Q7eJw5/v1OSEFAk00F8lMN66dIl3GmZ5LlCvyU+/TnAIuyR5ipiiybX8rblGp1JsKxRMKlXoLLnQ25fXIshoom5q66Rus5VUck6U8zWBNLZL3thjCdv7F0JnrOzt5k+gYf+0MI3I1NhElbWgRvsY5R4sveZpFlTepT5HuEJcS75CIH6ut6o/hBG/PJe6ededH7mFTsjgYW9hKcI3809Bak6/XZnagzTGZ7qzC9obayCeNSpw4VYxTuj5UcxR/CsnCPxSaS6CLWDr//MGDeF+XKn2kEyzHoSW0wlfLzASDtNw/1S8tN8h/27aEdojlOOkjgmnkq2ULTuzbx29o2VcPJtoMAd8sryFgs90Gz+jFaZyt5GnkfZxpwm5zZ5pma/K0ZCZsqMbOGyqnUWUTRIoSwkDe8TnnFyq9pJ1pjoNLaIHvZ0kJGmFZoDsgrbPIiCJZX/O7ifNhgHGUOTQ6RDxKvI8Hzo7BscGOq5sa/ht5IaK6PgyQFC29zTH5y0jTPxawtsravp0GSXRD/s3B0UEmxtkz9cjeu6wvV++D0tEhE38aHFaGXcXOqR8pNjar+kePBX7EnEvcNdoPH9+JuDt79OTwR7C9bZ5sFpcHpvgvxZy09U9NCK7RaJmb3ET0ymRMm853I+v7r8+rWCAkCxcovBB1cbnXlmtNb8bXnh4ajQ7dSLuLCdu+ujxi0f+Dj6XmmJq2Lkzc2RuSEeh57Pr514EaUThH05VfUVTMFilnCdJ2sbMjymLymnPrBtr7vH2SHH/5RSddXJfHvMbJjvRHl1TlSWg+m76aBpOMpkHTp9M40+DmyCgtM81Po/nTMmmjg7uz41sUWRUMl4tRjPIVZ++Gq2dH9nirOZ9g0j/xVW/5JAYld2QOblvoAFa3bAGZsKGzcLumyxMuSmeH4/0D94GsxeI2rKTNsXjztcbTngPqdmkHRtaha9982gdfvRi7usexTbEQsxQ7tm2zRl4A+8WA/Zxu2rN3+W44vajfXnPr/K0aWASrhVtflE/7+Nd11kj6L71dcTW4+UoQdJem/H8KrP1hqr76SgEXvhPOdIZ+7pPpncUeh3dibnceQXhYJlrj8mRtbFcXNE+qrP5a05LuZweYRneJAU/cCNpnQWOYIEtn5GVSpBZSXWYmqU5qyaTwjFlaYVh58K96aanSoyyVsuelr0ufB+YIQyXTmsGoMZkYNdaMSqY+UG/f22V48jFX1izzy5oVvLCYDtPZZjssLAszZmoHn0Z57ywOVmcFnwcr6gfW2NPsAqCJ6J+3YrqJXmvOLGVqtSVMk41eqedXYaVjeqGFPt2df69FUX5MvFiKuYuRNUFm9zry9p7tTqvL5z3SM9I2wi5tE9yGTJlvUW4wpyJ2RQuBr/8Jja2lsxjr0felbo2AYj/kTZJJNpDIQ2klrdOxa4UuVaGL7aLvA0wKMnd9FR15IfNYzCRVbkJSYAkP/6/gmDglebmkQPY4mC9YQk+mLxHwp4X70TQwPwsa0fPWuoCS9uhYcpZoQlBbWxCHWf0TLi8IzgxpY2oquUEqbSCnpjZSPt9J3tmjXrWu5y6U+D/69pOeUpUlN899IQ4Z3bitpE+dPPIm3Rlm97R07//4xpjq6NpncCIItu7h/4Z7pF3DPXeBjOpzhZ24lu6MLUB7KUOG5NYtXX3VzKV43F5C5+Skdysef/bhgAUVLJfw/sCL0Ff4kauwKwvUtUlnaHyaGdLkwwQtMli+UDhWSmEI3u9SHryZinCXcHT3kft6IlaHtcxt7GNJFrarVGbR+v09pyAtIn+m7K3PddfDlPMJpMTYe75I5skTa9K800o6Xc2cfxx5jVk0Wb48qQq84NoGTi8Dvyc3z/J2aU8JbYQxZeHpT3s+JfMLQn8ZOiLbYLRKm/43iYOoINw7i9xkHRMfwBwopINCIijIacxt4fpt/bqjZtq2iXrkUWlNuG3+o5B0OfTEu31KX7oVw7WqfBtP/HM5ar+5km/H8OyWSjiEHPozv9Gps9b3TKcU3IEtOY+EazH8tWCdRk5I6LmM/Se9BxyL7JtEgpRd75SLkTdjCSXK4tpiZQkh9iZykerdrhSBaJP9eM2ImLXgGWqcyl11GnN6FZc6jnq2gCUeqYGfF/XP7IeoF+OcnGrRaVys/DIuOJh+apdhVVxKsm1JEy5mir81q9AMX566oX4jNtMNT7jiJnXPvaCk5QmpNwHR1VoW27CorY1RvOu3djf/L9fU0awJ/tUkW2c/3ajtyDO9at7nYGOixG+TOZCxsPMWF4Nsac86x2cKGU6zoiRV7WpT+KpL2+q5Ir+YBHuOtC8NIzxsO/UR1jEbeM2SzYbGWq2lYybBI5WCzryRgtSrs1lSFyhu5r2QqWUveMkXB6rOQ62Huhq3tGxa2hK+rGVouKWh61b7e/h5ZcPMhhmE6wcE+C+kUS3D3mSJvJFyJrtgvZnE4sspxMOPc/EHtirfJPLkmfNj1zOzuE2bVnKbgE114ef8041TJ2VNcGGCgEkYBjMEAhlhsPyIQE6gMgUwVsQEXpypVeAJCKfkuoRTY5QzUxlCtitXx7dE38ry04xWRpFMLwtQgoSYssJDS+fm2oh/pmTxBYTsECsx3ehQk/zcwZ8JZHyqIzWBQora5ecOBFvEcDCPWilErQ5yFd/LND6FWxtPvcugLXzWRc5lG3J8toxhjvOjDWZeNO5qCslB4MFKxeW8STeVwCtiWYkUopXNZkrJFJbSNoaEmMagSYWpIRI3GU92S0JS396vSvVIKQtHTKewzIb7iZMJ+DA8IVkEq29JG6TAy+XYSDSSncNhSjuiOfc57HL2N+x/9eGnM7sPTzq8e/b7ESc40zfWB1eyaYUTi1J9l81YRFwnLmmvrZD6P5fKZHWaJCkpz5ZN33oMSAJiVxQqqjoxYdffXw5bKIqsCSoB49NnqMA5hixfm2nJ4Bmdmt3l5KTtcSF4CpHiA52mgFt9ZaoezB/fDIrbA3Ev+wEdo+mG5imeeJPxYgyaNLcK/v5H5KE9pvskEqaPs+YQydx9jzMe9wHvxnnRJtR8IT94++FGSMItiUKXhH9SZUlosMX5Zcd7IslH0gjejJdwLttd9tEERlpWh6qZ7nUDzxmoqC0sZD2QDvS7GM0cLaeZcdwYyK9w6ZhLCTeXbiJwEhVj1CH/lpJnfzUgcU8jdc/q4ZFtHRuPr+pYdW5jR1qCV6f16UDtYrSPjytoa65BLZEzZooiTz7K0hPTdmYzNzYD7/HKlX4/276uAngR7na5v0xhadYU7+B+NkV13/Ii4lNO6YYEn3mdfAr4DiPiCKd0C8A1OjSlW+6mFBG9UinRW+SmyLvn/Zf7PikX9G4C8At+uONgl6d58Qee6JLKQMuy1snWDo3pgDhJ8tia3DH18OW1sDCCFKLQsLxlvkIOr1BH2LGihBprdhu0wvshqPTsXNZnF5IKVIbfYrTMTAZpdHolYfpAXQZdEVCmopa+iJmpAxJJaloPA0eahW2gveZS+6nc12CKIUB0d+HmexGLzVjJWhnTsqiDRu3L8PXJHB6oJnBKEpsMLmabLaOcpjVWMa02RpVRTSqWmx10ocYpnT7wRJO/rkTB84r0HtlHX3/c/6lf0r9cOkOj1qyXyJZolJpDYPhn0tikXx6J+1KTU/vEySuK5hVVhUq7T2ptIQC1WJaYQyaXV1c4GVtzC66OSWdoctDR+J2fzGaY8hbqGDoruFxZNwkyJSwYOLl3LxctUKzIBMz2MbTdWFQ0qejc1nbYHcG2kKtRpq505oUjifUOR2Id13yBxV/LQHEdrrQrhxILVIbvYrT0TBphf2sloXUgkBZXQXwmWy57RnzdWOMYlXudSr3OpQLORiiMe7AZfoisCl1qJu6IHxjO0UzufrIzNe/ygcek+CfWUig1EwOUSyA5J2VjEj15Q8rti0OfO4nHLtTj4za+ldkIvZySFwlhAykrSCV562NSKdZlx3LonJKpcAPwi4kywaoQ4QHdX2T9Vfw9pXAK8J61qTMuwotnFxdltD2x0jTeRu4O63sSnfTemuNmG4U6NEuUKEwUsZimsJtpe5ojTdtW4WCa4NMiQ8V8GgV60z7eM7cmv2LOojmL4dRcRwkSSHld+G2k4SCvIViVeh9Amp25OxC83zMudAkzq0LC3J0F4I7IaBHnlLDm5QdY8x3lmyZD5sB3NaNbnfmDXLVVf/pp8fPs58VPT1v1au5gfqsT3dzlwIN33fMMw/8NGc+LaSWqZjTVDNCyq8JKURNWbRRlK6gCwgO3+1yJGOkenjr8VywuOSdN+/VX4EXAvk5cxiERSQ6Vst6GXM8HdqWuWxc3dl5+orHPVmDc2t7Y/hHwanMyivN8rOTEbXx5NR2m1HpGJrM+dVsyM5NRT/LEXQjHhl+Iu/zew8iRwFUn61WdvDzcmfES9p9qcnM7EkNiqnAJn0zMJnqMr55SdFkqIfvIE//ODDS0Ws0L7NjOIorpGFw8gWiikHqiMVGVeOFLydTNYlOWJJ06dA3FXEsTuhSg2jeU0/9h4xd8A9/knz4zNG8GcGrVj17/sCMrmTANH4pfgMcdzXCGRV7+PuNgWGPoOg9baJbL5A47CGqtWQ49vUz+5fLpWcKC3KVe1VX3KJ63RyzPsT4hOPDheAfhsrmhoK/G5pgX6mgJrQBerTlbyaWt/Q41ZKewzTKj0SxjU+xDqO/W0rjZStP1hN44TGxNYmJNLCauF780qVbqU5eUVDe1Fk43R+brcB2XZZHlSiKOTn1t8kLtnYo9XTkZF5qGMSNCMyo0eeQJFnppnTnWgP1iAqv6Spf6nUUgIxDJJgo7MI5ogooJgEXObUOt53wCq2bV072mU9og5X70drX7XgHk1b7wkgEX6J7RLh+2JvhExo0k7jgP0um9feNhA9dg+JbDjpnWOO0o4WkLEkynIvDzR8pvIvzSgtjdNm1p8VQ08pvXl1y/lWtCPAvCV0IsGmoX2sSBGoYcRJ6SMqbtkxUIx4J5APFoqCIPNjx9P91i4Tq7af30vmV3z3H4eWEQ9oz765ePbY15ohHxZccZ5xjHgocT8UjHGUcs/IgHxxnXYm80DG6VtKZKrVhq6btUh9iq1rfa6qpG1ct1+wF4VbZsp8lKdgBh2ZCrAaplQ7wzQ/AFwLKdkMLAe8smAglLTyQkx7I1DPDffcjz4pNfALFe7hezOd026If3+L3d/YFuB8xr83gVRUdduiA+3uX9/BPz5z3B5NP8ZKT9Sxq/2tvm/xhu/zcE3+K/Af827V/S/i2NP+y3pHdzEpAq2vwpwj573m/pMY2nGJELDRDq7wDHGda4n3Ot/q21jmV/bdI2x6LHKmy9ttSPuanJSDWQ+uQQwOsezQuXCT275fAZf55fwa8UfsFzdn3kZ/x51AuctFezI/486gHhQxY8iqHmbFgBsf5tg9kRf95NwkpUgGYD/jzCEBTwCpDfmD6w4Yjv6G/0byHYkN4YK7DhiHf1TisHblY7csS7oFr60sffkE5FsNsc8W645igGgCSbzRHvwmBcVS9DBNJGiS3W4siJIwBDK7PZw6XyTWx0AxvKbQB3Y99Cz7CJfo4JQP35BLXJLA4rSbHez/3l62vEv7zJsNcJ3Zatr20j7INpxZunFTH6v5gI5PcAfJ4i3wH49j8mf2+J/JUkDSBghABA4D935nijg7PgzRLV0YwLoQIpOW3RdVNhkYWI9qPDZe5jtN9S1zgQMbAkSwkKl0eGGUXHfoGM+QyyQuVKZ86TxpDLSexKY+9DnK48imQq2BUBRewMR2V69AbJ0/GwSRmIWJRXXGZfZOnpSA7J5LZPmCQ4VqX9kp/M8adPmAZyLKt9zchIJlpTJ9+gxT3XhXfNRTv1kU5EynER+rx/278vD3ZO4Qwnoky4nQqKi/5GHkrmS4pdOQ7LKZ1R0s4Aly6vXLhITyzSbN3bDvC+BUbYaoSFKQHTRmC7S/ajMxFYLdV1JQ45DdEyuRkFRghsxcJtakc9traNZ2cHy38Ny/6OSNEHgriFx0YCeJ45OGYiWWWPFhECaIYiaI3QxyIWeOPzfbTP16q07JQou52GctEZpHjhTMRH5UwRkWpnqtisnJGLkIe1zdPGAjAL4EQgWOwMgXHSiSR1zYnCTJwzVGJynGjUtH+U0eTZhk2HTlMM3q1Jg0a9qKTEJFSoHKxyUSWVbm+qEJVFq1ZULdbDUepiUKdM2u9XSwgWKMKL+OH/v4/kgu7OB7vSVczseSyTs6C+2h6t6kxGVYwO7ayC+ovytNZNpuZ2tHcAWHVoVQuuUm5+ACkhGZ0RuSQZk88RAuVJ0kamM4wz2Dg+MYHFhjYlgmrD2iiNSix/BLw9mlR0atN0WC7yHkqFMgj2bSKDjHz0TloiIlYz+KzzzIRVelsJp0hp6KnslskFVuiT7rOst6epda2tye5Ml4aES9snTYxTKyJ+XxVQQgC5uFwJDOw/12+hKNFixIoTD7cwhJLi/1YRkaQio6CioWNgSsPCxpGOi4dPQEhETEJKRk5BSUVNQ0tHz8DIxMzCysYuQ6Ys2RxyOLnkmsDNw8snj19AvgKFihQrUapMuQqVqoKEHeaa54JB35tvuSU222dnULDYlwas8ae/LDNkoWue+sOw/f7xt39td8inPnZYtRor1bqhzieuu+OmW277Qb0v3PWZIxr8bpUH7rmv0U9+sUizJi3atGq3VYcunbr1mKjXJH1+NNlUrzfFNDNMd1bGg5lm8/n3q1HvjuISNvrwxP8SZlq243rxBDJF20mSjgWICL+qGjOt4lqadrh+C34hjkNBCgIiklRkFFQ0dAxMaVjYONJx8fAJCImISUjJyCkoqahpaOnoGRiZmIVU2vMRlBU2sb1JPGid7xhikeeTphXQ1kMGwCNPPPPmcHZkFOkpkcTzKI+r+CTPPokjQUKfyrKqhFWtvRWZpKTTXjPBU9WLXXeHLMFTguloryt06+3rYOEru80ZBnbJt+10Nk2SbT1Nk13gLuR6dXlr7U3tqaeW/ClYKIjAD+GrEAVfAz8CIXxNlxcxDyNcFMMJgKRo3h93bVPd3cK4qmom9tZxnncWaK2Lnm0PjdUtvLeptbbuPu10WXGE6+fTT/GOuUm7+10Hlzew6wX6OiN9wa93fCM6u7ck+MA1J1U7JToEAAAA) format('woff2');
+}
+
+@font-face {
+  font-family: "Arial Plus";
+  unicode-range: U+221e;
+  font-style: normal;
+  font-weight: 700;
+  src: local("DejaVu Math TeX Gyre");
+}
+
+@font-face {
+  font-family: "Arial Plus";
+  unicode-range: U+30;
+  font-style: italic;
+  font-weight: 400;
+  src: local(IBM Plex Mono Italic), local(IBMPlexMono-Italic), url(data:font/woff2;base64,d09GMgABAAAAAC6sAA4AAAAAbVwAAC5SAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnQbiVYchmYGYACEKhEQCoGkNP9JC4Q2AAE2AiQDiGgEIAWFUAeKABvEVyVsm9bQoDtwqJ1Kac9GVLH+IYrKST/7/y8Lmo6wRbMD+06NreJEYBJSgXQbTrrDfHUq9I8atg3SLIeVQYw+88Nvjfi3J1hOf3ufvoWiroXR7D+voL8ZhJdHs+8IjX2S+wO/zR60fFAEJVRokRYLoyiJUjE61i6qdFEu6mo31+HCba5dn7uqbReTemw8c+cdhH8QFuVwGE1S4XVlbY/niTXW+4uIZIlijcSQGSIdIkM1i3jzRMKneyhU+t2VcHW35nw5AmEiTMsDAjX/1+a2FEHLTeo0aZWuW0COnDolZMe6i59cwPHHLmvCRQClNlFndGHZcRSVXCKYfpm+ARUqxA/NLb5CaC+arFUktC+Vha6O6kwQvYn5VU77hVu39dHw2fqlhRMgJNwzb+zxRqEqpUp1X+CrdE1WMiwxByD5v/n2OcaCoOcJne6udFapxr1aYB/6M6Yg0S36niHJpbFWK81Yvl3tkeVD7aH36L2HPpS996W1nxj9fz6ghUfmiDH6IPs0BA7SCBCer/1e7Tvzc4NgwxswNhMrkr37fmb/5gaACsivNa5sLI6vsDWmRlZ4Vd/G9vdgDCOZ+tMc4X/+cj8nRepGF7egNI2Yd00vizTSPEu7/4Huy7H+j/skKrJM5tmqf+cBFAAygEqN0LyJJUIxsUKxc0JxK4IyzzwoG2yAsttuKMccg3LOOSjX3IbxnVGokFHegIk/VpiwsUPBAli+sKi6kxh4YGZ/nJngt1i2NwJ/mXc2g5IoLY+qlhDUC2wDRM4KNDxv0Q6FKm/DeRoq5ywJlSuRaZSr1azTRNPMscgK62yyw16HHXHCOVcMuuexF9750e8++hwsioSiYggiJKUWKY6OmZNHrmKV6rXqNjlUiACACim0Ccv8ngATcoAPY4Cz/mdBA2GDNJ+BALk2r7RQAG0FJhXNhwEYGyrVn2kRARVeAxuwNmKaf60f7az/J9bH1tb3Zad/9+CD9T+DlcuKPk8MjUgsAkCURFT/srM5EHdoD74sRYK9yav23WwPhaK3a5vibxmYpgDU63nDiCxSvVbdJpthniVW2WCLXfb70lGnXPDJ69YDT70y6md/+ieAqkaRUTQsXGJyGloJDKzcMuUrVa1Ru/F6zLLAMmv0hkr3joVKLWAe5MAk6IEWbidMs01I8YPEAR3QZJ2QQDlUWlv5oMLaQLU23tp1w0IGlNusZe4BnLQ0jaYLyIFxEAVtkGbNTKyFgDxwWLeX11rMBwlgR1/50CiNCYKeJgHMsz2QtT5B7Bw4UmXjyVUkpHkBFaghFDQ0rGE5tnBoGNfcAk0M4L1eKEBalIAMilWQG2WifFSKqlEjakfjD/w9UABd2c/9DTdoS8y1DqRJcZ7Hja02sDrnIRzh7uMW/zS1An/Ja2kC6ffcCAL1StrUDpFrwM4QB7yKagJFG4qByDh5AAIqFj6lSAlMja+aYBqzDh4ARql5Duvu5+ZWRa5kS1HtdPjgAaXQwQg7I8KIw5tfeqLdDMXbr4VMr1PUwZIoNEGslgC2itNWQ9diVZCby4fC7bcAyFhNYErJX8V6m32e+diTvEHOz5ctByrt4dF87XmChCuMSkguXBwDO4985eq1m2iGBVbYEAQwaIIkGkGEhjSBaAThG9IEoBGEbUjDRiMU1IasQEOWHsoEGqGfQRlAI3QqqD/QiI5F4u5KGBQLi1LHrNgxvPYbEwOXhJo2xDKyRBVtyaLVaWVgpxF01CoYAosZJWfVi4v1UnFVTMAV2aokQgJpolDw/PhjYGIJUH3D0L7jCwLgvpw4Gg3eOaPxx8DEMnZ0ctXthLFFrmXhAPpwuffPHLIGRae4hEQ9e6ERnBcOjYHgmBbUJIMC4CKzzbj4qOmBsAuL+vwXABsU/ZehLgIAdCX6WAB8GHDtDlrblKIGdhTVp9g1mU+O75LzEoCixxhKkbETu7Snxwsj+pLwI/hxfBN0wn6BULBS6D82Jpqdb4vds+P2xwdmofPD+bH25ULaG6jyr/v6nrvLb/i/zwAA/n8BLx5e7Hix8UXjn6iRCwAAQBk5AnA1p+awcprcFQBXXXMdwA030wccdMsdd8V0Q+653/uBYQ919ZGgj7cWfG+87e3sHUBVZ56CKhDaNMKLejcRWByesC8p7VVKx5f+lxUIReJgSYhUJlcoVepQTVh4RGSUNjomNi4+ITEpWac3GE0pZovVZnc4Xe7UtHRPRmZWdk5uXn5BYVFxSWkZzJk7f+HKdZu2b9uxa2f/nn179x84dPDwF1998/WRo9+eOH7yFLRXVtU9Gr+1teFVdz1QmHcNHaBmFQAAGrdg99v0Cg8AoGn7cfnB7LXnL9y5+2B46N4AnDXy99lzAJjw+xBmHc9cvGDpsuVLVq+BVbd9G89dvtoGrmwAABQMIhIqXDnmEwCg+gMA9GSAGg4Y/wBwGwCwhwH6J3CRcsKS289pyEKOJV1dRA5V8JKGx+pRwoBdXqGNclsNdfQsIXM5XFWh1mJR9bBJHEn3kuJEWOCKh6eKKudUhT3CsS1yYLFzTcIsPHSR3+ywIpOohKup8HrVK8gcc22iieKWeCrhWgQTdTzPMGC4H8coFGICGCJM7VOEvuWgwcayD/hVvmd9iKKBIgqXRKl2ExKJqCGaJn4tZKbQh+8DVjLSy0hTV2pSY0l5KIuaOB7X7vyqXC1v/4aDFz7W5Xp0bbEAF2EWW6srV1iHEEOoT9FkLkciVTb4UEUpRf2T1o+egLmkVEYkjReiAc+wJcYIMb+XPVOjCFM/iWO0TZoYwxyVxtGwX6wJSibJDxiIV4x1zawFabx63gSRF7v/yiHv0z4LFiPRAIKZ6wa2D8CGVGXk8fUCuUIhC7tUC1KjP8mdl/Iqmx+FlN96Te5gI8GkplFFJr/qDGScVwp17b9XYZj3HEiqZUxXI5px/Yx9svYXD+VxIB2hINW5Yoo7ncA/GxJZYz2k8np0uTJ31msuL/r0d/1ikkuMTXLRRCsUasxObpQ4lfRNdWGEDOKA9zeKgDzpzzFW5yCgz7LBgXJytPBH7rVJQ+HhyKPzBemrgLeRvjyVRiBROHrz+ZypFWuBnqPAgv9FNWmAwLvYLCRgQxaO9DgxkUJ4F/su3l4lPBIjjHIlLtnTngQWaJksaecqi0HicIgeftgnWU31ZnEy6HuSnq/T+gMJ2ulkhegjweDdrxbnXShOEJcRCYZARWLLBef5J2azv9nFS2b2lQo/xCjeziyojg9vsSqhHAgOHGQQsBlKcK9jaVvG8BXdUOpoN4FV2i1WW8e34kCuLTWnoSpKruHhUTi6HP8ZITgyoCx5i56PFe7jCKubHcSaiRFgU9STQLZEoLXF/6OkZ+Qf9g+7gK1E7m51MBV90p3tkRfjCML/Zxd6wX+HwRv9fV1KIJvdUnU9QNSuf/BMkdHsqVFU/BDb1D6D3w1gCNSIOmfeu1pW/nuv5PThBUe8h/U6fcTVsUHrU4qEXJpDc23DmsQ45CahkLd2kWG/60qV2VPa6mgvKqGDuIywNjxAERun0t+vZmQdzOmmILXJ0lE6xcIa59cp6mL2wk2qn5HsEMTYGyYV9h3JyG3x6+Fi+igdHTwg0x0+uO0w4Hq+LXmEfzkoCCafjWO5QrjFUVYIZdsq6JEVzmYWDwOblhCI/G3WDHB/iZK5EhiATJmkeWqJ+UoQjbf+sqbQBJKAGxbFWI5TqQgRT9sxsOhR/fu4UuWwrG2wNzNjSM2+Xy5RmeAvOpWNi1ukd17LsSUkqbYqsP/xVGi6rN8buFcpQiRDwwjEz+KblEZBTGZxF3u91iMsmzMR4GOULHdxqcTW8sAQZIQtlxggTLRM5mfSmkQoKLNSkLVh+xJgnAzCzKSqmaN2OS5tZ7dnJ+8It2c83kVe+qrJtARcUurOfKiNapr40hj5PtHIl4p0NVPia8KFpYQTAIh5g2NU7UYR0NNJAuFhF0OcYs/ORDmaG8+X0cDz6aogh4GFVDd9RNjt8XVK88XohXfR1Qy1j/0L1yk2VnyACayE8zumrQurj5banic0HxRHpJxV6/C8DiGX9uxR5+gsWbeqqX5h1k+UeF+QHpWUXjhQ/I3Oc2fsdMjOGXiHucNlJkFE1/MYNDFk6xTE91cf7C18iBwStv4rssvFI7AEx0zGMnl4O9jRXKJOTyIPa43aTiX+gssqp+lH00M1QekQu9j2d3ZGDCn7yGcrxzmDPxa+kmI98UFyluF4MnokHb0TSB4AVKxcZc9MsRRpQ8w34qmI8CSkEQUdS2UoCD3qCLmVdfzSZtWoB+fP0TM506649dKUG1aP1qcPR2uQYl0pqeng4OjufDLE7KxRndofrgLuC4cJW2sXD2m1HtlMxiq5ezuYccZ4s2w80TyMAGO4PE4RGT80uTe6rkMKC6q+Saa8KvI/QorfNCr6hn11iZpwva0WNEGl/W6WxihdjQjvESgwY1sqs9METHmZjgcltj85CRYafwVOBGRmokXcp3GOjhpzWNb0kaPpU1Pw6kMnMzYbdhA1G+ZatInWWSEE73/Q1JUREHDQJt40ueCx9KuC3vJvVQCiYPWDBQK0Pi3UzBfEV1m8cOs/tcm3tR+nR0Jclxq01wkQQnUMRJXj1tbQI/bsSJQeS57SMD7Ehp1eko4WFgxncUADjw75vuAvjRHSuJkNOsIFPBDSclzXtGb8bRsSJCTDQICCvL4IxF+2cUE2A2Lc4y5ZQ72XNw1zOywb8YWrai/EWJielldBqxy2s03SPT5Pab7ovjxkCpX3e1n2ZeLKGnpmayE8BW9DHglcYzVFySQLDU16OyVGYKEhAqBXDiKzPWEKdruiTbS04HIyTGCsQ7eqBzXXUWiWS4IgYLhVNem72SJJFirva4xlIy1XOHc/OZGMHFUqovftn8W2ZREf02CInb359mVtTCZljz+/SF2+l8e1nb84VWFlbbp15gix5XH9OTtg128+iJrufnsY6jYNIcYH5V9OGfqTu4vRiAeeYJZj/ms7onyNmCXbGu0+g4yl40gY1o21gTRXXMJYroORsOhi1udRekMDkFr/5lWMbpzI8gsHGBK/6Eglf+YpdkiLfcjAMUF0OWOD6jfRY86jFLNEM+Ker4Lg7lC9SEWalsSW9WpcwRK2cUV5bKyvl7N9UFdWAI+xYw7Yb5DxcGa43NGkh9OaZPORlKyLRozRyUGkcBgPKZtmBj3U2OUXQpZj5jl7nGLhg6EsS6oa1qBND2O8cDGU8ovIwwClo5MHNDuURPpItUe30y6SKH0ss16RbloxpGCHkEH2FLDkku4vwaOFHdVjK9Or9upwfa5IJS+BqoUeiW69JFa9xwrBOWB5yV9WxG/kOP1QlxkqdV/439ZJlxglTmKKt7vuG7Yhq2TctWfOdCoS6nO0Uen4tPTJauhWhVWimnqiIl5acF3BiEOz+ICviKMbo20MLueNpyTODMjUf6luSSLPWVCJ/SPT4/2a390RGWG7QlPyvq0XzXR4cptglLENCwye9Fvi8kVLV21xFCx5cBa65dkjDz1I2TR6rsUlHQ5uOda+5Jh/3Fl9kXqyQf54ox+vQyZDskce3lc5TO1ug6vDDkPncpdN1fc5ZC0cLoplOs6DfB7qx2HaQB12zW5C53Y0dV7ZrSZCwNaWCZWJrXWIl8BSH8IYPG61YJCm/kf8ZPSrfDSNAXlCqv4oiKreNY+QW2AU4dTYtKlbf8OxyKvg6UwH1RbsoceCDOO2DgQO1UItyxFGCWR6fjyJcX6T5Inrpi5cduW+evx10+kNmhw5/cIVqxlPrbHdmGlnT3+itq9jly4GCZgYdF5m97OEbAiB9oWAUEIhVi3fjEZkj8LofiJqVdA0/nXgeQC9RolsWzExApBHZsw/SvlQLJbNCzUMtLfBk3UU2eyatrJaqBQrvMhgFO6xDpKL0xas1KuzagJNRH6lrAbWqFUFPZEnSG4NVi2gxanjxS0STdYamDp6RqfiYphcnEt0Pl6nqIiYJdHuEnj3qOSxnZfif5xamqDSqO9rQraXZC8hk33iCiidRShUyQlmQ0oGYVJBjX3I4sGUvmfokc1XUi3KtctTD2DZUu2T+62G0CKNU0hN+1seecu90Hv6gkxdgHAztGTU1PEZ1mOdDBMouSdW+UNflLg9YgzfvZ2ckFw95eBB2sN7XhIqJMadVUPCnMLpSZHLhm5mZls3RgcPiobgXNsCutfjr8QA3ifqOkhyqroQjp5d4Vq3SHS0ZmtwclheUWA9OXTluyfvGltHaWJfofUUBN6j/YUpicvJys3jPTwxJysmU2WVUjLJWatvUqlao5MaYrEiTwobinUSNVonEuA3cZK/WtkCgsP7okQgJWXf3ws1Dwo3BTzVpPI+n8wiP4nfsmoLMEepOMG1bNUhvgUX9ZvoIR3H4diTpXENYPHDGYcWq+ZOP7TI9tD204BtJ6rZps9meE60ECr1h25fN4cxFF5/bBHNDRU63uYGpVMrE3xrTMT8xLrjGnsWIvu4OpP+GlKnEabq4gqFy58uCnqjujhR8pMR6zQRahSRT2X/W3AZTjhdGZ9itoYGOD/8L46G9JO/mVwTT7QZzARENp4X1naZZ72tsJ4sCzf4VuTfv2tgOxJybZmfQSqkWvus8llNSUJZoN7byJJZCz1ZJQ21ud7zEF/XtIawwvrtHIXWyrDhCj4uIyPGmKl9uUfE3y69IAjlIvr7F5yqWfECf8PSHaXMQFeF1js+CaS3VHS7ig43h3M021MXV7dXZPkW5jhqojo3UTIzJFHMEmlmtBlxvY+0SfIYddC7mtJ4SXVbg8jOg0sSySw9+mVax+r+AdOTk8miYWuoyY3kpYPG4v51JfvgbaLwziWS/pL12M+OHn6cM3UT3QC9eEo618QFIIoe0fFUlr1EglcXsObzMDNsPPoMwCA1xRM6lKS6wAZVpcldpE5SH3G0Jb1ikm8DrU0r87XGuQxhvPp33FVUHIel/UEk/pcGOWK5UhxBvLZ91r39M2vbBhAL/HSbkoncXZZOpjgF3pp/4/m00sdHLYEv9x53ssNCbeykAH2InG3TmMyGu68OdIF4mTUjaTWTR5T/HBHrilzVzNhdYvCVK8z0kIFgQf6yofEYi9lpUInTTYnl4mRNip8w8IhRtnJ6LEdkzU7exKYRI3QxKRlICqQz5uWRnfNet3h+rCMZ6xjzom+QTeuwoG6P0pHxr4whUVmVJVkRghKTtUphkunoYXlHUlQ7ljNv8q25dpKRQ6VE6xL14Xd2G4k5UycCGimtaq1MS1hTPK2rZlrzx2pXemZy2UL9p5xYXWZZaVZEcInZWqWITLEUuhALi47E6hJ0yWcJzOxo1/hNt/Ov3EEsLW3wGdGmsZ2bJPb8Bo8/4YUmJUzCt3wsFiaVVngs3Oi0rnjC1HirUSlym+NrRdEp7nzjBo4AibBqjUG8SdkpaYltAh/ViwTRATS/FpBtWeFGvVf2/qQvrWrFEgtZ/xyE7Bj6SMmccY2QdJVsh4xOkn6YpP9w6a4HJNXNuHrpv0a2TftAeVOB0QfsXrPNDw6ls2ho5d1IndUQYeacmtDrYIcVVOY7I0SuKx7h39QK84gv/qZe19KlzxNqjawqQ4pvk09F6GJDbr40PtIVJGSlSL3lvIQOMyUTOzxeHRprywzzL5M5xuT96+XYVI6SkhBvcYgfsIPLEBtrbYDa24ug9Elp+Rg2yXyM6X93KMBOrQyKxw8yFM8ObuQwvGTv4Bjr0t8Fl3JtA82lA1urvDZk3YJtAy89Wdn2FFvWZkx119n/eUpe6qI0sQb5ZEmwRsx2sXxJkoWRvfLPFwyxLya7BN5Sg2pp8DvgIk0V0ydKSZWBtapyk6tEnawxBt4YV2hjphBOLudllvf4NviUaOP9rcnZVu7tsohwHT9GpT9gZcK+gX3RHsGkQI9mouILT2dntO3sZcse0UOfEkGSv9PhthcUyiC0c2A/YskP+SEVsaRK/ypELNPMEUdlyI+WyVoiE2BHFe7B+x6BMC+/Z0ohlizFVbxqhUFA5mfP9ic7iOKKzjOIF+zflz57BUn/PCbHCScTqZGJns4BT0QENeB4MJCR9IeKow6tnsM4d0A6kOPjU9Sek5VelU5Ic1ODjyxaxm/3n205+BmxADd38iTxU7txJdRjZy9+9rRWFnJkeT64T53Ta9ocao2Hi4JHCHdrcmsI4pHYIkfnQKUtEn84ss4O5oDneYTKPKdrPW4WRlkusQHVk1VSjKQyFGNS8Dx6g/yU68m3tXZPbj4cJk1s3R/7dnKGwF8uVe+Bqd8wR4eye7IJqePr2Z+/5V6ljIrg4mi3M5ptaThXkff11c9zmrNn/pZTq+mek8nXNY2rwPeo8rrl7d+mRJg0bdldjeQAXkhBt+nt7d9zwpI9JW6jAnPTTvXQHBkmjdipjyoIilFZfaeOHz5+3aNMcGabEzVLJ1up2XRzli5cnG6KK+fDirbaNk9wfI9YJN9d8MOAYandHI/zCli/6LQg7LiWljrD3O8xriG7eG1R9mxRSkNuQTaflFGb1A1XCwbcikIhghuP9BZm6wdAnTBgE8/ze07c9kWx3xfE8OHipY69AxO8dxA37AD/3ORFxlXYrlXNi0qFNVvScxPnJM/HNs6vm1NKz4WHKp99e3LNR+K2YNu3zDhSrt2mZsB/HxDb25BuxHJP1mQ9bJ7vVTHDr/cOkU683QuT5pN3SrJ0hK8+pN227uyHf8Rz07B/pK0gt+WungCoXYjlCWKBN7/YAiIOiOAe4kyrqIxkdUdXFRiMMbZwNMY7z207aUFS4jQCTybmabo1xMS/1qe97qG1zTbExVo9eYgFsXD8SHGROjj82h2bh3maaTW5PRxzjqkqMphind2fxziyiENqdVr+4wNRP2Tgo4MxDiiIxsojstI0dlm3JaNUGS07f/hArYH9y1aNwZNFSdsooJMMpqRY35D5v71v7Q6aa/CDFROyGSky1j3ptXtBDPfOTXFxjsxcf1rADymva2w1yzrtmbXqJMlvr1YKA+e7w1YJJqIJFHTg8iMMWdCNBfXFZQpLs5342F1WRMrxKkK3M25F0an7Ohvg/BD1ROD+2wmG1PXb6WX2oyTDUd/6dr0+7gDJcJvde4dkuFOoEN9vpMLQ0OQYc0bsvxpLhoWS5TcJezPbYkpLrywJZ7fHlhbojI6ZYBaG3jazLInDf3RqJK7Op6zE2bbsnJ6zOUIkiciROcvnXqiplmS93WXxEfIjot3hGkEQUb1KKXTlRWK5f0eFBrkho5u/lornsLQfufEHddkMSTWXJGYZS46RDKTss7UX9vyQn8GXTfAC2pDPMdLJ33Xm1L5+epn9PskgqmkW328EEsbBUZT/uXw8w6ZPsprimH/eTVPqfcwbzs6asN9srg7nBCh+Tzv0s0cc4mCK+mWSNFv+o9TyXCM+IjImj4BitKQcIRkI07fNvXHgek2RJqb6OyBnYazkNCwjWKHMkWESvlYpzmm8owTx1dbYPIEGiVH6vzszxNVGu/YLyGDy7f7+jMMHHMRnYdz0Cc4YCohIuJ3HYvvVGKwZZcrYcAdPypp8ZOXKSKMtO5fs3ChgehmMCXGhBgvYq+Bh+10jcKPAkbkwM6bwC6ZYy7tz3HV3LeD3wZf2M8tJhhHGfNwg7fzKYDfZlas6Wp+C5byNUpIBQRzNYdy++6mS+BRXRKh475920lfNBw6KZcqjqX5qU4nsQktdlYAkMJrC5PTLxZd+tyIznccGJVKfG5lM+BkRVYkJBGZ8wWqSoS5glo0xx8795j7JcD95SvyL1WWtqVL+zI+wZJ6uN98TfCu6szBuwGOMF68MF8cn5/AaYoQU3RO7//9UmyxVu7CodnKCOSRLSKSzIgqaSQaY5aW6FEpVi+IqzdHZnkBuPcPv/p2h1xExNlN0tjCIwrMzgz4I8+gt0RLE0q+nD3i71AUhWzK1jkw/Um1/EC5tLtQhFeO8vOOsOGoQIglnCeOFOdRyKQnC0+zv+kp/1msKjEIeZ+wir5RenO5JSMz0iU0TKeqD+ISX5r9bWUMJaDZwmFzvl6H8oDXc+i89a1aPlZJJn4C5mWZJ1jtcFm+VKEzh1oj5AUT1jsq3UlLerLd+2O3l//GfL+ONXvpUkqvK+tzODOKIBAVMHTkrLc8hz+atiDduSiU5qiyf4/Zy5878sOcdUxAJ/80X+wVi8NSEmDhCyfi96z9TDfVlG8t0BqksIOmriRKsl5/eaVBJD/WeSsuReGECflm2LS5I9fg99sJTkTBjf+STWrLrZC9cbvIVk+jQ/IEthcBbGMTi5jzxzY+pWI/97qS4/2xcfEHsn2wIZPHCTKyUs4KyjLyoKR2OfLPzSni7sesRFbcH+/eIlwQ7xdGWnSJu03lyNGJqTRK19juj8YSBfXGHn37Zi3/jT+1orfwUfSmMWp2klWufTtAvzjFnINaNAjoMImydT8irSC9dBuI+8RyRSZmCKpLRbbQyo4UFSYa8YG2omc360moOHHiS6HBXFPhHhn1NMvYxsV6sg9W2FfSUpL286Xf/2vueJVkGzO6A773yOr8um/I5hSLj+NZdi5hwW9M+I/qxuxem1zr0JH2fgBaWpnqoOSiMA7zjx0jGJTO6csZ3Yf/uKoGuJSTjsY453u85ECyNrzGFsj723TkFZ2iSX5pcbLWmOGhQZHonSUjRKkTDN7+YpD7f7x9jSLPSCEPXRfrSd7JD7x76pfDm4cNlX6WfD9fLH+LCy3pOlTcuiGHs5oaRe7XagbdvbInEZA2uMWRGLMyv6Il2xBZzkuREpURF5glSkkKzZ9VGIkqGx9sVHI2M8eI7o6kiWec0KdiOT3qBTLN/59qca3zll3XzCAiB/0rAu8kaLDcrYWL5POKlEIk2OaRrl93OoOACbUK+6r6HZVZExRsjVAQ0W/SsZY38vJkdhAmOkfzuqoW9Lt7ZeST9DTkGtHmiSwMLgmVcW7WNr0geTo2NdznZlbwrjEqK1BoTg9e+KYR7NJO1jsHcbOY7lAEpnMlsCwaPpvuL58CpM/4kgz/YW4Sr1tSJQwJNaFOQDONoZm97gQQoXikCVrwgs4fB4c81/MuXSfpLLNuDdskr7iFbQ9I/wtcGGLDiNswoSXqQdTmUTWJI2YKU2do/38SwrhOj2Jwp2adURYbTkMaX3YjEErG0bwMDhgnpjleq2NUhEp4EfSFKFObQm7S6kKendm2UCOuK2Ximgy9vhWTrDw07jRJgXO667g6PWLaUq4PcmWu2c6x/sDtaIP6tFOtVzt4IlL9kKQG0QJs6XlFk0xcLI74jvk41EyN882U7zCD9YT/vPR80GDK6edzEzQzGYV8kO/O8sCQ8KI22NQwf9BOHKXizHi5bW+sV2NqY+JmW5Kjk4lZILuSKoyJ4moBUUgpPkYwtWCWq28gi4fkTQsJNwk9ndzWjunZJU06PXw+tuWDjkl9ZlXslK3nATjLtDvm1d3X0Sj/139d/u6Zsa5mR0ALTpuzN7b3kgFMfMMO3AhGYL3D/YuiKCNlTO/YRJwWh2NM7l5/ZOWebfO6O0zvuHwFgELWRNTfKOtNaYnTtoRQ/tnaTc1co5r5QrcyX5MtM3PHIuGPSoaE0byillYBm7OZhLtl1No9D7PXBL/f9bX436KqbPYvk65nzSYb97N5ssuvmmxx8SaozRpJn0zUJzWbEoJeZfHS/G0IYRK1HVkglGW6+IdjOwHgk0qRLTm3NKMTeXcthENPtEm3l3br02AT+4ePnaNjmlHBNpDExjr/gVhXXiYrmBJG03ZKQN1H5u57OjOJFW0woHd5bZzLVhwxMpmR4thlErRwKjpvWuDNwL9mWKiiz0k9JmdzbkOmzHb6/Km0VaWZsPQzH1M98vdbPrtqqv4HB4Vm2YB3HSc2LTBVPteTXaUxKK0cS6ArVBbeY0otCY8Ld4R/0S9RlxTW6n0oS1v9onPLoE9Tof8ItMBW5yM7ZAhYxMSUu3ljsJLsmfGDwOUQSj/yEP8eXyMFqHwvidefNmh4QiJ7MK09F236HKVadErDOYtuqt2H+tCV4qMh+Mn8OatLKgbi7s9pvHa4/H2SD/KsYXHNjz5QG5c6Mtq44Gwkx7Qr5dQPJtFH6aTdiWtxJk5u5+eLMKnIJ1e6b6nbb0bAG0ei1ZtyIOTFK9N8FslmexJ4UXuZMCA9s2//aF7vZGrkgPBO7/2sXM+MkMTZKJrVaQCVpC3kTEctxPjE68Inao43wRBonOlYNs/7LXvG4pHNeZ+msRRCjV3UrA11hQwEy3mt3gNLO8sX5zWWfPCKYU8EOHyUh3tTnlKMYHr9XB5D9Vy36j8ncP3/CXnNFB7D2rsD68PwM47iiHSQhO6sK5oU8wXNeG8roU6Hq9eFX6ShsPN6x2J/FOF/t5B8N8URAj+GPoxHVHO0PfP7ceIP+u1XrBz5Paky0hwlDZszBA2TX6IEf9veN74MvOu/cvtMbA8vAIfHXLFRZEes3s27+7pB9ipgSgVgJKsy6I1MgAKkvnzm+WLLHPa3LmarRHyb68mspLGC4XiHGt/pW2muS8YVg/4gihHcrNShRz8+4XmdmwrRtktGcKa+m5EhGp6sYSbLZmOzZySpGqF8PxYOt2RixEUv2+PXAP3//mpW9nI8r/cn0E66Uvzwr+9fBQSg8l1L0VvnoCY8Re4Y5Mb2zaEZHhsBH0xoVaZKuDDxXoXgRLDcyhufwvOWcKKPTOx/b6ImVGfit+74WkV2dVruslkMi8jT7jkcQNKel9aWHyQ+4naTgVwv7FiqJoK+MijPGq3xTG76U38cIE6XX94b6cLbwgmS+dzxFsfdeIhqPZT+jxtcYGO4tkrwpVlE6oo2hQRnTf4LB7T35zHuRaDLabzaL/d/jYPTZCK1Jojw1mJt4oO0PSKyMrt9H6fpRkLgER8TKEkQ9Ip6Z6u/I1JUBikeeuh55+HyRRI7D7gjjhNsToHLvrg0Hh7LFz9VT1YcSaC2BezHz94KuMkK24fuOgSDmxQkMKo75NYOpX8dUnBic3sfpwr218aShqsDEcCMYK6PXh0s55u+XHMoKHncZWacbWspXauRBbk/EQU6zXU3yGw2QVxT0z+kh6bS0jj9m7WMnQ2JlTI9EwrFiau4ESM0xSVFxQuEjEqafymVIXDq4yGWbMHiMTCtfxsA1+ukYDo7+OkhENqG5ONoFeF9vkuc5w7NrwSvJurJ25rzR4HA1sGAbw1JWxKycIS3WKwuFW6QY0kJKkxcNLG4REHCpAoIoNwENgVhMUbg17WAQzD8/0LBTJ/6D2OS14vptyuM48g7tgQyYP5rN7IgDvxW1EXXc+dit4g3st/l8c7I6vBvqTfcW+ZOj9Nq3TP59C9fvXbHGyj2+uAlWRv/6Ip8/bBK9vX+lsKWh6c2uWfT+ZBXQ64eJQS79FOczXjHHUN1itCSPXDg/tXIirZHWVueXG00ruaI/iwk0CZD2AhUPpFwk+4JCWL0G1JK+WZ+UZ1t4zAdmA9DwQA0Igedjk1lqz8uE/YexBj4pdQS24yOsgRT272g/RbxF4q3hUTR7yPXl0rk+XCr4gdSJlsr15dKBCkonmpXry6UjqoGH96BBmOZjAYQ70fRcXy6d6wNUiHGiGbm+XDpQISHVV2czLQ6MVG439zL3KrceroDVyajldnMvQz2cczJSud3cy1AP6alXg8HjZFRwu7mXuVehHnKdjFJuN/cy1EOhU7eKqQ+kEsD4+T5Itpu9yrahekxPHVqqpe+hHQH34J52/y7iDV1OSH1yrz1Z8ItoIx7Pfoj4Y0o4Wu6fJOT+U+4/N/sD+08uv4RG9H/B/pf7T7n/kvtvzf5g+78PFuCNzkscwvf32Obv5JFx3RIzbwCY8tcAhnLbp73pTPnBulFgYRnL8ZvFFhqv6wsBdVVe6j3DOlR3NECf7xiEQgFLbD3fNBw6/Q0nz/T2g2eKyT5YqDyfEkqw/fYpyZQ5EwJsPw/Eq5jasUKos55eUvnn4kIJtl8S9inZUFoIsP08SH5VBKCYTQk8iMzY/+ywOgQqtlX8UswyY//zAI8VgcilejjmGw/QLejhdIhlFgJEsMP2oTIUHswQUlwQtIaBpVIAVmd1j81WTOnYO6A1tetaZaeL4Tt/Pe0pzt6Za+hwyZDjcnuWvWklUMU9U5Ud/m+u/kyed52v/f6D6GfUIoShjj6HmXI5hgKAdmE0ZN/BknbCPx/BjAYAz6YxnwOAF/8fvxnrusotewgPjQgNAAAFWpUoRS8ojH7nVaIaBaH6lxsfGIuv7ZxhCHLGrL2jtaFqyeoaREYMRhZaHx02SVEOOLDwQUOi1dqRI2fIJYIwpmWxdfcDatxEWygwWIg9caYwW0AaSa+HStjkYKMpU9fdX2M+EI1jC0ciCehB85YYosyRmM0GHvF4LA40CBmd0enWWGVSycCAAgKBRNBiV9JQA3yLAxpSE5gxchCE/WbW6WOFfW3Cn2+yL+tQvjBJZ9RO8ti3bpgZvc7Vd/kAe+/iolCMJZvh1cGzYOZekQ3ko0E3nhjgbQ67Ig9mEurgWcAIcawMAo0u8SDP/OpQqLgNbOJe3xaAsWO8o4v5zORG/MqSDDYbXUZh/ZpxrERlR6vOGP3ssi/dbiddS7oVXZsxnUTi4HGX23YRnOYOQ7xnkJesYZXMZyarWcsBVlR2cr90dDMYm5i/feygn828c1VwyZOUjSTioBqarLN47fDK46OEiXapLqVtqxQmDoVil0PDO+cwAoNyWH6xOBwknQ6Pll1nvQXkl1weqPQCgHwAhxJggUMj+9phaF11WNJwHA4jhQ5PnGl/chYtev52fIFShHz9JIBKphgBF1sPQIiRj6JZ33Dm14GcYiXiC4wZRzPpNdYuom872Hcb9PhvKJL/xqaTlzPxH6g9y/L5nTcHKoAHn8fHnnfX28ECHr43+UsJzkEM7PPsTr5uVYk0s1mUo/KsymGB8NwDdXh5nLW/8bP3gQl8z1ucAmB4snAzINLHFZsxeoZB8Yy1W/0J1Mnyq//Mcvm5PuFHB6YkUjJejRSEScxw0yG+ZvGr3fhydMe6C85/QPVmTE7Hn/Ov4/0ZJoIGYx/kfZ0lOF1G9beOOINp6/afI/JCgiCj8OaDyhcNvaWqyPb/qwIF4eDi4RMQEhELJhFCSkZOQUlFLZRGmHARIkXRihYjVpx4CRIlSaajZ2BkksLMwsrGzsHJxS1VmnQeGTJlyZYjV558BQoVKVaiVFkwsN0ss520xqg5lliozx47goUFHptppd/9YbG15jnvud9sstdf/vS3bQ646rKDylVYptJ1Va645pYbbhr0XrUht91xSI1fLffAPffV+sFP5qtXp0GTRs22aNGmVbsOXTp1G+d74000wSRTTHbUVlP1mGa6H/3smGGHfREcCg8PPfPojXievXj15t1HC0sbW7u+trZvrmG0z2wOM0bSorC0X0jLYH+DAquopKyiqqauoamlraOrp29gaGRsYmpmbmFpZW1ja2fv4Ojk7OLqZmNrZ+/g6PS0pNQjeZp+yaa7XNp3qY9tadelzWYyl6WsZFe1TwtTVN+5yNWN7QrvOK6n28p+LkrLCXfj2uMid5IMvqUut+7eiHyeVLsB1DYBjyq+h72OJPdTrZtZ7VeqLdDmwTJllM6YCm1vNwjtPDdcLHs0s8Dv2yD00NhDEaCRQs8VCg89D9AoQKHQ8/BSWauUlaxlI1vZyV7uMpOHPOUl76/nyiT8ljqXuJEmqDz53cWasWXuL3V2VS0hx8Qf2DVFUaSaXRjoQPFm+xN2l3/JAFUr1c6L9dwaPqDDN3uZPzmtJQgo6BcjZKmvhS4IAAA=) format('woff2');
+}
+
+@font-face {
+  font-family: "Arial Plus";
+  unicode-range: U+221e;
+  font-style: italic;
+  font-weight: 400;
+  src: local("DejaVu Math TeX Gyre");
+}
+
+@font-face {
+  font-family: "Arial Plus";
+  unicode-range: U+30;
+  font-style: italic;
+  font-weight: 700;
+  src: local(IBM Plex Mono Bold Italic), local(IBMPlexMono-BoldItalic), url(data:font/woff2;base64,d09GMgABAAAAAC6cAA4AAAAAbMgAAC5CAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGnQbiVYchmYGYACEKhEQCoGiaP5SC4Q2AAE2AiQDiGgEIAWGBgeKABuDVxXc9d0OpMjPyzuehcDGocfMcEUUFZTi4v9PCVKOULO5hPI0tooTgXFdDikehp2SMPqMNRZy8feLPPzQlE7lpGbLz+UJRlMbSfUcpzyFtqfJvYjbG2H5Id9MW28kTHKElj7i/YGfW2+djI3BXzLGio3oJQMWLKgSRk6ipBRMFOP0wMw7o68xLqy8O6uuQr0MoZDB3f2zaUJVsiLYGCXZlJBVT0St/dtzj/wHUowSKECa9H8yqAgskGIVx+VZmNh40rGRWVubxdNk6s+AIRHAtTT/S9W8s/P/WEdAtLNy61TnOqS3+5YEThAPmoFm4C6GdtHiDIi4EFPrKkSOODin0yQPrH//G/epk3A3dlMXZtyOIFm6dEAtbz+3HLipbCVJ0RXojr7tTXxSl0qrdN1s/o/cEKLhGjfEY7fySlsQSf8mmtxzZhll1o4SC4UTbGC+gaVbZu837whI4jGqtic88P/9pfzf2XT6aMuQflMbyE4Ao+3NYlCDsQQwgMHGw+NYavNEChJIlaNMz6qWc7lfxrHwTE5NuCk1OaX2fza1dtYr2UpYhy6T6nJdrugmrAPAplrNn5V3Z71WtLYca9eyE8khh1jJvScKyQHm6o4VOUB4BNABloRVc21JXF5RNlwNpKNjzMZ6HxN/Fv35Zo6Q0jmLzVnn6K+Vvyfpi7jh3cG7aqrRcf4HUACoABq0QaOTy4LikAfFxQOlQDWUceNQNtgAZY89UI45BuWUU1Au+RDG176BChVFB0x4CsAk0khQsABWNAXU42Q2QZh9D08RcPeGetoAOV3X1wEak+aK6Tiii6rrEojiezQ8utqhMLWPzENQOeVyULkAlUG9Fh36DJtjoWUmrbPFLvsc8ZYTTrngmpvu+8RXnvrZn/4PFkVGMeUbpVSVOhNN16JTj0HLrLHBsF32OwtUcNaFfTDF1HMCEV1SAzB01U+1cOCBAi0SM90BDbSnGOWDvP1X8z/Z4tKc80qXUfGnpwuDE4bDPQhEOkpDaz61H2sVEDOUS95DI5IzAUiShTnRYiR3iD4MQhSrpphWa52vn6iHmnxIoouP1m2MUR/wGj5UicK69JtlnnHLrbLBNq864DXveNeZyZnd9tBn03s896u/A6gmiopiKzBauWoNJpupzTwLLLLCaTbZZo+DjrrAJb7sGjeBSk+OgUq7YoYvJ5hHh+8H4zbnumccmvx0Rb3vlM/vNfUzmAC2RQ8aq8Iopeaewi3gJJT2aCUQ0oCPIIX4qaMai84JqwHyAg3ZFIXVW90YGm29EiBzEHI+USTvmSgubmI+JWKUqRa7pkGLDj0GJaxjbhmhYVxyHaxtwK9JaEiSZbLVPKVAkQrTNGnTY/D3H4UC6HrY8WMN1m0nLrOOV6Wkc0cF1RQnNgM7ROI+ddzet70LkHZHZzuofvBGAOjOzmjvgcRtYT1IB5OKWhtSYwUDKr35AARMAgiNRJkcUABQMlmNLfCgzjPNOGmGVO8x87Aq0/I0LbP44AFVOUjSW0QYNUnHzVO0q6FNQ5dCbZfZcc2lyibBAYBI9fAz9HC+Czp5z1Giw23AKdb1nEZzJLDTbmjc4uUpdRrl9NMVL8v/DDy2NzxOlEarYJJSM0pn4xJUoV5Yj2HzLDFpQyiAwRaleYIwwibyBH6ETegJ7AhbpCcNyBFBYERgtEXAk/Y/Gh+etNloPHhyhkW28pA0KLmMihfm+cXydvBPfNGUdJJDdDYTAy2R0THHmTyni348DIabMa+4ECTRTApcY3+vCSeKqGSuiUwmTbG4ePgiCAhJ4w70JDKiAPBPPWjsqbhTvglPvhEKePke3kGOh63KcgIcQN/5+vYr7iAuKamhIUknEpqi6uLQGOhT5wDNFojn4YbL3/EiqO2AtBuL+v8vwAbF+QDqCQCArqOPAYDAAEBWlE2qPGopqLA8NkQ/qCGdc20C0Ix6gSILcyLn8rAkjOyiRExIOuJA+pADEqlkpZT34gUMrIht1mCOW+8XDuMgRiTNOiFlX3uW3/b5Tm1i3X/0fwAA/nsPPnn9c9fPjT/bPkl6YgEAACqKg1UoumddhjWPh7tQ8aJLLnuvuMpo95rrPvKxV/GGm241u+2Ou0q9pzz3fT4aX/jSa/EVQDWrQTf6JIIDQjXH1HF4wlGl4/jScabpf1kkEqlMrlDGquLU8RqtTm9IMJoSk5JTUtPSMzKzss0Wq83uyHHm5uW73B5vgc8fCBbCwjr64SjNdq3l6+Md9/bnX3vP0PjYxNTk9Oz83MLi8tLK6vrmxtbO9sH+ocu+Cz3txtZ7g9u7pn/WH4bx59ALmi8CAEDbNdjzcW6oAwCg/fr9+nlja0+f+ejj23du3JzygSe/Hj0GgKEfd2HBvfkvLVnx8sTy1Wtg1cvNG0+dv9gNcOEKAAAKBhEZE668cAYAqAEAAL0KoOYB/kMA8Z8EYB8A6O9AZ8noOm9g1mlhXx0ZKjrCMEYCHTRAxVARYEZXL4pDB0V7Qhl1nQQPoQ5BoxS3Z0WiPMKiL6KeRtlARQTpgshGlMQajZ0YFRG7Mq2bQ1SocqIywFJo14ksSkUassgZ0TcVNXRYwZC+xt9gIh/M/cAXJZo6GVsh5zI2bm5CWbh3MjRpSNSAtCQkCuu4FUKySTIwzPGc2aa+ZUWWtCA8DRsxwHFIYcl6N7SivYp2TW2oHcBiiF1HtMKbRRf1Tv30x+Q9wuajbi4DKNEFgLpOO/UVaUwqTI0F1SE1I+pcQ/RkZ4xN+peE7z0QUI7jiiI3qzwmClQcg+44CKYUuC0bGoQ2y2aULlNEYRorQ0OHqAZ04ZPdhCfkoFgn01LwXCsmyPzmw93m/qhwVADBgAhy7+PqQEXoHEOoYUuaSaWAIrhlxG47A3mORnDVCeEGFb85AnBa8UTicADkhaZD8p+BB69qn36BnpiZge87t3BZHZ1QvcZyK9yVQZIioam0CryqF7B3xwbqI1PLmiDpmR2Gy1XtimFx0UGujtZc5GCLlofT87I7OqplzG1CyQwIaNuTGyYpuCOjKVXPX/idWqR/UE0BV6JI9ZHTzNX0c8STL39naW40sovHV0+Jy3BPpZYKWgge6CzaUYFUL6SBbVf1ypfO+wLtO/26jkkWtJhMj5tIPbYI+yZkh9wcUBs6EbCNACFn/RgXAMfdCD+aChw1UzwakbUVlpfltoyMthYzC4K7ULgCKt4Epqz9XMhrjcS7M/594HpcRa4aX3LjINnTkcRzFFeYSGBoGLFUX5+F7tZUvoqgPd6/btHDqyk64/YZMenLKXTcXWpqSNuTm7qCE3L3plNJLzG5rSpQugQXfwKhweZ9vjHYax9a0TRF3IN7j60pDLpZ+7Y5oy1bl6B/6SlutpiwuQ7t3CDZmSBxPFZ1+Qs3WGA9rkFKg0+V4C0/qOXF1smZ5dbm5Q3X76cWTOmiwpeQzBpxPpvMrNmDbTNeKGeDW2YZFNj1xbYK/u8XqvbvtUPxuHrMt1hmP0FatueaQs9vIHMLpNJda+I1fyJtAU60jjZrnzwrNy8FBWn9lyR2PXWkkR2TxlxMtUTJXmur86dhp7RY6MMmYc2NKceS5RUYRIikEVeQL6RDOzuoeL7l4+RFWdXvCUvxkqvXVDPpVNJYu6fjK98vkj4i2+W7pRolcH4jUjeGU6W5ZgYl9ZHAjdUqldQlP5TGZ2znzJAUyDcICBLt4R00ApCicPFlASM2fJ2jZyPbJoZ96+RmZqLcpTNvO1KHMhLWJoLgVkIXRornfoxI5wQBu2TIANhG2I0StGWSCx9F5avB6W0vj5NU/XSK5LcC1qcrp7qmQ6tMdVNz9dB85BBA0fKj4pwAp2eklsl4huPV/tuAiVhGNNgw9jsDyRTjb/Wb6uuImguLkXiX6hA8lqNUnfA7F/7wo3LGNyREbgPp5IMbo1b92rnMA8aauOabkE2bVbffH99XqT8FtuMVdxVIUcduS60A/xly493IAvbqYyiFjA5X8OVlD/ePg+zZ4IHWSWcd3KBwoNaxXQzun97XQVqSLIba5Iq5o+v9Yz970nqgZiBqbFn7/ZDHoOwd+b5DOzCR2P5uUawkv7WqBZbIUz/XEz1eJ4yEsTas/HMpTKxEeU4jFcJ1hQeWw9Ec0eZJ1s5b65tK3+ulIoZkU9M+vxHsQgqNF6Mu/6FaUI7OAl8NccYmm9Jv1zq2oyyGEu3Ds5DXC3Qza/IRn0aHbNJIXsLdlMSDhOpToRfiJduK9nh+GzdBFMIVxvye0PyTvNE7kaGX3kBywTVII2/GC6FOHDT6vSJ1ycl5KSN3AMdqjSiJpGsttfB9J7J81kCeQn+tQk93/PdoKcSe0cYCPOhbESzCyrm1Sj6Smqz4w5POzkadXCTI36MxSHMpSU4F1d5JHA8ZysLKJ/sc/gIm8ZTbFGTYsJtf8XqB447lVvinar5K2mLJ1WxTmRuSZaq5acxzh7ph7eXxu3NIjZuD4x2w3VHQC3MMdv7CDcVRClTZhPbdu1HEzEBHnw7pbVKOFca6WBUWp3+RGii/bLUhJQlPxYYd6Hx6tg6ggxvi7AhyM5lAhDuTP1ADttetIW5JnEw4rvWZGeYkss03R/byt0p6PD/Pn1FaMvqmtTI4wPVNUuXWmL18o+mBDpOk30HkSSHIbTomSw2S3fy6rUOu61aA1ICKhQWenyAf3BH+/pzvNRxwTsJ9tgfJy4NGqkXOxaqGxSxLiRKu6gR6+hN+kp3eFiujnyWP9Kplm28qgNj9p/K7BclzQp00kKvEea9YoC4qZAfHPQaIG2xZXNipC3ewtEmniSs6wv0c7Y1Ub2mx1eb9zg4Sbwt39Wn4xUVh82+oflZGjJbuX7JIccpZRCmEHaqq0AqMC2PdthZKelcSOpxzTDE7psa7VP9lEul+PbyJACnC7jm4g6uCAinzpIK2lgITGx8uuo5PibJ1HWj69d6cSE9T9mqUBq8OI0QCZRWgawL0lwT8uipbneVvWkLTXhCgDOMyuPJ13jkzyJLzeoUmd2XCFwtGNL4Mv0dr9wcMUlbNjS+x5m4fSBjAHBpN6xAEApG7lVflpfpMl+nJPGdQIrkhGjpzfhh8bTMjtyFqfPHrNCgjsh3O9/PBspFapu+E0aXV3hh5CRiofpyFboXv+KYh51nZLjorR9IpK0eLXP2oJcuW2WPcoOvYliKJRSHvBOzLdL6WXDIpHgM2qib8Sp/sAbhDCIxcpSKZrlZdtHNhWowqH/keykqIueaaZMnY+NRs8y1xb7UL60ZRIarCk/V8YrsgwrqwOo3JzDDSgZxJ7jWtzKJbfS6sARAU8IBf27aEmXXYCcEHfRyy0+K4kN3PCe231su7CkgKbZYytJ+FAlz+lBiFmrcqmKv5ESn3GuAbQ/3h5W79XiWX4sug4dkTMAiO4mJ027XOTeQXqsaMruOaGQqZ/s+9JenBUHteMvow2gFNwVLj7a95V73UZmMmy3q4CYfH2caIQfow3mA/S8Q7PM1itaxdlm9v1txtT+ImyltkyNomC1wltnl4WE9eBli95M+bRcnN3hm88LX7Ombhup6l6ctQ45LxIY2grslY08lPJTXj4LlIM5rZyJa5wJPFjL34NeciqXUMN/bSZmgKTkPhmUV++jeFXk6k31k4OFZBEXg2T0DZumzr4Eavx/ITAG0kvBMyN37leXyF7Lm7Mz7u0uPYEnfoZU86X3u+guwNx8wAy4hUHrBNuRmVua5efuOoFyECgB0xJmRajIMk42ZQaSbQu/gwM7Fdc1wHjaQKN756olG/pBCV5FFyiL3VD0WQnxpsWTfgUIjLg+xJ7YGalCWdl30BsiRinYJvO/gZPn6DsffIvZyL/9CR/Oh13t2r9yBJ+sQiT5gNis50P4u8VfPxn0SseNIij5T+JQnfWB17a1TtsYFrum+EdChFuc+fn9JYHlLpSwRNyAeMUOIiS1tOKgqhpqYSr+5A6qa8gxN6yuMyC/WIb8f9XUV7w5M+wF8Ru7OzdCB9IDb8n08Lj69ZlPQmmD3zMh8nMba9mpvjuAXoG7by9xjHYrt7dUP/TVOIUlmCn06pf9IK09OnWejNYohUysTnFZle8m/kRw2Oww3+x6G4wZQ4pvegR6qNGCAG3FcPJzBnVh5b9PxV63btIsfADne78lEhB6wq3brP10GNlVZ/ac2sq0qoJtTVrLrk5lpZV7MozWpLSosbMDf5+IDfoRxmw7Pd1RefW1oRtThKKutqXUfsiDzztluhZwhGfhVnps5CeJI17RZRBe80tZu1EnMDhG4jVAH19ZDf4Qfqz+af1qXtkku1/1j+1y8Q4tnJPqHRbDwOtJ3qYE2fG105fe5o1Haq9/lU75E5hi3tZoKP8FZiKGl9eeW0HEVpzMmkbbr5NaMDnURmUxerTejVTassxx88H3XwhotfGcxNiAk8LFOuTnnHYhtF9//mV55/6Vi24OF3kdtL2HAsaHN6HcbI4N8ORJ1QLFIc86oPn5gkx5u0viVZFrCe2XkhvvNsXXQIvUEx/hcKWEcx+yortVz/w1yF9DDNjiiEVrNblKCyCB5FWmILGzuqmbkXMPaaQLre//4qFdeM3rMOP9teRBwlSYXY+tQ9Sb13q+kRJBJyY+o76ZUY5Plt1fK2QomQLsICbkuSY16SA/Y+L9Ru8Cxsah9bUVxT5qo3Tl/EqJGImAmR9fGVKb5H8x8l+ZTT+O1wenb+OJtiax3jqzdnJneoHPHR0X7djmZyu9+wlC5vc5SuhitZ0e8c5vQe0tIopCMuOhwfPj5w/C17Nyz5jr80C4uD/ynGNVGMQl9nyl2rAIvFmHkL1eYCjzLSt3ykRLrTPdrvKTJXyDMconoz+bILe6Rf0zjWMHc0WcJK+s4YLKbgWMxuNlmS/KfEWwfQcwaOe2+S9kyVus4/+KbWulp+5wH8ylv07zHCt7+xMiyVGLM7LrLz+1DP7ASuwWLVB4Sm9sFwmTY6N9USMMtXT3eA4pWsxS4BmSDhqdUuOTVQ2ZL60MXQJQb5+/9V5pRUeJjYIXu+OUEezM1sleQk+Xi7Oo+1emItCRlJJ1qwNIK8Re/mzgQ1byydN7fm6Ouu98vZPeW8MemfJ3QCIqSn2k2Pid/+2RYtiXNESqJydSZ5Xb63Q5efFuTvmnasz/Wb1ZSc+u0sCV8l0qpfjpnBqFxyGFiUvqHZbZ6kZeVDPaGPbzjjewJlhZYyac/p3/5bJSqr6AOBMz5JUZfvaotP7zV90S1hGPQGPGCgw2f5lDs6qvrj92SOIxWolKGZ9b788uYCFv5IgiNREZ1nTWuQ5XR0VLrNnjJ7BL4g05UWJ/PnmsNKa3fy+y1iKlFGMFwvpjExYWaLhIZ8oYUBvnsVrKw3dOpGjro3eJC5zGgTZ3kmp8fnppchJ6NL2K+4ufH+p/zFN76IWG7bRKBv5s0DXyun9yGnF/VlrC441tjDFsamD5zxL/iLb34FZ78VrC3ClGvHBCy09FOpsvq37sTru6e8AmNjT6hEh7gWeWSvUJzh31YwPzlXdg0s7F2+TE9uGqHm6me5q8JJruSAuFjo1lIE4szp3bQAVoWJTdP5XBn8kDr/gkJ534ENRkWQMg4nyl4lKUJUD3ckOYrlzykKDqedZHYtGU7x0IpSukUIa9ZsHAPoWBO8zNxzxrFno3HqmnvqtIrUTlgGa6eeVdaW5k++LMOG062pCYjvbll0Cv1Zs3GiJUUgw8tGtEHkXDguqWZWCpZNkO5TWWLeAwllZt+ykSbt7sKBfqsrvUg8I8qtWR4lWOxFRNnWOlohq01iFyQ9SBH0vKh1owpV3WgTvDR1tX94/khz/M6i7pGMwOdf9tndHpqfOyKR0btarZ7roOybepczpBFuj9apMaK98SQFXUOZSHiXEhpkMNZAOveO7oPokvq5s0Oqff6Zg05/sk9cInZrlot4iwvQwrTsWpqf2SixcJOuGZIyrLNmz2S2/J/VOx+Wyd8wyFf1Tq3Sid44SbwjQFjta32P1jLjFHYcnFPBH2S3HrWG21ClSyJF6QaVvjur+zvOECCRgYqYd42Xl6Amdo7P334Ik7Rh/i4w2Z5asy5vnaeSY8+Q3m3KaSIJzpiS5/RN7dU/JY083cOO5sDTG2TvjbkF2a/5sRLgU8yVsgy7qC6rXPrKCiYc+RKDA+b0aloxZ6BQnjhlID4HQdE39a/OKfxJYFdlSmss1kpZ2oD6ReJAgYk3y4ulEaUebQGsvqLcQahaWsUsHgvbeYMqEE6kDpaVfJgU+KWo0O34tVT36dkVqaVmvTl5jX68i6ury4a8vBr2Jg/GUt+b/Mv0FAlDtkVRKLkEFErpeMrPVdVfVyv1aa8aZNPWOxhupqPKmigvzMkIxWS7h0yPppV1OqTalIA62ve9lTkhX5YsL8s1N0thn7nWvOqVeokzpPq6AvZU3psuGUWZq5OsGrsVyD+20rmXkoO0ZuZOk7mzi4QIzxEvLPPZ18A629SWiBriFZL3yqKaHXFTQM6fmq3fzlxBGl2/CLeeJFxctXtoy9S79LnkvrmgfMWwRNJOsrZPW7LzRQv/q8oOpJOY0+nt2PE0CO+ofps8vcWwM3qc5B0P7XxF+b7qT/jnl2TuvJMGztAT7md97TBjMSk0z8Kou9x38jKzDvIXk1fOG1DDw69/pD9qL71obcrZpHbT/4s3LVgMlHc5/Q84/fDadzPTPadLlPAGJa6KS3Pr3THDGaUlhuSM8R0ERu2kfV0SK+xOWzQjCvfskxAnpku4HnfwdR8t2ELRp2Rv2Cjg0+UTsOLzydQK3DOYL5PELU1k5mu9kllZZSWG5KxvpHzQkLzFIJCG/UApWs8/+XExX4KmA5MSbu9usSn6ckvDxpzy6lxyf8rhYk387rGNgkiqao6R+RZhyc6K9HVZ9/N50DFs5xISzZPDn09WNZTgNFj9tgYBpbe9rzkvfkZBYac2J9bBMt6Ux2x2Gcel7RgcAat+kMSLxUJaRXrmZ2+5efQ3DPZUmk3rwBSwmjdSE+HADdHR2sz4JSFH06I3As92srt3Ur1kS7E/8Bq7+xir/Ri7+7j7HK2w0AVPbuSFxO0l5bPOy6KOS2aO0svwj6DXJFFvLmbmxTtjZmQWleiSzXd3EBm1k74n3JFlQwVe0SD35A+FZFuhNyE1zT7WKohgSp7Dyna9ga95crOVuYLfovneQi170iAXezjk4o/CLGEp/tAXPg11EoK5WpsQx5T4jmrjn9vFhdlZlhSWuSb21iZ2t8GzHrt0uc+ZmaMqS4M7N6I/HpsR+ink6NpwJvjTSXa3r1LFqA74iaGo4jSYdOWaxa8v9tgsOU5TXnl5SWRc+2cBX44j5We7XGUoZiSMl0dWZRiEeoQTbPtseWHF/DRKdoYT5f1vrjtDfN/QF9cmtRjTTy/HUwfjVDtsuLG++z5B2TRWqiQ91J9aJOCR2V/QaW07lu9wmVKS3wQpSjFl+uvbtouT7BBZjJnkDLfNSwUiJdzb3+xSz/AEwvFW4qkltRkujlG9AiVJ9zTO1yBcfFRjbKYJsZNSzSiGcRndyJ95/+XJDA3+Epi0TfSzu4nCjfiY/LqARxo5URmH42+ccCm/BxSloEu9LuCv8UTrtJ4o3scN+YyzMr9PGi+1PS3mG3PalRO+AM4u1sR+H8Xb1udhWmj5WeZ4mc2qqxIAj2LLzEmna5LlDxawuwsRkpUzNC5+8xK7+5I+JnnjcG7g9b9Tv3sIra15EjKx93/IyWLMJIgxlp1v/2hNUTlYBXFSlu3fufqtgooUb9r82mnDKVZLtjWNpZJKvyxnd8N0ivFyAj0vJcnen5kXISIxP2YxFmwPH2bqk7qTvBHxBPpZFjtDmMesMcmI9vFG8fdsn6lCt3benz61WmRtX4QjyNqhlWJKz81hA7GXRon/isfalH1/JD2CiiW/Ma8i0+9MrLJLFMmmXBuDwAtacxIS0t3ZDAGhl8ZU4rlCIidIqFHSCeQ3x6oyPZq7PpnCkOb0E7gBhwPuLqTzPcEaHqUVt8VFqFGTWrY77p+F9dqAzRS5h76gwWSk5I1wBsz/nWMhQn98G6m0tMqtr5eZWEXp92g76rT8gLi0SP4d9WqEQIzGQk9zedr7SGTWzelSnFwpw862pduPMuveLswkRl55fXuaUG9JdxAiGin57PeErcdlXxd3vc2oO5IhVuA19Xk4b8m+9f8xEkLlcGBtL89Sw8JmnOxxKseUbl4vRF6TsPiA6tNGWxdXK5vdxN0uDdI+k9/EgeVvSi7V/ptE+dcZCJmyx/i3iDs4L9MfLstC2rOLK1PeYjZ3sdqWOcxXOrQzRptNaU6iudikslZ57CRmSxeYkOolpmThVNtmEQ/uUGQe9ra1aZTACG8ZJ82SiCNipzMbXIiTm6gqzcmqlSZ7w9Z/u50oudL4dwbbYjjKbHiJGKv5M/lp/gFmWX3k5h0bBREPtveCOJw06m+tzizp+eoPN4pA3Kf0ndCGm1Pjm2YaE5dnJ1wa16Le2zOmZyiH5HELQt9QUHTuZYT2sDtnj8xYU2Ykvmfc+teMOew0tLflx4BfkdE861XhVmRG06yPM+A6TR3lmFcoSknvkuR4S8udUcrYldH8xz9mCex8sy0u0+7OZ0elI3Y5e6lJV/gPluXxJ99QjkXqS4Trvjh6BE4vdhk0fuxD9PoBnZVWq3TkKZptRaalFaHRFHdazZii3KKcpMRySU62vmRBSyJFww/SvYoUlBmUP5Fdfnd5hVsb7e9wybV2W/rTcpXzilDc4CFbcCR8xEmR0HvLr379i6UItBdtIcY48w3vacxV2eVpEiwRF/FHFDLO+d2Vr8iy+ZJTCAyB4vN565FieQQRzdoWIRrKD0N3csx7xZzeKyYTJJXL3ppaooiLzi9xIRripZS6YnZn+q0bxBJCYoo923/Xv54a/U4V8jBCODclypLl5H8tlOGwKCZfMApvXE1gNiZAToHy2yujcg3iWuiJ1mAhsqqIwOY7EchLstNyl18In74levWIXNDS6EyO0QXJcr91QPUIPpMXSStcXNnnRT4XYfFYVhcr8qQ/GB3hTM1M96Yl6S3mufbYneCMR3YIsDgMfQWXa1dW7rdGJ5hzjPExc+6gbXSLMWj3ZFrjHtsN80li3k8SLA4TnaCiesCWVqztOdmdAcTzA5cnjXoZy2XhrcF8GJeqj1nzvt9yevEVdoeJy3wHj5vHqAf4TWUXIlFObVp8bZ6jRmnSE2/4+oYe5g497APltbMH+z3qhnbfx/LBj4WckwzKrvl1sc326CKZkyuaJYkozNfA5TyqOyC5VKAQOwdSGw1y70sAs8frD+SaogIVnhhDwlIVbsnVwo1YMi46BvGHh18+OIwsevJgcyIFAlXEKmNZpj0t2Xte5kxtZbVvEr8+oVMnYo5vfDZlnmB3RlFiBnR4j9o2QlHe2VhM+Kfr5EXViEwBY5a6npYI/rNMOxWqG20hhxb3HQQuC+Ie7FnhLt0/0b+8xt+/wijvKtmHVqwJ+JTKGc6q0tTyvofUPPVBSaSM+PvSEDkJ9b1pk86cXbOm58TcrOlZlxEkfVOrOEPNx0Bn5o3F/fdjx6oNHioO+JaxO1eyO12slr2XbDRX0JkRV+7NbIu2OdmdaWarujuZilPOTROwO18++KZtJbRTEq3mnOL2+kZVq4QmPhghKvrYp42yFJhSNVZpJcaYE59gznVliNKmhZACEIoFpNgTUSLS9QqlyBowm0XUyqVm7H1bGq0sg9nYJVaxGsQMtHDM3oo8IlsJfvPvj1iCcShh7IEflWbtrDX8VfFNqA/aWVFGrOqs3Y+/0+HGovPJE9U12sXB8h51TltPb4NF0WYtqIhPSnMYqb3V8aWCxuSlFfqneaaFT/bU7asxThcUmmxZG8YktHhyvG5A5u/L45Lod9XZEXi52PWm9m7A7LGU9oBdUjbh2OlbQH+hP2DPvMtkPcRSsBL0e+dqg9aEqSR6BNONdwEHMY6yr/3SeZ3hsVl1qm2BvhFLcSKrfeOYv5e+7yY4PB56OW9eobC/jQDLKdqbd3Fu9e0VQktBWcgnmptU6TUa1X3bsX6HQhtjMmaLouLrQogPJRQLKMrLYuHwuxXKTUUOdU2UeQN/sZyNzI3QcwRY0nDHJYbEB8h2fC76h1j+28DnCMsSb2+Cc9Q61e3NEGliTd/sTm3tGevJSV2/GRIVop+RLKFs38XzMizuTmS+8HKyREpUxQcvHxb4IqiEVA2XdTwq1lZxU0XtIWBXClaq6yJjjuQnWZ2ShKphEF2Mex6BQ8Qus/o+F7J+PeyUUeSCe9/5+fR2xwnI+fzESUcbfHngxAl7O0g3FTzQEQiuDQVOf7gk+Er2iIdjSlx1Sq93N9M7AHfLB2sXDtaCR713N2/ura3KyrXLWhfDtoWxrPSStEBImQo/jg/vrLv7qxnceWTHXmrgxL0OxedaSq6W7EjAEJr6K8BEmT17cn5Dwo6KvlGzV5/Hqa++O8MZ4ytLdmalPKGXf0HJ/YJe/lhwIE1tUZytdCVdmpPLgbZ1is+dmz7ZlKP4vFKPVEh68N6eYj2Sx6jjV2GbJkwTWEIVow6Et32+45UGjG/L8BaMz1B53Od7/hwyP7uny8eXTThHcZfYs6rnVozUJmGpeMnbJv1HB/Jdn742bGeoTIXcYy/UTLNML1lGr8AFChKhVv1N4cZibUGWiIITpBwNXvHgSUljd6ZrWCfJtk64vYPZ2IGch7wGR5Y9I45VMHJLoy9tq/hE4UYBjRiRG3m1JJmffpyIIWAF3zP8Pyxw63BJzHtBZWVHYk08yU12/AUX3hzwLflIjMWh6V1M/r877WKM1ZiReStWOBg47vnqVbIND7aG5LP/v9dxxcI5YiwRw/hQIDoUI35ZjMVhqDXciDH00UuPtOk2nRJ5WoSRfiXS+zMguHc9JX/n2bD0Y80mzZYizkzuCK55BOwNMcd+jq22xfrfForuSrB4DKuewxpe7yRo3v+a4jggaCJc7EQ0EwnCgp75kNdg/jtNLrLeO/zJrICuzksN5H7su8RVWNVR5vrQQ8FgsoCIYbEiru5AWD1QT7bl8xbgKHmrcdPA2pBlNcTKKaWY0mtCNkYskWUelCMnCJg1iFhbkKW8JGgQYwlYei33SkMvA0fK4CIfLoQdKHOf45RVbyDsI5UZWlTcQB3lesexXOY6jvG4o+dnH2cE3HFJxR25nHq843B99CU/gfrjgtimD9rS6OadeoRk16rjsY/Qz3vAzV/Qn+J436fomXiXdqNrF3mw6eceBnneXyt87epf+ZtH6/MNmnjsQ7QXLJ/v53opnNXnGIeP5Bzf/Bx74/URYV8/tYEZc+iVIy123O3SHUe/ur3n1dktZfQaziD5CcNf2D48sHROLm+OYUZuUavROrN/yVyqX3yIn9ApAPY4kB/DbAL5PGFhkVvak5JiVsko8eiRgCOYD9hNYLY2AY/LKBLa4wvK+n2ZbozDE+OJ/GmNLPPvRT0zEMjJx2mi2I8AZ+EcnIEzeS6vsmG/cBbO4Zm8xob9xlk4h2P6mvAtmk9QGBze2A/7qnAWzsEZPJNPtWE/cRbO4Zl8ZknWPclxArAP4P34efwiHuYv8Hk29hm8Hz/Ph/lTNvYOvB8/z4f5QMmLgz0GLeJBPEiBX+TDfJmNfRzvx8/zYb7Kpn8JhVtntsD+30Ez95svmru5MDHUbtynDrzhpZI3b1tvmtNkAm6VmbLarSsM5cHSZHlwYWRNeDL9zX/EfJoVyQD7KxKq/azaz6v83vx3NX4Ij6L/gfnfaj+r9g/V/qnK75P+a44FeC/XJg7h2+3F1pv5SXMrGzMeAEz5EYC12RpdvmBn+dXDYUBTadWWbxJfpfmbpb7PEweIMZHiMpXbAPpVjsH6/h6ceLIfHrjb4wfu7wruEGVZn6Ic0al+CPNx6woQ6TjCwXxcAMc1juUY5La5YPLya/z9EObjKSu4hJMK90PzcYEVCwD6JaccUUqVMLFs8iXAaiN1eGWVOFBdlqzP5hwjiq0SJpadRiSAHA9OGwYmFoCKcgYuO4wysezQ8UXjEUXISjaeDAKt7FTS2Y3GtfFzO9rpUFo4Xl1bpaB7dcnO1qlevqCcaN7L2C9rTRQHhVOR/MHvd3+jV94nARGMoheLzL4NQQFAO7Pz7U/DOSPzF1Iw3wAAj9Yw/wGAT/49OPyieJqcPDSDQYQGAIAC8zy40CdzUOy0NGB6CUANpAwE8ExtROxJa3f34oPtXiIPiq/7QEglS5OldkKR02cqfLAzuQgi00iTADWtcJIN7gEZo8hQKlpcCDFRNSH+98hDoZGh8kpQXMkVnihA1G+7mCQd3K9ep0y8Q9KIlDq4T4LmFAcsQZQai6zxEr8YptpB4pgZenKRX/dvxwjlgzggVliPKGbmiLEQxUYmWZaatMsmXAfsT88G94ccl+12pbdD9JfdjuwR1fnvgvhvQL6kxGJI5naSp6TDfYnXsAwSrG9Q4nB/4kupWMwBEdkpPmUd7jleQ+AHLvBCMpB8o8mI158uAS/GxSm1hlR6ZbnzZUM7mu4eMpgR5VZi7WR1T9jO2D4A9RAk8W5nRVYZFLC4zrtcT8L7cUxzySdOu2ipFeZakEctt8ui7ktWPriaAl6ULiHGLfje0e5M7Ra82Mm+4uWJ8H9QADVAIbxBeChPDUNeM53LvNSqIgoKzasFjeJKwYiJoGBFpq3gULKl4PFz9xmdsFLYe65OAoAKgIIitKSg8b1RMLLdLVjGpBYcfhYWPE32/U26xPyAXacuQ3q0ataiD8LIIEEKRD4bL4Rbe6aqk1OrtudTxKz1UrXxo7H2j7Uhf0sPMFMhmc2XXMon+F8NEf/1Uns4o/dPzXaCxU792jQahFieTh2KQQGd+NsaBxFvZ4dXtkWMNg1OevrUGYWtQuCTJhxfOHcJIQAjHZMM6bQH0UZa4NRKhgY+47wpwzZ5S+wTn2nLoX7ULvcS4mRoU3pGlFLSfUavViEVaYIKc05PQaPOBGE0lYdeE6bDd0mnp1dCval0BYquGkYbXZ/LzVnt+jh5wIV/xZ9CbfS2tl3C0+VzZhSiwYs/1iwjo8GLGzUws2EGZs7aVxwRCRkFFQ0dAxMLG2fGKTly+rNKJIpYtBgICSkZOQWlWCpx1OJpaOnoGSQwMkmUJFmKVGnSZciUJZuZhZWNnUMOp1x58rm4eXgV8PELCCpUpFiJUmXKVahUpVqNWtPUBQM7LTDmpDW+sdByS222165gYYn75lvpZ794yVrjTnvsJ1vs85tf/W6Hgy4675B6IS9rcFmjCy657oqrrvlWkxs+9JHDmv1owm033dLie88sFtZqunZtOmzTqVuXHr1m6NNvwHcGDRsy04hZ3rHdbO+wMJenPOcYdzjCUT2jfx5xz8C0bMf1mvE6b/E2Z3iDNznLIvab+hm8xwmFbZmQ94M6w9dDQYVTVVPX0NTS1tHV0zcwNDI2MTUzt7C0sraxtbN3cHRydnF1c/fw9BJSadcHVy5hRker4U5vrUyA74ONmXwdbALMZGazmI/JlYclGzdRiaRuMj45HG68CU6KZ2FoV1edru7vKyuRkW06Qj2ddX2kC/rB3H4FxM6ORi+rb4BWyBeMhZCRZpIVdXdrP/ug3tZBmDeX3sNlcOm9u6O1WGqJzCVIAHECAIBmAOAeAB4B3FGARwGPALijteYUtEColzlcgFTanXZDa+OvzeG0qAvN6GukQn+DWNlGutr+j5u1Ru5rbWto/KlcaWyAQhagT/AE6JnxTbkd/0gAkIx0GWK4U6mTAZJ6ZlcjNAVcoYjBqRAtHXoFxgQAAA==) format('woff2');
+}
+
+@font-face {
+  font-family: "Arial Plus";
+  unicode-range: U+221e;
+  font-style: italic;
+  font-weight: 700;
+  src: local("DejaVu Math TeX Gyre");
+}
+
+:root {
+  --page-number-style: decimal;
+  -prince-change-line-breaks-for-pagination: yes; /* see https://www.princexml.com/doc/prince-for-books/#pagination-fine-tuning */
+}
+
+@page {
+  size: A4;
+  margin-top: 28mm;
+  margin-bottom: 20mm;
+  margin-inside: 19mm;
+  margin-outside: 13mm;
+  -prince-page-fill: prefer-balance; /* see https://www.princexml.com/doc/prince-for-books/#the-property--prince-page-fill */
+
+  /* Uncomment when producing WIP versions of final standards, see https://www.princexml.com/doc/paged/#page-regions */
+  /*
+  @prince-overlay {
+    color: rgba(0,0,0,0.15);
+    content: "DRAFT";
+    font-family: Arial;
+    font-weight: bolder;
+    font-size: 200pt;
+    transform: rotate(-60deg);
+  }
+  */
+
+  @bottom-left {
+    font-family: Arial;
+  }
+
+  @bottom-right {
+    font-family: Arial;
+  }
+}
+
+@page :verso {
+  @top-left {
+    content: url('../img/ecma-header.svg');
+    padding-top: 5mm;
+  }
+
+  @bottom-left {
+    content: counter(page, var(--page-number-style));
+    font-size: 10pt;
+  }
+
+  @bottom-right {
+    content: '© Ecma International ' string(year, first);
+    font-size: 8pt;
+  }
+}
+
+@page :recto {
+  @top-right {
+    content: url('../img/ecma-header.svg');
+    padding-top: 5mm;
+  }
+
+  @bottom-left {
+    content: '© Ecma International ' string(year, first);
+    font-size: 8pt;
+  }
+
+  @bottom-right {
+    content: counter(page, var(--page-number-style));
+    font-size: 10pt;
+  }
+}
+
+@page :first, :nth(2) {
+  margin: 0;
+
+  @top-left {
+    content: none;
+  }
+
+  @top-right {
+    content: none;
+  }
+
+  @bottom-left {
+    content: none;
+  }
+
+  @bottom-right {
+    content: none;
+  }
+}
+
+@page toc, copyright, intro {
+  --page-number-style: lower-roman;
+}
+
+@page :blank {
+  @bottom-left {
+    content: none;
+  }
+
+  @bottom-right {
+    content: none;
+  }
+}
+
+@page front-cover {
+  background-image: url('../img/print-front-cover.svg');
+}
+
+@page inside-cover {
+  background-image: url('../img/print-inside-cover.svg');
+}
+
+@page front-cover, inside-cover {
+  background-color: transparent;
+  background-position: center;
+  background-repeat: no-repeat;
+  margin: 0;
+  padding: 0;
+  page-break-after: always;
+}
+
+html, body {
+  background-color: initial;
+}
+
+body {
+  font-family: 'Arial Plus', Arial, Helvetica, sans-serif, "DejaVu Math TeX Gyre", Symbola, monospace;
+  font-size: 10pt;
+  color: #000;
+  line-height: 1.15;
+}
+
+h1, h2, h3, h4, h5, h6 { -prince-bookmark-level: none } /* see https://www.princexml.com/doc/prince-output/#pdf-bookmarks */
+
+.copyright-notice + h1.title {
+  break-before: recto;
+  color: black;
+  counter-reset: page 1;
+  display: block;
+  font-size: 15pt;
+  font-family: Verdana;
+  font-weight: bold;
+  margin-bottom: 2.5ex;
+  margin-top: initial;
+}
+
+p {
+  text-align: justify;
+  text-rendering: optimizeLegibility;
+  text-wrap: pretty;
+  overflow-wrap: break-word;
+  hyphens: auto;
+  orphans: 2, -prince-prefer 3; /* see https://www.princexml.com/doc/prince-for-books/#pagination-goals */
+  widows: 2, -prince-prefer 3;
+}
+
+h1 {
+  text-wrap: balance;
+  line-height: 1.4;
+}
+
+pre:has(> code) {
+  margin: 0;
+}
+
+p + pre:has(+ p) {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+emu-alg {
+  display: block; /* Can't render block elements inside inline elements. */
+}
+
+emu-alg li {
+  orphans: 2;
+  widows: 2;
+}
+
+emu-note,
+emu-note p,
+emu-table tr,
+emu-table th,
+emu-table td,
+pre,
+h1,
+emu-production,
+emu-figure:has(> figure > img) figure,
+#metadata-block {
+  break-inside: avoid;
+  border: unset;
+}
+
+p:has(+ .math-display),
+emu-table thead,
+h1,
+figcaption,
+emu-alg > ol > li:first-child,
+emu-grammar:has(+ emu-alg),
+figcaption:has(+ emu-table) {
+  break-after: avoid-page;
+}
+
+emu-alg ol li:last-child {
+  break-before: avoid;
+  break-after: initial; /* it's okay to break after the last item in a list, even if it's also the first item in the list */
+}
+
+emu-note {
+  gap: initial;
+  justify-content: space-between;
+}
+
+emu-note .note {
+  font-size: 9pt;
+  min-width: 4.5em;
+}
+
+emu-note table td {
+  background-color: white;
+}
+
+emu-note p,
+emu-table td p {
+  text-align: left;
+  hyphens: manual;
+  overflow: hidden;
+}
+
+emu-nt, emu-t {
+  display: initial;
+}
+
+emu-production.inline {
+  text-align: left;
+}
+
+emu-production.inline emu-nt {
+  display: inline;
+}
+
+emu-intro {
+  page: intro;
+}
+
+emu-intro, emu-clause, emu-annex {
+  margin-top: 4ex;
+}
+
+emu-clause p:first-of-type {
+  orphans: 3;
+}
+
+emu-clause > p:first-of-type {
+  break-after: avoid-page;
+}
+
+emu-clause p:last-child {
+  break-after: auto;
+  margin-bottom: 0;
+}
+
+emu-clause > p:only-of-type {
+  break-after: auto;
+}
+
+emu-clause > p:first-of-type + emu-alg {
+  break-before: avoid;
+}
+
+emu-intro emu-intro, emu-clause emu-clause, emu-annex emu-annex {
+  margin-top: 3.5ex;
+}
+
+emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex,
+emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex,
+emu-intro emu-intro emu-intro emu-intro emu-intro,
+emu-clause emu-clause emu-clause emu-clause emu-clause,
+emu-annex emu-annex emu-annex emu-annex emu-annex {
+  margin-top: 3.2ex;
+}
+
+emu-intro h1, emu-clause h1 , emu-annex h1 {
+  break-after: avoid;
+  font-size: 12pt;
+  -prince-bookmark-level: 1;
+  -prince-bookmark-label: content();
+}
+
+emu-clause emu-clause h1, emu-annex emu-annex h1 {
+  -prince-bookmark-level: 2;
+  -prince-bookmark-state: closed;
+}
+
+emu-clause emu-clause h1, emu-annex emu-annex h1,
+emu-intro h2, emu-clause h2, emu-annex h2 {
+  font-size: 11pt;
+}
+
+emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 {
+  -prince-bookmark-level: 3;
+}
+
+emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 {
+  -prince-bookmark-level: 4;
+}
+
+emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  -prince-bookmark-level: 5;
+}
+
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
+  -prince-bookmark-level: 6;
+}
+
+emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1,
+emu-clause emu-clause h2, emu-annex emu-annex h2,
+emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1,
+emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1,
+emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2,
+emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1,
+emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
+  font-size: 10pt;
+}
+
+emu-clause ol, emu-clause ul, emu-clause dl, emu-annex ol, emu-annex ul, emu-annex dl {
+  margin-left: 0;
+  padding-left: 1.75em;
+}
+
+emu-clause ol ol, emu-clause ul ul {
+  padding-left: 2em;
+}
+
+emu-grammar {
+  display: block;
+}
+
+emu-grammar:has(emu-production.inline) {
+  display: inline-block;
+}
+
+h1 + emu-grammar {
+  margin-top: 1ex;
+}
+
+p + emu-grammar {
+  break-before: avoid;
+}
+
+emu-table td,
+emu-table th {
+  overflow-wrap: break-word;
+}
+
+caption, table > figcaption {
+  caption-side: top;
+  color: #555555;
+  font-weight: bold;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+caption {
+  -prince-caption-page: first; /* see https://www.princexml.com/doc/css-props/#prop-prince-caption-page */
+}
+
+/* do not break inside of small tables */
+table:not(:has(tr:nth-of-type(5))) {
+  break-inside: avoid-page;
+}
+
+table > figcaption {
+  display: table-caption;
+  -prince-caption-page: following;
+}
+
+table > figcaption::after {
+  content: ' (continued)';
+  font-style: italic;
+  font-weight: normal;
+}
+
+th[rowspan] {
+  vertical-align: bottom;
+}
+
+td[rowspan] {
+  vertical-align: middle;
+}
+
+emu-table thead {
+  display: table-header-group;
+}
+
+emu-table tfoot {
+  display: table-footer-group;
+}
+
+emu-figure img {
+  margin-top: 1ex;
+  max-width: 100%;
+  height: auto;
+}
+
+.attributes-tag {
+  break-before: avoid-page;
+  break-after: avoid-page;
+}
+
+#spec-container {
+  max-width: initial;
+}
+
+#spec-container > emu-annex {
+  margin-top: 0;
+}
+
+#toc > h2 {
+  -prince-bookmark-level: 1;
+  -prince-bookmark-label: content();
+}
+
+#toc > h2::after {
+  content: 'page';
+  float: right;
+  font-size: 10pt;
+  text-align: right;
+}
+
+#toc a,
+#toc var {
+  color: #000;
+}
+
+#toc a[href]::after {
+  content: leader(dotted) target-counter(attr(href), page);
+}
+
+#toc > ol.toc {
+  margin-top: 0;
+}
+
+ol.toc {
+  font-weight: bold;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+ol.toc ol.toc {
+  padding-left: 0;
+}
+
+ol.toc li {
+  text-indent: 35pt hanging;
+}
+
+ol.toc .secnum {
+  display: inline-block;
+  min-width: 3.25em;
+}
+
+/* skip the Introduction since it's before the first emu-clause (and therefore doesn't have a proper page number) */
+#toc > ol > li:first-child {
+  display: none;
+}
+
+#toc > ol > li {
+  margin-top: 0.75ex;
+}
+
+#toc,
+#spec-container > emu-intro,
+#spec-container > emu-annex {
+  break-before: recto;
+  break-after: page;
+}
+
+a[data-print-href]::after {
+  content: ' <' attr(href) '>';
+  color: initial;
+}
+
+.real-table {
+  max-width: 100%;
+  width: auto;
+}
+
+emu-annex > h1 {
+  text-align: center;
+}
+
+emu-annex > h1 span {
+  display: block;
+}
+
+emu-annex > h1 .secnum {
+  margin: 0 0 1lh;
+}
+
+.copyright-notice { /* ecma mandated */
+  font-style: italic;
+  border: 1px solid black;
+  padding: 1em;
+  page: copyright;
+  break-before: page;
+  break-after: page;
+}
+
+.secnum {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+#front-cover {
+  page: front-cover;
+  position: relative;
+  width: 210mm;
+  height: 297mm;
+}
+
+#front-cover h1 {
+  color: black;
+  display: block;
+  font-family: Verdana;
+  position: absolute;
+}
+
+h1.shortname {
+  top: 86mm;
+  font-weight: 400;
+  font-size: 21pt;
+  right: 31mm;
+  text-align: right;
+  margin-top: 0;
+}
+
+h1.shortname a:link, h1.shortname a:visited, h1.shortname a:hover, h1.shortname a:active {
+  color: black;
+}
+
+h1.shortname .status {
+  display: inline-block;
+  margin-right: 7em;
+  text-transform: capitalize;
+}
+
+h1.version {
+  font-size: 9.7pt;
+  font-weight: normal;
+  margin-top: 0;
+  text-align: right;
+  top: 96mm;
+  left: 139mm;
+  string-set: year attr(data-year);
+}
+
+#front-cover h1.title {
+  display: block;
+  font-weight: bold;
+  font-size: 20pt;
+  line-height: 1.2;
+  top: 109mm;
+  right: 15mm;
+  width: 95mm;
+  text-align: left;
+}
+
+#inside-cover {
+  page: inside-cover;
+}
+
+#toc {
+  page: toc;
+  counter-reset: page 1;
+}
+
+#toc h2 {
+  font-size: 12pt;
+  margin-bottom: 1.5ex;
+}
+
+.annex-kind {
+  font-weight: normal;
+}
+
+p.ECMAaddress {
+  margin: 0;
+}
+
+}</style><style>
+    @media print {
+      @page :left {
+        @bottom-right {
+          content: '© Ecma International 2026';
+        }
+      }
+      @page :right {
+        @bottom-left {
+          content: '© Ecma International 2026';
+        }
+      }
+      @page :first {
+        @bottom-left {
+          content: '';
+        }
+        @bottom-right {
+          content: '';
+        }
+      }
+      @page :blank {
+        @bottom-left {
+          content: '';
+        }
+        @bottom-right {
+          content: '';
+        }
+      }
+    }
+    </style><style>
+      @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css");
+      @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/a11y-dark.min.css") (prefers-color-scheme: dark);
+    </style></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+  <li><span>Toggle pinning of the current clause</span><code>p</code></li>
+  <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
+  <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
+  <li><span>Jump to the most recent link target</span><code>`</code></li>
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">+</span><a href="#ecma402-locales-currencies-tz" title="Identification of Locales, Currencies, Time Zones, Measurement Units, Numbering Systems, Collations, and Calendars"><span class="secnum">1</span> Identification of Locales, Currencies, Time Zones, Measurement Units, Numbering Systems, Collations, and Calendars</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-ecma402-calendar-types" title="Calendar Types"><span class="secnum">1.1</span> Calendar Types</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sup-availablecalendars" title="AvailableCalendars ( )"><span class="secnum">1.1.1</span> AvailableCalendars ( )</a></li></ol></li></ol></li><li><span class="item-toggle">+</span><a href="#locale-and-parameter-negotiation" title="Locale and Parameter Negotiation"><span class="secnum">2</span> Locale and Parameter Negotiation</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-internal-slots" title="Internal slots of Service Constructors"><span class="secnum">2.1</span> Internal slots of Service Constructors</a></li></ol></li><li><span class="item-toggle">+</span><a href="#ecma402-datetimeformat-objects" title="DateTimeFormat Objects"><span class="secnum">3</span> DateTimeFormat Objects</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-ecma402-intl-datetimeformat-constructor" title="The Intl.DateTimeFormat Constructor"><span class="secnum">3.1</span> The Intl.DateTimeFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-createdatetimeformat" title="CreateDateTimeFormat ( newTarget, locales, options, required, defaults )"><span class="secnum">3.1.1</span> CreateDateTimeFormat ( <var>newTarget</var>, <var>locales</var>, <var>options</var>, <var>required</var>, <var>defaults</var> )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-ecma402-properties-of-intl-datetimeformat-constructor" title="Properties of the Intl.DateTimeFormat Constructor"><span class="secnum">3.2</span> Properties of the Intl.DateTimeFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-ecma402-intl.datetimeformat-internal-slots" title="Internal slots"><span class="secnum">3.2.1</span> Internal slots</a></li></ol></li></ol></li><li><span class="item-toggle">+</span><a href="#ecma402-locale-sensitive-functions" title="Locale Sensitive Functions of the ECMAScript Language Specification"><span class="secnum">4</span> Locale Sensitive Functions of the ECMAScript Language Specification</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-calendar-abstract-ops" title="Abstract Operations for Calendar Calculations"><span class="secnum">4.1</span> Abstract Operations for Calendar Calculations</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendarsupportsera" title="CalendarSupportsEra ( calendar )"><span class="secnum">4.1.1</span> CalendarSupportsEra ( <var>calendar</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-canonicalizeeraincalendar" title="CanonicalizeEraInCalendar ( calendar, era )"><span class="secnum">4.1.2</span> CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendarhasmidyeareras" title="CalendarHasMidYearEras ( calendar )"><span class="secnum">4.1.3</span> CalendarHasMidYearEras ( <var>calendar</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-isvalidmonthcodeforcalendar" title="IsValidMonthCodeForCalendar ( calendar, monthCode )"><span class="secnum">4.1.4</span> IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-yearcontainsmonthcode" title="YearContainsMonthCode ( calendar, arithmeticYear, monthCode )"><span class="secnum">4.1.5</span> YearContainsMonthCode ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-constrainmonthcode" title="ConstrainMonthCode ( calendar, arithmeticYear, monthCode, overflow )"><span class="secnum">4.1.6</span> ConstrainMonthCode ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var>, <var>overflow</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-monthcodetoordinal" title="MonthCodeToOrdinal ( calendar, arithmeticYear, monthCode )"><span class="secnum">4.1.7</span> MonthCodeToOrdinal ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardaysinmonth" title="CalendarDaysInMonth ( calendar, arithmeticYear, ordinalMonth )"><span class="secnum">4.1.8</span> CalendarDaysInMonth ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardateera" title="CalendarDateEra ( calendar, date )"><span class="secnum">4.1.9</span> CalendarDateEra ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardateerayear" title="CalendarDateEraYear ( calendar, date )"><span class="secnum">4.1.10</span> CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardatearithmeticyear" title="CalendarDateArithmeticYear ( calendar, date )"><span class="secnum">4.1.11</span> CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendardatearithmeticyearforerayear" title="CalendarDateArithmeticYearForEraYear ( calendar, era, eraYear )"><span class="secnum">4.1.12</span> CalendarDateArithmeticYearForEraYear ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendarintegerstoiso" title="CalendarIntegersToISO ( calendar, arithmeticYear, ordinalMonth, day )"><span class="secnum">4.1.13</span> CalendarIntegersToISO ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var>, <var>day</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendar-date-records" title="Calendar Date Records"><span class="secnum">4.1.14</span> Calendar Date Records</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-calendarmonthsinyear" title="CalendarMonthsInYear ( calendar, arithmeticYear )"><span class="secnum">4.1.15</span> CalendarMonthsInYear ( <var>calendar</var>, <var>arithmeticYear</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-balancenonisodate" title="BalanceNonISODate ( calendar, arithmeticYear, ordinalMonth, day )"><span class="secnum">4.1.16</span> BalanceNonISODate ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var>, <var>day</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-temporal-nonisodatesurpasses" title="NonISODateSurpasses ( calendar, sign, fromIsoDate, toIsoDate, years, months, weeks, days )"><span class="secnum">4.1.17</span> NonISODateSurpasses ( <var>calendar</var>, <var>sign</var>, <var>fromIsoDate</var>, <var>toIsoDate</var>, <var>years</var>, <var>months</var>, <var>weeks</var>, <var>days</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-nonisodateadd" title="NonISODateAdd ( calendar, isoDate, duration, overflow )"><span class="secnum">4.1.18</span> NonISODateAdd ( <var>calendar</var>, <var>isoDate</var>, <var>duration</var>, <var>overflow</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-nonisodateuntil" title="NonISODateUntil ( calendar, one, two, largestUnit )"><span class="secnum">4.1.19</span> NonISODateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-nonisocalendardatetoiso" title="NonISOCalendarDateToISO ( calendar, fields, overflow )"><span class="secnum">4.1.20</span> NonISOCalendarDateToISO ( <var>calendar</var>, <var>fields</var>, <var>overflow</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-nonisomonthdaytoisoreferencedate" title="NonISOMonthDayToISOReferenceDate ( calendar, fields, overflow )"><span class="secnum">4.1.21</span> NonISOMonthDayToISOReferenceDate ( <var>calendar</var>, <var>fields</var>, <var>overflow</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-calendarextrafields" title="CalendarExtraFields ( calendar, fields )"><span class="secnum">4.1.22</span> CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-nonisofieldkeystoignore" title="NonISOFieldKeysToIgnore ( calendar, keys )"><span class="secnum">4.1.23</span> NonISOFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sup-temporal-nonisoresolvefields" title="NonISOResolveFields ( calendar, fields, type )"><span class="secnum">4.1.24</span> NonISOResolveFields ( <var>calendar</var>, <var>fields</var>, <var>type</var> )</a></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#normative-references" title="Normative References"><span class="secnum">5</span> Normative References</a></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License">Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 2 Draft / January 21, 2026</h1><h1 class="title">Intl era and monthCode Proposal</h1>
+
+
+<emu-clause id="ecma402-locales-currencies-tz">
+  <h1><span class="secnum">1</span> Identification of Locales, Currencies, Time Zones, Measurement Units, Numbering Systems, Collations, and Calendars</h1>
+
+  <emu-clause id="sec-ecma402-calendar-types" oldids="sec-calendar-types"><span id="sec-calendar-types"></span>
+    <h1><span class="secnum">1.1</span> Calendar Types</h1>
+
+    <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">
+      <p>
+        This section, Calendar Types, is <a href="https://tc39.es/ecma402/#sec-calendar-types">present in ECMA-402</a> but is slated to <a href="https://tc39.es/proposal-temporal/#sec-calendar-types">move to ECMA-262 as part of the Temporal proposal</a>.
+        This proposal re-adds the section to ECMA-402, but with additional requirements for Intl-supporting implementations, beyond those specified in <emu-xref href="#ecma262" id="_ref_29"><a href="#ecma262">ECMA-262</a></emu-xref>.
+      </p>
+    </div></emu-note>
+
+    <del class="block">
+      <p>This specification identifies calendars using a <dfn variants="calendar types" tabindex="-1">calendar type</dfn> as defined by <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Elements">Unicode Technical Standard #35 Part 4 Dates, Section 2 Calendar Elements</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).</p>
+    </del>
+
+    <ins class="block">
+      <p>
+        <emu-xref href="#ecma262" id="_ref_30"><a href="#ecma262">ECMA-262</a></emu-xref> describes calendar types, of which <emu-val>"iso8601"</emu-val> is required to be supported.
+        This specification additionally requires ECMAScript implementations to support calendar types corresponding with those of the <a href="https://cldr.unicode.org/">Unicode Common Locale Data Repository (CLDR)</a>.
+      </p>
+    </ins>
+
+    <emu-clause id="sup-availablecalendars" oldids="sec-availablecalendars sec-availablecanonicalcalendars" type="implementation-defined abstract operation" aoid="AvailableCalendars"><span id="sec-availablecalendars sec-availablecanonicalcalendars"></span>
+      <h1><span class="secnum">1.1.1</span> AvailableCalendars ( )</h1>
+      <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation AvailableCalendars takes no arguments and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#sec-ecma402-calendar-types" id="_ref_31"><a href="#sec-ecma402-calendar-types">calendar types</a></emu-xref>. The returned <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is sorted according to lexicographic code unit order, and contains unique <emu-xref href="#sec-ecma402-calendar-types" id="_ref_32"><a href="#sec-ecma402-calendar-types">calendar types</a></emu-xref> in canonical form (<emu-xref href="#sec-calendar-types"><a href="https://tc39.es/ecma402/#sec-calendar-types">6.9</a></emu-xref>) identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects, including their aliases (e.g., <del>either</del> both <del>or neither of</del> <emu-val>"islamicc"</emu-val> and <emu-val>"islamic-civil"</emu-val>). The <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> must include <del><emu-val>"iso8601"</emu-val></del><ins>the "Calendar Type" value of every row of <emu-xref href="#table-calendar-types" id="_ref_0"><a href="#table-calendar-types">Table 1</a></emu-xref>, except the header row</ins>.</p>
+    </emu-clause>
+
+    <ins class="block">
+      <emu-table id="table-calendar-types"><figure><figcaption>Table 1: <emu-xref href="#sec-ecma402-calendar-types" id="_ref_33"><a href="#sec-ecma402-calendar-types">Calendar types</a></emu-xref> described in CLDR</figcaption>
+        
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Calendar Type</th>
+              <th>Description and implementation notes</th>
+            </tr>
+          </thead>
+          <tbody><tr>
+            <td><emu-val>"buddhist"</emu-val></td>
+            <td>Thai Buddhist calendar. Month numbers, month codes, and days are identical to ISO 8601, with one era and an <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_34"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref> differing from the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_35"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref> in <emu-val>"gregory"</emu-val>. All years are treated as having 12 months. For compatibility with other systems, dates prior to ISO year 1941 (2484 BE) are defined but may not correspond to historically accurate values due to the calendar reforms of 1940 and earlier.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"chinese"</emu-val></td>
+            <td>Traditional Chinese calendar. Lunisolar calendar, based on <a href="https://pmo.cas.cn/xwdt2019/kpdt2019/202203/t20220309_6386774.html">data published by the Purple Mountain Observatory</a> for dates between 1900 and 2100 (which complies with <a href="https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=E107EA4DE9725EDF819F33C60A44B296">GB/T 33661-2017, Calculation and Promulgation of the Chinese Calendar</a>), falling back to an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> approximation outside that range. The <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_36"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> is as in <emu-val>"gregory"</emu-val>, and there are no eras.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"coptic"</emu-val></td>
+            <td>Coptic calendar. Similar solar algorithm to <emu-val>"ethioaa"</emu-val> and <emu-val>"ethiopic"</emu-val> but with a different <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_37"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref>. There is one era, starting in the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_38"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref>.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"dangi"</emu-val></td>
+            <td>Traditional Korean calendar. Lunisolar calendar, based on <a href="https://astro.kasi.re.kr/life/post/calendardata"> data published by the Korea Astronomy and Space Science Institute (KASI)</a> for dates between 1900 and 2050, falling back to an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> approximation outside that range. The <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_39"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> is as in <emu-val>"gregory"</emu-val>, and there are no eras.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethioaa"</emu-val></td>
+            <td>Ethiopic calendar, Amete Alem. Similar solar algorithm to <emu-val>"coptic"</emu-val> and <emu-val>"ethiopic"</emu-val>, but with a different <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_40"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref>. There is one era, starting in the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_41"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref>.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethiopic"</emu-val></td>
+            <td>Ethiopic calendar, Amete Mihret. Similar solar algorithm to <emu-val>"coptic"</emu-val> and <emu-val>"ethioaa"</emu-val>, but with a different <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_42"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref>. There are two eras, one starting in the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_43"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref> of <emu-val>"ethioaa"</emu-val> and one starting in this calendar's <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_44"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref>.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethiopic-amete-alem"</emu-val></td>
+            <td>Alias for <emu-val>"ethioaa"</emu-val>.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"gregory"</emu-val></td>
+            <td>Gregorian calendar. Solar calendar almost identical to the ISO 8601 calendar, except that it does not define week numbering and it contains two eras, one before the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_45"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref> and one after.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"hebrew"</emu-val></td>
+            <td>Hebrew calendar. Civil calendar with Tishrei as the first month of the year. Lunisolar calendar with one leap month inserted after month 5. There is one era.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"indian"</emu-val></td>
+            <td>Indian national (or Śaka) calendar. Solar calendar with one era.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-civil"</emu-val></td>
+            <td>Hijri calendar, tabular/rule-based with leap years 2, 5, 7, 10, 13, 16, 18, 21, 24, 26, 29 in the 30-year cycle, and civil epoch (Friday July 16, 622 Julian / 0622-07-19 ISO)</td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-tbla"</emu-val></td>
+            <td>Hijri calendar, tabular/rule-based with leap years 2, 5, 7, 10, 13, 16, 18, 21, 24, 26, 29 in the 30-year cycle, and astronomical epoch (Thursday July 15, 622 Julian / 0622-07-18 ISO)</td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-umalqura"</emu-val></td>
+            <td>Hijri calendar, Umm al-Qura. Lunar calendar using months calculated by King Abdulaziz City for Science and Technology (KACST) for dates from the start of 1300 AH to the end of 1600 AH, falling back to <emu-val>"islamic-civil"</emu-val> outside that range.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamicc"</emu-val></td>
+            <td>Alias for <emu-val>"islamic-civil"</emu-val>.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"iso8601"</emu-val></td>
+            <td>ISO 8601 calendar. Fully specified in <emu-xref href="#ecma262" id="_ref_46"><a href="#ecma262">ECMA-262</a></emu-xref>.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td>Japanese Imperial calendar, era system hybridised with the era system used in <emu-val>"gregory"</emu-val>. Month numbers, month codes, and days are the same as in the ISO 8601 calendar. For dates up to and including 1872-12-31, years and eras identical to <emu-val>"gregory"</emu-val> are used. For later dates, the eras and ranges defined by the Japanese government are used. Note that ISO year 1873 is the 6th year of the Meiji period, starting on ISO date 1868-10-23, during which calendar reforms took place. The <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_47"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> is identical to <emu-val>"gregory"</emu-val>.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"persian"</emu-val></td>
+            <td>Persian (or Solar Hijri) calendar. There is one era.</td>
+          </tr>
+          <tr>
+            <td><emu-val>"roc"</emu-val></td>
+            <td>Republic of China (or Minguo) calendar. Month numbers, month codes, and days are the same as in the ISO 8601 calendar, with two eras, one before the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_48"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref> and one after. The <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_49"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref> is different from <emu-val>"gregory"</emu-val>.</td>
+          </tr>
+        </tbody></table>
+      </figure></emu-table>
+    </ins>
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="locale-and-parameter-negotiation">
+  <h1><span class="secnum">2</span> Locale and Parameter Negotiation</h1>
+
+  <emu-clause id="sec-internal-slots">
+    <h1><span class="secnum">2.1</span> Internal slots of Service Constructors</h1>
+
+    <p>[...]</p>
+
+    <emu-note><span class="note">Note</span><div class="note-contents">
+      For example, an implementation of DateTimeFormat might include the <emu-xref href="#sec-language-tags"><a href="https://tc39.es/ecma402/#sec-language-tags">language tag</a></emu-xref> <emu-val>"fa-IR"</emu-val> in its <var class="field">[[AvailableLocales]]</var> internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"><a href="https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots">11.2.3</a></emu-xref>) include the keys <emu-val>"ca"</emu-val>, <emu-val>"hc"</emu-val>, and <emu-val>"nu"</emu-val> in its <var class="field">[[RelevantExtensionKeys]]</var> internal slot.
+      The default calendar for that locale is usually <emu-val>"persian"</emu-val>, but an implementation might also support <emu-val>"gregory"</emu-val><del>, <emu-val>"islamic"</emu-val>,</del> and <emu-val>"islamic-civil"</emu-val>.
+      The <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> in the DateTimeFormat <var class="field">[[LocaleData]]</var> internal slot would therefore include a [[fa-IR]] field whose value is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> like { <var class="field">[[ca]]</var>: « <emu-val>"persian"</emu-val>, <emu-val>"gregory"</emu-val>, <del><emu-val>"islamic"</emu-val>,</del> <emu-val>"islamic-civil"</emu-val> », <var class="field">[[hc]]</var>: « … », <var class="field">[[nu]]</var>: « … » }, along with other locale-named fields having the same value shape but different elements in their <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref>.
+    </div></emu-note>
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="ecma402-datetimeformat-objects">
+  <h1><span class="secnum">3</span> DateTimeFormat Objects</h1>
+
+  <emu-clause id="sec-ecma402-intl-datetimeformat-constructor">
+    <h1><span class="secnum">3.1</span> The Intl.DateTimeFormat Constructor</h1>
+
+    <emu-clause id="sec-createdatetimeformat" type="abstract operation" oldids="sec-initializedatetimeformat,sec-todatetimeoptions" aoid="CreateDateTimeFormat"><span id="sec-todatetimeoptions"></span><span id="sec-initializedatetimeformat"></span>
+      <h1><span class="secnum">3.1.1</span> CreateDateTimeFormat ( <var>newTarget</var>, <var>locales</var>, <var>options</var>, <var>required</var>, <var>defaults</var> )</h1>
+
+      <p>The abstract operation CreateDateTimeFormat takes arguments <var>newTarget</var> (a <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>), <var>locales</var> (an <emu-xref href="#sec-ecmascript-language-types"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types">ECMAScript language value</a></emu-xref>), <var>options</var> (an <emu-xref href="#sec-ecmascript-language-types"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types">ECMAScript language value</a></emu-xref>), <var>required</var> (<emu-const>date</emu-const>, <emu-const>time</emu-const>, or <emu-const>any</emu-const>), and <var>defaults</var> (<emu-const>date</emu-const>, <emu-const>time</emu-const>, or <emu-const>all</emu-const>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a DateTimeFormat object or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It performs the following steps when called:</p>
+
+      <emu-alg><ol><li>Let <var>dateTimeFormat</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor"><a href="https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(<var>newTarget</var>, <emu-val>"%Intl.DateTimeFormat.prototype%"</emu-val>, « <var class="field">[[InitializedDateTimeFormat]]</var>, <var class="field">[[Locale]]</var>, <var class="field">[[Calendar]]</var>, <var class="field">[[NumberingSystem]]</var>, <var class="field">[[TimeZone]]</var>, <var class="field">[[HourCycle]]</var>, <var class="field">[[DateStyle]]</var>, <var class="field">[[TimeStyle]]</var>, <var class="field">[[DateTimeFormat]]</var>, <var class="field">[[BoundFormat]]</var>&nbsp;»).</li><li>Let <var>hour12</var> be <emu-val>undefined</emu-val>.</li><li>Let <var>modifyResolutionOptions</var> be a new <emu-xref href="#sec-abstract-closure"><a href="https://tc39.es/ecma262/#sec-abstract-closure">Abstract Closure</a></emu-xref> with parameters (<var>options</var>) that captures <var>hour12</var> and performs the following steps when called:<ol><li>Set <var>hour12</var> to <var>options</var>.<var class="field">[[hour12]]</var>.</li><li>Remove field <var class="field">[[hour12]]</var> from <var>options</var>.</li><li>If <var>hour12</var> is not <emu-val>undefined</emu-val>, set <var>options</var>.<var class="field">[[hc]]</var> to <emu-val>null</emu-val>.</li></ol></li><li>Let <var>optionsResolution</var> be ?&nbsp;<emu-xref aoid="ResolveOptions"><a href="https://tc39.es/ecma402/#sec-resolveoptions">ResolveOptions</a></emu-xref>(<emu-xref href="#sec-intl-datetimeformat-constructor"><a href="https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor">%Intl.DateTimeFormat%</a></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"><a href="https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor">%Intl.DateTimeFormat%</a></emu-xref>.<var class="field">[[LocaleData]]</var>, <var>locales</var>, <var>options</var>, « <emu-const>coerce-options</emu-const>&nbsp;», <var>modifyResolutionOptions</var>).</li><li>Set <var>options</var> to <var>optionsResolution</var>.<var class="field">[[Options]]</var>.</li><li>Let <var>r</var> be <var>optionsResolution</var>.<var class="field">[[ResolvedLocale]]</var>.</li><li>Set <var>dateTimeFormat</var>.<var class="field">[[Locale]]</var> to <var>r</var>.<var class="field">[[Locale]]</var>.</li><li>Let <var>resolvedCalendar</var> be <var>r</var>.<var class="field">[[ca]]</var>.</li><li><ins>If <var>resolvedCalendar</var> is <emu-val>"islamic"</emu-val> or <emu-val>"islamic-rgsa"</emu-val>, then</ins><ol><li><ins>Let <var>fallbackCalendar</var> be an implementation- and locale-defined <emu-xref href="#sec-ecma402-calendar-types" id="_ref_50"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is one of the values returned from <emu-xref aoid="AvailableCalendars" id="_ref_51"><a href="#sup-availablecalendars">AvailableCalendars</a></emu-xref>.</ins></li><li><ins>Set <var>resolvedCalendar</var> to <emu-xref aoid="CanonicalizeUValue"><a href="https://tc39.es/ecma402/#sec-canonicalizeuvalue">CanonicalizeUValue</a></emu-xref>(<emu-val>"ca"</emu-val>, <var>fallbackCalendar</var>).</ins></li><li><ins>If the ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be issued.</ins></li></ol></li><li>Set <var>dateTimeFormat</var>.<var class="field">[[Calendar]]</var> to <var>resolvedCalendar</var>.</li><li>NOTE: Rest of algorithm unchanged.</li></ol></emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-ecma402-properties-of-intl-datetimeformat-constructor">
+    <h1><span class="secnum">3.2</span> Properties of the Intl.DateTimeFormat Constructor</h1>
+
+    <emu-clause id="sec-ecma402-intl.datetimeformat-internal-slots">
+      <h1><span class="secnum">3.2.1</span> Internal slots</h1>
+
+      <p>[...]</p>
+
+      <p>The value of the <var class="field">[[LocaleData]]</var> internal slot is <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> within the constraints described in <emu-xref href="#sec-internal-slots" id="_ref_1"><a href="#sec-internal-slots">2.1</a></emu-xref> and the following additional constraints, for all locale values <var>locale</var>:</p>
+
+      <ul>
+        <li><ins><var class="field">[[LocaleData]]</var>.[[&lt;<var>locale</var>&gt;]].<var class="field">[[ca]]</var> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> consisting of <emu-xref href="#sec-ecma402-calendar-types" id="_ref_52"><a href="#sec-ecma402-calendar-types">calendar types</a></emu-xref>. Specifically, even if supporting only the calendars from <emu-xref href="#table-calendar-types" id="_ref_2"><a href="#table-calendar-types">Table 1</a></emu-xref>, the list may also include <emu-val>"islamic"</emu-val> and <emu-val>"islamic-rgsa"</emu-val>.</ins></li>
+        <li>
+          <var class="field">[[LocaleData]]</var>.[[&lt;<var>locale</var>&gt;]].<var class="field">[[nu]]</var> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> that does not include the values <emu-val>"native"</emu-val>, <emu-val>"traditio"</emu-val>, or <emu-val>"finance"</emu-val>.
+        </li>
+        <li>
+          <var class="field">[[LocaleData]]</var>.[[&lt;<var>locale</var>&gt;]].<var class="field">[[hc]]</var> must be « <emu-val>null</emu-val>, <emu-val>"h11"</emu-val>, <emu-val>"h12"</emu-val>, <emu-val>"h23"</emu-val>, <emu-val>"h24"</emu-val> ».
+        </li>
+        <li>[...]</li>
+      </ul>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="ecma402-locale-sensitive-functions">
+  <h1><span class="secnum">4</span> Locale Sensitive Functions of the ECMAScript Language Specification</h1>
+
+  <emu-clause id="sec-calendar-abstract-ops">
+    <h1><span class="secnum">4.1</span> Abstract Operations for Calendar Calculations</h1>
+
+    <emu-clause id="sec-temporal-calendarsupportsera" type="abstract operation" aoid="CalendarSupportsEra">
+      <h1><span class="secnum">4.1.1</span> CalendarSupportsEra ( <var>calendar</var> )</h1>
+      <p>The abstract operation CalendarSupportsEra takes argument <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_53"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref>) and returns a Boolean. 
+          The following algorithm refers (via <emu-xref href="#table-eras" id="_ref_3"><a href="#table-eras">Table 2</a></emu-xref>) to the era data from <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Data">Unicode Technical Standard #35 Part 4 Dates, Calendar Data</a>.
+         It performs the following steps when called:</p>
+      <emu-alg><ol><li>If <var>calendar</var> is listed in the "Calendar" column of <emu-xref href="#table-eras" id="_ref_4"><a href="#table-eras">Table 2</a></emu-xref>, return <emu-val>true</emu-val>.</li><li>If <var>calendar</var> is listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_5"><a href="#table-calendar-types">Table 1</a></emu-xref>, return <emu-val>false</emu-val>.</li><li>Return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li></ol></emu-alg>
+      <p>
+        <emu-xref href="#table-eras" id="_ref_6"><a href="#table-eras">Table 2</a></emu-xref> lists all currently known eras for the current set of calendars, including their aliases, ranges, and kinds.
+        The canonical source for this table is the data described in <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Data">Unicode Technical Standard #35 Part 4 Dates, Calendar Data</a>.
+      </p>
+      <p>The era kind is used by <emu-xref href="#sec-temporal-calendardatearithmeticyearforerayear" id="_ref_7"><a href="#sec-temporal-calendardatearithmeticyearforerayear">CalendarDateArithmeticYearForEraYear</a></emu-xref> to calculate the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_54"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> (<var class="field">[[Year]]</var>):
+      An <emu-val>Era Kind</emu-val> <emu-const>epoch</emu-const> means that the era is the epoch era, so 1 Era has an <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_55"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> of 1. An <emu-val>Era Kind</emu-val> <emu-const>negative</emu-const> means that the era is a "negative" era growing
+      from the epoch, so 1 Era is an <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_56"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> of 0, and larger <var class="field">[[EraYear]]</var> values produce smaller, negative arithmetic years. An <emu-val>Era Kind</emu-val> of
+      <emu-const>offset</emu-const> means that the era is "offset" by a given number (in the <emu-val>Offset</emu-val> column), so 1 Era has an <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_57"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> of <emu-val>Offset</emu-val>.</p>
+      <emu-table id="table-eras"><figure><figcaption>Table 2: Eras</figcaption>
+        
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Calendar</th>
+              <th>Era</th>
+              <th>Aliases</th>
+              <th>Minimum eraYear</th>
+              <th>Maximum eraYear</th>
+              <th>Era Kind</th>
+              <th>Offset</th>
+            </tr>
+          </thead>
+          <tbody><tr>
+            <td><emu-val>"buddhist"</emu-val></td>
+            <td><emu-val>"be"</emu-val></td>
+            <td></td>
+            <td>-∞</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"coptic"</emu-val></td>
+            <td><emu-val>"am"</emu-val></td>
+            <td></td>
+            <td>-∞</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethioaa"</emu-val></td>
+            <td><emu-val>"aa"</emu-val></td>
+            <td></td>
+            <td>-∞</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethiopic"</emu-val></td>
+            <td><emu-val>"am"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethiopic"</emu-val></td>
+            <td><emu-val>"aa"</emu-val></td>
+            <td></td>
+            <td>-∞</td>
+            <td>5500</td>
+            <td> <emu-const>offset</emu-const></td>
+            <td>-5499</td>
+          </tr>
+          <tr>
+            <td><emu-val>"gregory"</emu-val></td>
+            <td><emu-val>"ce"</emu-val></td>
+            <td><emu-val>"ad"</emu-val></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"gregory"</emu-val></td>
+            <td><emu-val>"bce"</emu-val></td>
+            <td><emu-val>"bc"</emu-val></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>negative</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"hebrew"</emu-val></td>
+            <td><emu-val>"am"</emu-val></td>
+            <td></td>
+            <td>-∞</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"indian"</emu-val></td>
+            <td><emu-val>"shaka"</emu-val></td>
+            <td></td>
+            <td>-∞</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-civil"</emu-val></td>
+            <td><emu-val>"ah"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-civil"</emu-val></td>
+            <td><emu-val>"bh"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>negative</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-tbla"</emu-val></td>
+            <td><emu-val>"ah"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-tbla"</emu-val></td>
+            <td><emu-val>"bh"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>negative</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-umalqura"</emu-val></td>
+            <td><emu-val>"ah"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-umalqura"</emu-val></td>
+            <td><emu-val>"bh"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>negative</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td><emu-val>"reiwa"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>offset</emu-const></td>
+            <td>2019</td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td><emu-val>"heisei"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>31</td>
+            <td><emu-const>offset</emu-const></td>
+            <td>1989</td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td><emu-val>"showa"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>64</td>
+            <td><emu-const>offset</emu-const></td>
+            <td>1926</td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td><emu-val>"taisho"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>15</td>
+            <td><emu-const>offset</emu-const></td>
+            <td>1912</td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td><emu-val>"meiji"</emu-val></td>
+            <td></td>
+            <td>6</td>
+            <td>45</td>
+            <td><emu-const>offset</emu-const></td>
+            <td>1868</td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td><emu-val>"ce"</emu-val></td>
+            <td><emu-val>"ad"</emu-val></td>
+            <td>1</td>
+            <td>1872</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td><emu-val>"bce"</emu-val></td>
+            <td><emu-val>"bc"</emu-val></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>negative</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"persian"</emu-val></td>
+            <td><emu-val>"ap"</emu-val></td>
+            <td></td>
+            <td>-∞</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"roc"</emu-val></td>
+            <td><emu-val>"roc"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>epoch</emu-const></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"roc"</emu-val></td>
+            <td><emu-val>"broc"</emu-val></td>
+            <td></td>
+            <td>1</td>
+            <td>+∞</td>
+            <td><emu-const>negative</emu-const></td>
+            <td></td>
+          </tr>
+        </tbody></table>
+      </figure></emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-canonicalizeeraincalendar" type="abstract operation" aoid="CanonicalizeEraInCalendar">
+      <h1><span class="secnum">4.1.2</span> CanonicalizeEraInCalendar ( <var>calendar</var>, <var>era</var> )</h1>
+      <p>The abstract operation CanonicalizeEraInCalendar takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_58"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>era</var> (a String) and returns a String or <emu-val>undefined</emu-val>. 
+          The following algorithm refers to the era data from <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Data">Unicode Technical Standard #35 Part 4 Dates, Calendar Data</a>.
+         It performs the following steps when called:</p>
+      <emu-alg><ol><li>For each row of <emu-xref href="#table-eras" id="_ref_8"><a href="#table-eras">Table 2</a></emu-xref>, except the header row, do<ol><li>Let <var>cal</var> be the Calendar value of the current row.</li><li>If <var>cal</var> is equal to <var>calendar</var>, then<ol><li>Let <var>canonicalName</var> be the Era value of the current row.</li><li>If <var>canonicalName</var> is equal to <var>era</var>, return <var>canonicalName</var>.</li><li>Let <var>aliases</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the strings given in the "Aliases" column of the row.</li><li>If <var>aliases</var> contains <var>era</var>, return <var>canonicalName</var>.</li></ol></li></ol></li><li>If <var>calendar</var> is listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_9"><a href="#table-calendar-types">Table 1</a></emu-xref>, return <emu-val>undefined</emu-val>.</li><li>Return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarhasmidyeareras" type="abstract operation" aoid="CalendarHasMidYearEras">
+      <h1><span class="secnum">4.1.3</span> CalendarHasMidYearEras ( <var>calendar</var> )</h1>
+      <p>The abstract operation CalendarHasMidYearEras takes argument <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_59"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and returns a Boolean. It returns <emu-val>true</emu-val> if the calendar has eras that start in the middle of the year, or <emu-val>false</emu-val> if all eras start on a year boundary. It performs the following steps when called:</p>
+      <emu-alg><ol><li>If <var>calendar</var> is <emu-val>"japanese"</emu-val>, return <emu-val>true</emu-val>.</li><li>If <var>calendar</var> is listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_10"><a href="#table-calendar-types">Table 1</a></emu-xref>, return <emu-val>false</emu-val>.</li><li>Return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-isvalidmonthcodeforcalendar" type="abstract operation" aoid="IsValidMonthCodeForCalendar">
+      <h1><span class="secnum">4.1.4</span> IsValidMonthCodeForCalendar ( <var>calendar</var>, <var>monthCode</var> )</h1>
+      <p>The abstract operation IsValidMonthCodeForCalendar takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_60"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>monthCode</var> (a month code) and returns a Boolean. It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>commonMonthCodes</var> be « <emu-val>"M01"</emu-val>, <emu-val>"M02"</emu-val>, <emu-val>"M03"</emu-val>, <emu-val>"M04"</emu-val>, <emu-val>"M05"</emu-val>, <emu-val>"M06"</emu-val>, <emu-val>"M07"</emu-val>, <emu-val>"M08"</emu-val>, <emu-val>"M09"</emu-val>, <emu-val>"M10"</emu-val>, <emu-val>"M11"</emu-val>, <emu-val>"M12"</emu-val>&nbsp;».</li><li>If <var>commonMonthCodes</var> contains <var>monthCode</var>, return <emu-val>true</emu-val>.</li><li>If <var>calendar</var> is listed in the "Calendar" column of <emu-xref href="#table-additional-month-codes" id="_ref_11"><a href="#table-additional-month-codes">Table 3</a></emu-xref>, then<ol><li>Let <var>r</var> be the row in <emu-xref href="#table-additional-month-codes" id="_ref_12"><a href="#table-additional-month-codes">Table 3</a></emu-xref> with a value in the Calendar column matching <var>calendar</var>.</li><li>Let <var>specialMonthCodes</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the strings given in the "Additional Month Codes" column of <var>r</var>.</li><li>If <var>specialMonthCodes</var> contains <var>monthCode</var>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></li><li>If <var>calendar</var> is listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_13"><a href="#table-calendar-types">Table 1</a></emu-xref>, return <emu-val>false</emu-val>.</li><li>Return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li></ol></emu-alg>
+
+      <emu-table id="table-additional-month-codes"><figure><figcaption>Table 3: Additional Month Codes in Calendars</figcaption>
+        
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Calendar</th>
+              <th>Additional Month Codes</th>
+              <th>Leap to Common Month Transformation</th>
+            </tr>
+          </thead>
+          <tbody><tr>
+            <td><emu-val>"chinese"</emu-val></td>
+            <td><emu-val>"M01L"</emu-val>, <emu-val>"M02L"</emu-val>, <emu-val>"M03L"</emu-val>, <emu-val>"M04L"</emu-val>, <emu-val>"M05L"</emu-val>, <emu-val>"M06L"</emu-val>, <emu-val>"M07L"</emu-val>, <emu-val>"M08L"</emu-val>, <emu-val>"M09L"</emu-val>, <emu-val>"M10L"</emu-val>, <emu-val>"M11L"</emu-val>, <emu-val>"M12L"</emu-val></td>
+            <td><emu-const>skip-backward</emu-const></td>
+          </tr>
+          <tr>
+            <td><emu-val>"coptic"</emu-val></td>
+            <td><emu-val>"M13"</emu-val></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"dangi"</emu-val></td>
+            <td><emu-val>"M01L"</emu-val>, <emu-val>"M02L"</emu-val>, <emu-val>"M03L"</emu-val>, <emu-val>"M04L"</emu-val>, <emu-val>"M05L"</emu-val>, <emu-val>"M06L"</emu-val>, <emu-val>"M07L"</emu-val>, <emu-val>"M08L"</emu-val>, <emu-val>"M09L"</emu-val>, <emu-val>"M10L"</emu-val>, <emu-val>"M11L"</emu-val>, <emu-val>"M12L"</emu-val></td>
+            <td><emu-const>skip-backward</emu-const></td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethioaa"</emu-val></td>
+            <td><emu-val>"M13"</emu-val></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethiopic"</emu-val></td>
+            <td><emu-val>"M13"</emu-val></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><emu-val>"hebrew"</emu-val></td>
+            <td><emu-val>"M05L"</emu-val></td>
+            <td><emu-const>skip-forward</emu-const></td>
+          </tr>
+        </tbody></table>
+      </figure></emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-yearcontainsmonthcode" type="abstract operation" aoid="YearContainsMonthCode">
+      <h1><span class="secnum">4.1.5</span> YearContainsMonthCode ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var> )</h1>
+      <p>The abstract operation YearContainsMonthCode takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_61"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>arithmeticYear</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var>monthCode</var> (a month code) and returns a Boolean. 
+          It returns whether the given <var>monthCode</var> exists in <var>arithmeticYear</var> of <var>calendar</var>.
+        </p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="IsValidMonthCodeForCalendar" id="_ref_62"><a href="#sec-temporal-isvalidmonthcodeforcalendar">IsValidMonthCodeForCalendar</a></emu-xref>(<var>calendar</var>, <var>monthCode</var>) is <emu-val>true</emu-val>.</li><li>If !&nbsp;<emu-xref aoid="ParseMonthCode"><a href="https://tc39.es/proposal-temporal/#sec-temporal-parsemonthcode">ParseMonthCode</a></emu-xref>(<var>monthCode</var>).<var class="field">[[IsLeap]]</var> is <emu-val>false</emu-val>, return <emu-val>true</emu-val>.</li><li>Return whether the leap month indicated by <var>monthCode</var> exists in the year <var>arithmeticYear</var> in <var>calendar</var>, using calendar-dependent behaviour.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-constrainmonthcode" type="abstract operation" aoid="ConstrainMonthCode">
+      <h1><span class="secnum">4.1.6</span> ConstrainMonthCode ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var>, <var>overflow</var> )</h1>
+      <p>The abstract operation ConstrainMonthCode takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_63"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>arithmeticYear</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), <var>monthCode</var> (a month code), and <var>overflow</var> (<emu-const>constrain</emu-const> or <emu-const>reject</emu-const>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a month code or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. 
+          It returns the month code in <var>arithmeticYear</var> of <var>calendar</var> that best matches the given <var>monthCode</var>. If <var>monthCode</var> does not exist in <var>arithmeticYear</var>, it is constrained to the best common month if <var>overflow</var> is <emu-const>constrain</emu-const>, or an error is thrown if <var>overflow</var> is <emu-const>reject</emu-const>.
+        </p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="IsValidMonthCodeForCalendar" id="_ref_64"><a href="#sec-temporal-isvalidmonthcodeforcalendar">IsValidMonthCodeForCalendar</a></emu-xref>(<var>calendar</var>, <var>monthCode</var>) is <emu-val>true</emu-val>.</li><li>If <emu-xref aoid="YearContainsMonthCode" id="_ref_65"><a href="#sec-temporal-yearcontainsmonthcode">YearContainsMonthCode</a></emu-xref>(<var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var>) is <emu-val>true</emu-val>, return <var>monthCode</var>.</li><li>If <var>overflow</var> is <emu-const>reject</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>If <var>calendar</var> is not listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_14"><a href="#table-calendar-types">Table 1</a></emu-xref>, return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>calendar</var> is listed in the "Calendar" column of <emu-xref href="#table-additional-month-codes" id="_ref_15"><a href="#table-additional-month-codes">Table 3</a></emu-xref>.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-additional-month-codes" id="_ref_16"><a href="#table-additional-month-codes">Table 3</a></emu-xref> with a value in the Calendar column matching <var>calendar</var>.</li><li>Let <var>shiftType</var> be the value given in the "Leap to Common Month Tranformation" column of <var>r</var>.</li><li>If <var>shiftType</var> is <emu-const>skip-backward</emu-const>, then<ol><li>Return <emu-xref aoid="CreateMonthCode"><a href="https://tc39.es/proposal-temporal/#sec-temporal-createmonthcode">CreateMonthCode</a></emu-xref>(! <emu-xref aoid="ParseMonthCode"><a href="https://tc39.es/proposal-temporal/#sec-temporal-parsemonthcode">ParseMonthCode</a></emu-xref>(<var>monthCode</var>).<var class="field">[[MonthNumber]]</var>, <emu-val>false</emu-val>).</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>monthCode</var> is <emu-val>"M05L"</emu-val>.</li><li>Return <emu-val>"M06"</emu-val>.</li></ol></li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-monthcodetoordinal" type="abstract operation" aoid="MonthCodeToOrdinal">
+      <h1><span class="secnum">4.1.7</span> MonthCodeToOrdinal ( <var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var> )</h1>
+      <p>The abstract operation MonthCodeToOrdinal takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_66"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>arithmeticYear</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var>monthCode</var> (a month code) and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>. 
+          It returns the ordinal month number for <var>monthCode</var> in <var>arithmeticYear</var> of <var>calendar</var>. The given <var>monthCode</var> must exist in the given year.
+        </p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <emu-xref aoid="YearContainsMonthCode" id="_ref_67"><a href="#sec-temporal-yearcontainsmonthcode">YearContainsMonthCode</a></emu-xref>(<var>calendar</var>, <var>arithmeticYear</var>, <var>monthCode</var>) is <emu-val>true</emu-val>.</li><li>Let <var>monthsBefore</var> be 0.</li><li>Let <var>number</var> be 1.</li><li>Let <var>isLeap</var> be <emu-val>false</emu-val>.</li><li>If <var>calendar</var> is not listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_17"><a href="#table-calendar-types">Table 1</a></emu-xref>, return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-additional-month-codes" id="_ref_18"><a href="#table-additional-month-codes">Table 3</a></emu-xref> with a value in the Calendar column matching <var>calendar</var>.</li><li>If the "Leap to Common Month Tranformation" column of <var>r</var> is empty, then<ol><li>Return !&nbsp;<emu-xref aoid="ParseMonthCode"><a href="https://tc39.es/proposal-temporal/#sec-temporal-parsemonthcode">ParseMonthCode</a></emu-xref>(<var>monthCode</var>).<var class="field">[[MonthNumber]]</var>.</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: The "Additional Month Codes" column of <var>r</var> does not contain <emu-val>"M00L"</emu-val> or <emu-val>"M13"</emu-val>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: This algorithm will return before the following loop terminates by failing its condition.</li><li>Repeat, while <var>number</var> ≤ 12,<ol><li>Let <var>currentMonthCode</var> be <emu-xref aoid="CreateMonthCode"><a href="https://tc39.es/proposal-temporal/#sec-temporal-createmonthcode">CreateMonthCode</a></emu-xref>(<var>number</var>, <var>isLeap</var>).</li><li>If <emu-xref aoid="IsValidMonthCodeForCalendar" id="_ref_68"><a href="#sec-temporal-isvalidmonthcodeforcalendar">IsValidMonthCodeForCalendar</a></emu-xref>(<var>calendar</var>, <var>currentMonthCode</var>) is <emu-val>true</emu-val> and <emu-xref aoid="YearContainsMonthCode" id="_ref_69"><a href="#sec-temporal-yearcontainsmonthcode">YearContainsMonthCode</a></emu-xref>(<var>calendar</var>, <var>arithmeticYear</var>, <var>currentMonthCode</var>) is <emu-val>true</emu-val>, then<ol><li>Set <var>monthsBefore</var> to <var>monthsBefore</var> + 1.</li></ol></li><li>If <var>currentMonthCode</var> is <var>monthCode</var>, then<ol><li>Return <var>monthsBefore</var>.</li></ol></li><li>If <var>isLeap</var> is <emu-val>false</emu-val>, then<ol><li>Set <var>isLeap</var> to <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Set <var>isLeap</var> to <emu-val>false</emu-val>.</li><li>Set <var>number</var> to <var>number</var> + 1.</li></ol></li></ol></li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendardaysinmonth" type="abstract operation" aoid="CalendarDaysInMonth">
+      <h1><span class="secnum">4.1.8</span> CalendarDaysInMonth ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var> )</h1>
+      <p>The abstract operation CalendarDaysInMonth takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_70"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>arithmeticYear</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var>ordinalMonth</var> (a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>. 
+          The returned value represents the number of days in the <var>calendar</var>-specific <var>arithmeticYear</var> and <var>ordinalMonth</var>.
+        </p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendardateera" type="abstract operation" aoid="CalendarDateEra">
+      <h1><span class="secnum">4.1.9</span> CalendarDateEra ( <var>calendar</var>, <var>date</var> )</h1>
+      <p>The abstract operation CalendarDateEra takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_71"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>date</var> (an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>) and returns a String or <emu-val>undefined</emu-val>. It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to find the era for the date corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> and returns a lowercase String value representing that era, or <emu-val>undefined</emu-val> for calendars that do not have eras. It performs the following steps when called:</p>
+      <emu-alg><ol><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_72"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>false</emu-val>, return <emu-val>undefined</emu-val>.</li><li>Let <var>era</var> be the String to indicate the era corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> according to <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li>Return <emu-xref aoid="CanonicalizeEraInCalendar" id="_ref_73"><a href="#sec-temporal-canonicalizeeraincalendar">CanonicalizeEraInCalendar</a></emu-xref>(<var>calendar</var>, <var>era</var>).</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendardateerayear" type="abstract operation" aoid="CalendarDateEraYear">
+      <h1><span class="secnum">4.1.10</span> CalendarDateEraYear ( <var>calendar</var>, <var>date</var> )</h1>
+      <p>The abstract operation CalendarDateEraYear takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_74"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>date</var> (an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>) and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> or <emu-val>undefined</emu-val>. It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to find the era for the date corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> representing the ordinal position of the year of <var>date</var> in that era, or <emu-val>undefined</emu-val> for calendars that do not have eras. It performs the following steps when called:</p>
+      
+      <emu-alg><ol><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_75"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>false</emu-val>, return <emu-val>undefined</emu-val>.</li><li>Let <var>eraYear</var> be the <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> to indicate the era year corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var> according to <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>eraYear</var> is an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>.</li><li>Return <var>eraYear</var>.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendardatearithmeticyear" type="abstract operation" aoid="CalendarDateArithmeticYear">
+      <h1><span class="secnum">4.1.11</span> CalendarDateArithmeticYear ( <var>calendar</var>, <var>date</var> )</h1>
+      <p>The abstract operation CalendarDateArithmeticYear takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_76"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>date</var> (an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>) and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>. It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to find the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_77"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> for the date corresponding to <var>date</var> in the context of the calendar represented by <var>calendar</var>. It performs the following steps when called:</p>
+      <emu-alg><ol><li>If <var>calendar</var> is not listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_19"><a href="#table-calendar-types">Table 1</a></emu-xref>, return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-epoch-years" id="_ref_20"><a href="#table-epoch-years">Table 4</a></emu-xref> with a value in the Calendar column matching <var>calendar</var>.</li><li>Let <var>epochYear</var> be the value given in the "Epoch ISO Year" column of <var>r</var>.</li><li>Let <var>epochDate</var> be the first day of the calendar year starting in ISO year <var>epochYear</var> in the calendar represented by <var>calendar</var>, according to <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li>Let <var>newYear</var> be the first day of the calendar year of <var>date</var> in the calendar represented by <var>calendar</var>, according to <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li>Let <var>arithmeticYear</var> be the signed number of whole years between <var>epochDate</var> and <var>newYear</var> in the calendar represented by <var>calendar</var>, according to <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing.</li><li>Return <var>arithmeticYear</var>.</li></ol></emu-alg>
+
+      <emu-table id="table-epoch-years"><figure><figcaption>Table 4: Epoch years</figcaption>
+        
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Calendar</th>
+              <th>Epoch ISO Year</th>
+            </tr>
+          </thead>
+          <tbody><tr>
+            <td><emu-val>"buddhist"</emu-val></td>
+            <td>-543</td>
+          </tr>
+          <tr>
+            <td><emu-val>"chinese"</emu-val></td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td><emu-val>"coptic"</emu-val></td>
+            <td>283</td>
+          </tr>
+          <tr>
+            <td><emu-val>"dangi"</emu-val></td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethioaa"</emu-val></td>
+            <td>-5493</td>
+          </tr>
+          <tr>
+            <td><emu-val>"ethiopic"</emu-val></td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><emu-val>"gregory"</emu-val></td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td><emu-val>"hebrew"</emu-val></td>
+            <td>-3761</td>
+          </tr>
+          <tr>
+            <td><emu-val>"indian"</emu-val></td>
+            <td>78</td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-civil"</emu-val></td>
+            <td>621</td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-tbla"</emu-val></td>
+            <td>621</td>
+          </tr>
+          <tr>
+            <td><emu-val>"islamic-umalqura"</emu-val></td>
+            <td>621</td>
+          </tr>
+          <tr>
+            <td><emu-val>"japanese"</emu-val></td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td><emu-val>"persian"</emu-val></td>
+            <td>621</td>
+          </tr>
+          <tr>
+            <td><emu-val>"roc"</emu-val></td>
+            <td>1911</td>
+          </tr>
+        </tbody></table>
+      </figure></emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendardatearithmeticyearforerayear" type="abstract operation" aoid="CalendarDateArithmeticYearForEraYear">
+      <h1><span class="secnum">4.1.12</span> CalendarDateArithmeticYearForEraYear ( <var>calendar</var>, <var>era</var>, <var>eraYear</var> )</h1>
+      <p>The abstract operation CalendarDateArithmeticYearForEraYear takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_78"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that has eras), <var>era</var> (a String), and <var>eraYear</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>. It produces the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_79"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> for a given set of <var>era</var>, <var>eraYear</var> in <var>calendar</var>, a calendar that includes an era named <var>era</var>. It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>era</var> be <emu-xref aoid="CanonicalizeEraInCalendar" id="_ref_80"><a href="#sec-temporal-canonicalizeeraincalendar">CanonicalizeEraInCalendar</a></emu-xref>(<var>calendar</var>, <var>era</var>).</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>era</var> is not <emu-val>undefined</emu-val>.</li><li>If <var>calendar</var> is not listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_21"><a href="#table-calendar-types">Table 1</a></emu-xref>, return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li><li>Let <var>r</var> be the row in <emu-xref href="#table-eras" id="_ref_22"><a href="#table-eras">Table 2</a></emu-xref> with a value in the Calendar column matching <var>calendar</var> and a value in the Era column matching <var>era</var>.</li><li>Let <var>eraKind</var> be the value given in the "Era Kind" column of <var>r</var>.</li><li>Let <var>offset</var> be the value given in the "Offset" column of <var>r</var>.</li><li>If <var>eraKind</var> is <emu-const>epoch</emu-const>, return <var>eraYear</var>.</li><li>If <var>eraKind</var> is <emu-const>negative</emu-const>, return <emu-eqn class="inline">1 - <var>eraYear</var></emu-eqn>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>eraKind</var> is <emu-const>offset</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>offset</var> is not <emu-val>undefined</emu-val>.</li><li>Return <emu-eqn class="inline"><var>offset</var> + <var>eraYear</var> - 1</emu-eqn>.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarintegerstoiso" type="abstract operation" aoid="CalendarIntegersToISO">
+      <h1><span class="secnum">4.1.13</span> CalendarIntegersToISO ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var>, <var>day</var> )</h1>
+      <p>The abstract operation CalendarIntegersToISO takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_81"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>arithmeticYear</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), <var>ordinalMonth</var> (a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var>day</var> (a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. 
+          It returns an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> that corresponds with the given <var>calendar</var>-specific <var>arithmeticYear</var>, <var>ordinalMonth</var>, and <var>day</var>.
+        </p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li>If <var>arithmeticYear</var>, <var>ordinalMonth</var>, and <var>day</var> do not form a valid date in <var>calendar</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>isoDate</var> be an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> such that <emu-xref aoid="CalendarISOToDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate">CalendarISOToDate</a></emu-xref>(<var>calendar</var>, <var>isoDate</var>) returns a <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_82"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref> whose <var class="field">[[Year]]</var>, <var class="field">[[Month]]</var>, and <var class="field">[[Day]]</var> field values respectively equal <var>arithmeticYear</var>, <var>ordinalMonth</var>, and <var>day</var>.</li><li>NOTE: No known calendars have repeated dates that would cause <var>isoDate</var> to be ambiguous between two ISO Date <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Records</a></emu-xref>.</li><li>Return <var>isoDate</var>.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-calendar-date-records">
+      <h1><span class="secnum">4.1.14</span> Calendar Date Records</h1>
+      <p>
+        A <dfn variants="Calendar Date Records" tabindex="-1">Calendar Date Record</dfn> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> value used to represent a valid calendar date in a non-ISO 8601 calendar.
+        Calendar Date Records are produced by the abstract operation <emu-xref aoid="CalendarISOToDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate">CalendarISOToDate</a></emu-xref>.
+      </p>
+      <p>Calendar Date Records have the fields listed in <emu-xref href="#table-temporal-calendar-date-record-fields" id="_ref_23"><a href="#table-temporal-calendar-date-record-fields">Table 5</a></emu-xref>.</p>
+      <p>This definition supersedes the one in <emu-xref href="#sec-temporal-calendar-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendar-date-records">Temporal, 12.2.1</a></emu-xref>.</p>
+      <emu-table id="table-temporal-calendar-date-record-fields" caption="Calendar Date Record Fields"><figure><figcaption>Table 5: <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_83"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref> Fields</figcaption>
+        <table class="real-table">
+          <tbody><tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td><var class="field">[[Era]]</var></td>
+            <td>a String or <emu-val>undefined</emu-val></td>
+            <td>
+              A lowercase String value representing the date's era, or <emu-val>undefined</emu-val> for calendars that do not have eras.<br>
+              The value of this field for a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_84"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateEra" id="_ref_85"><a href="#sec-temporal-calendardateera">CalendarDateEra</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is the <var class="field">[[ISODate]]</var> field of a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[EraYear]]</var></td>
+            <td>an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> or <emu-val>undefined</emu-val></td>
+            <td>
+              The ordinal position of the date's year within its era, or <emu-val>undefined</emu-val> for calendars that do not have eras.<br>
+              The value of this field for a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_86"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateEraYear" id="_ref_87"><a href="#sec-temporal-calendardateerayear">CalendarDateEraYear</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is the <var class="field">[[ISODate]]</var> field of a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
+              <emu-note><span class="note">Note 1</span><div class="note-contents">
+                Era years are 1-indexed for many calendars, but not all (e.g., the eras of the Burmese calendar, not currently available in CLDR, each start with a year 0). Years can also advance opposite the flow of time (as for BCE years in the Gregorian calendar).
+              </div></emu-note>
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[Year]]</var></td>
+            <td>an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>
+              The date's <dfn tabindex="-1">arithmetic year</dfn>, which is the year relative to the first day of a calendar-specific <dfn tabindex="-1">epoch year</dfn>, given in <emu-xref href="#table-epoch-years" id="_ref_24"><a href="#table-epoch-years">Table 4</a></emu-xref>.<br>
+              The value of this field for a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_88"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> <var>calendar</var> should be the result of calling <emu-xref aoid="CalendarDateArithmeticYear" id="_ref_89"><a href="#sec-temporal-calendardatearithmeticyear">CalendarDateArithmeticYear</a></emu-xref>(<var>calendar</var>, <var>date</var>), where <var>date</var> is the <var class="field">[[ISODate]]</var> field of a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth value corresponding to the date.
+              <emu-note><span class="note">Note 2</span><div class="note-contents">The <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_90"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> is relative to the first day of the calendar's <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_91"><a href="#sup-temporal-calendar-date-records">epoch year</a></emu-xref>, so if the epoch era starts in the middle of the year, the year will be the same value before and after the start date of the era.</div></emu-note>
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[Month]]</var></td>
+            <td>a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>
+              The 1-based ordinal position of the date's month within its year.
+              <emu-note><span class="note">Note 3</span><div class="note-contents">
+                When the number of months in a year of the calendar is variable, a different value can be returned for dates that are part of the same month in different years. For example, in the Hebrew calendar, 1 Nisan 5781 is associated with value 7 while 1 Nisan 5782 is associated with value 8 because 5782 is a leap year and Nisan follows the insertion of Adar I.
+              </div></emu-note>
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[MonthCode]]</var></td>
+            <td>a String</td>
+            <td>
+              The month code of the date's month. The month code for a month that is not a leap month and whose 1-based ordinal position in a common year of the calendar (i.e., a year that is not a leap year) is <var>n</var> should be the <emu-xref href="#string-concatenation"><a href="https://tc39.es/ecma262/#string-concatenation">string-concatenation</a></emu-xref> of <emu-val>"M"</emu-val> and <emu-xref aoid="ToZeroPaddedDecimalString"><a href="https://tc39.es/ecma262/#sec-tozeropaddeddecimalstring">ToZeroPaddedDecimalString</a></emu-xref>(<var>n</var>, 2), and the month code for a month that is a leap month inserted after a month whose 1-based ordinal position in a common year of the calendar is <var>p</var> should be the <emu-xref href="#string-concatenation"><a href="https://tc39.es/ecma262/#string-concatenation">string-concatenation</a></emu-xref> of <emu-val>"M"</emu-val>, <emu-xref aoid="ToZeroPaddedDecimalString"><a href="https://tc39.es/ecma262/#sec-tozeropaddeddecimalstring">ToZeroPaddedDecimalString</a></emu-xref>(<var>p</var>, 2), and <emu-val>"L"</emu-val>.
+              <emu-note><span class="note">Note 4</span><div class="note-contents">
+                For example, in the Hebrew calendar, the month code of Adar (and Adar II, in leap years) is <emu-val>"M06"</emu-val> and the month code of Adar I (the leap month inserted before Adar II) is <emu-val>"M05L"</emu-val>. Theoretically, in a calendar with a leap month at the start of some years, the month code of that month would be <emu-val>"M00L"</emu-val>.
+              </div></emu-note>
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[Day]]</var></td>
+            <td>a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>
+              The 1-based ordinal position of the date's day within its month.
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[DayOfWeek]]</var></td>
+            <td>a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>
+              The day of the week corresponding to the date. The value should be 1-based, where 1 is the day corresponding to Monday in the given calendar.
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[DayOfYear]]</var></td>
+            <td>a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>
+              The 1-based ordinal position of the date's day within its year.
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[WeekOfYear]]</var></td>
+            <td>a <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref></td>
+            <td>
+              <p>The date's <em>calendar week of year</em>, and the corresponding <em>week calendar year</em>.</p>
+              <p>The <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Week]]</var> field should be 1-based.</p>
+              <p>The <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Year]]</var> field is an <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_92"><a href="#sup-temporal-calendar-date-records">arithmetic year</a></emu-xref> as in the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_93"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref>'s <var class="field">[[Year]]</var> field, not relative to an era as in <var class="field">[[EraYear]]</var>.</p>
+              <p>
+                Usually the <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Year]]</var> field will contain the same value as the <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_94"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref>'s <var class="field">[[Year]]</var> field, but may contain the previous or next year if the week number in the <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref>'s <var class="field">[[Week]]</var> field overlaps two different years.
+                See also ISOWeekOfYear.
+              </p>
+              <p>The <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref> contains <emu-val>undefined</emu-val> in <var class="field">[[Week]]</var> and <var class="field">[[Year]]</var> field for calendars that do not have a well-defined week numbering system.</p>
+              <emu-note><span class="note">Note 5</span><div class="note-contents">
+                Currently, of the calendars supported in this specification, only <emu-val>"iso8601"</emu-val> has a well-defined, locale-independent week numbering system.
+                For all other calendars, the <emu-xref href="#sec-year-week-record-specification-type"><a href="https://tc39.es/proposal-temporal/#sec-year-week-record-specification-type">Year-Week Record</a></emu-xref> fields are <emu-val>undefined</emu-val>.
+              </div></emu-note>
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[DaysInWeek]]</var></td>
+            <td>a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>
+              <p>The number of days in the primary notion of week used by the calendar. For all calendars currently supported by this specification, this number is 7.</p>
+              <emu-note><span class="note">Note 6</span><div class="note-contents">
+                Some calendars have alternate cyclic notions that are similar to the 7-day week; many of them have multiple (like the Javanese calendar). This specification does not cover such calendars but can be extended to do so in the future.
+              </div></emu-note>
+            </td>
+          </tr>
+          <tr>
+            <td><var class="field">[[DaysInMonth]]</var></td>
+            <td>a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>The number of days in the date's month.</td>
+          </tr>
+          <tr>
+            <td><var class="field">[[DaysInYear]]</var></td>
+            <td>a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>The number of days in the date's year.</td>
+          </tr>
+          <tr>
+            <td><var class="field">[[MonthsInYear]]</var></td>
+            <td>a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref></td>
+            <td>The number of months in the date's year.</td>
+          </tr>
+          <tr>
+            <td><var class="field">[[InLeapYear]]</var></td>
+            <td>a Boolean</td>
+            <td>
+              <emu-val>true</emu-val> if the date falls within a leap year, and <emu-val>false</emu-val> otherwise.
+              <emu-note><span class="note">Note 7</span><div class="note-contents">
+                A "leap year" is a year that contains more days than other years (for solar or lunar calendars) or more months than other years (for lunisolar calendars like Hebrew or Chinese).
+                Some calendars, especially lunisolar ones, have further variation in year length that is not represented in the output of this operation (e.g., the Hebrew calendar includes common years with 353, 354, or 355 days and leap years with 383, 384, or 385 days).
+              </div></emu-note>
+            </td>
+          </tr>
+        </tbody></table>
+      </figure></emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarmonthsinyear" type="abstract operation" aoid="CalendarMonthsInYear">
+      <h1><span class="secnum">4.1.15</span> CalendarMonthsInYear ( <var>calendar</var>, <var>arithmeticYear</var> )</h1>
+      <p>The abstract operation CalendarMonthsInYear takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_95"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>arithmeticYear</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>. 
+          It interprets <var>arithmeticYear</var> as a year in the given calendar in the same way as <emu-xref aoid="CalendarDateArithmeticYear" id="_ref_96"><a href="#sec-temporal-calendardatearithmeticyear">CalendarDateArithmeticYear</a></emu-xref>. The returned value represents the number of months in that year.        </p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-balancenonisodate" type="abstract operation" aoid="BalanceNonISODate">
+      <h1><span class="secnum">4.1.16</span> BalanceNonISODate ( <var>calendar</var>, <var>arithmeticYear</var>, <var>ordinalMonth</var>, <var>day</var> )</h1>
+      <p>The abstract operation BalanceNonISODate takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_97"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>arithmeticYear</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), <var>ordinalMonth</var> (a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var>day</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> with fields <var class="field">[[Year]]</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), <var class="field">[[Month]]</var> (a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var class="field">[[Day]]</var> (a positive <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>). 
+          It interprets the given <var>arithmeticYear</var>, potentially out-of-range <var>ordinalMonth</var>, and potentially out-of-range <var>day</var> as arithmetical values in the given <var>calendar</var> and returns in-range values by overflowing out-of-range <var>ordinalMonth</var> or <var>day</var> values into the next-highest unit.
+          This date may correspond to a date in the ISO calendar that is outside the range given by ISODateTimeWithinLimits.
+        </p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>resolvedYear</var> be <var>arithmeticYear</var>.</li><li>Let <var>resolvedMonth</var> be <var>ordinalMonth</var>.</li><li>Let <var>monthsInYear</var> be <emu-xref aoid="CalendarMonthsInYear" id="_ref_98"><a href="#sec-temporal-calendarmonthsinyear">CalendarMonthsInYear</a></emu-xref>(<var>calendar</var>, <var>resolvedYear</var>).</li><li>Repeat, while <var>resolvedMonth</var> ≤ 0,<ol><li>Set <var>resolvedYear</var> to <var>resolvedYear</var> - 1.</li><li>Set <var>monthsInYear</var> to <emu-xref aoid="CalendarMonthsInYear" id="_ref_99"><a href="#sec-temporal-calendarmonthsinyear">CalendarMonthsInYear</a></emu-xref>(<var>calendar</var>, <var>resolvedYear</var>).</li><li>Set <var>resolvedMonth</var> to <var>resolvedMonth</var> + <var>monthsInYear</var>.</li></ol></li><li>Repeat, while <var>resolvedMonth</var> &gt; <var>monthsInYear</var>,<ol><li>Set <var>resolvedMonth</var> to <var>resolvedMonth</var> - <var>monthsInYear</var>.</li><li>Set <var>resolvedYear</var> to <var>resolvedYear</var> + 1.</li><li>Set <var>monthsInYear</var> to <emu-xref aoid="CalendarMonthsInYear" id="_ref_100"><a href="#sec-temporal-calendarmonthsinyear">CalendarMonthsInYear</a></emu-xref>(<var>calendar</var>, <var>resolvedYear</var>).</li></ol></li><li>Let <var>resolvedDay</var> be <var>day</var>.</li><li>Let <var>daysInMonth</var> be <emu-xref aoid="CalendarDaysInMonth" id="_ref_101"><a href="#sec-temporal-calendardaysinmonth">CalendarDaysInMonth</a></emu-xref>(<var>calendar</var>, <var>resolvedYear</var>, <var>resolvedMonth</var>).</li><li>Repeat, while <var>resolvedDay</var> ≤ 0,<ol><li>Set <var>resolvedMonth</var> to <var>resolvedMonth</var> - 1.</li><li>If <var>resolvedMonth</var> is 0, then<ol><li>Set <var>resolvedYear</var> to <var>resolvedYear</var> - 1.</li><li>Set <var>monthsInYear</var> to <emu-xref aoid="CalendarMonthsInYear" id="_ref_102"><a href="#sec-temporal-calendarmonthsinyear">CalendarMonthsInYear</a></emu-xref>(<var>calendar</var>, <var>resolvedYear</var>).</li><li>Set <var>resolvedMonth</var> to <var>monthsInYear</var>.</li></ol></li><li>Set <var>daysInMonth</var> to <emu-xref aoid="CalendarDaysInMonth" id="_ref_103"><a href="#sec-temporal-calendardaysinmonth">CalendarDaysInMonth</a></emu-xref>(<var>calendar</var>, <var>resolvedYear</var>, <var>resolvedMonth</var>).</li><li>Set <var>resolvedDay</var> to <var>resolvedDay</var> + <var>daysInMonth</var>.</li></ol></li><li>Repeat, while <var>resolvedDay</var> &gt; <var>daysInMonth</var>,<ol><li>Set <var>resolvedDay</var> to <var>resolvedDay</var> - <var>daysInMonth</var>.</li><li>Set <var>resolvedMonth</var> to <var>resolvedMonth</var> + 1.</li><li>If <var>resolvedMonth</var> &gt; <var>monthsInYear</var>, then<ol><li>Set <var>resolvedYear</var> to <var>resolvedYear</var> + 1.</li><li>Set <var>monthsInYear</var> to <emu-xref aoid="CalendarMonthsInYear" id="_ref_104"><a href="#sec-temporal-calendarmonthsinyear">CalendarMonthsInYear</a></emu-xref>(<var>calendar</var>, <var>resolvedYear</var>).</li><li>Set <var>resolvedMonth</var> to 1.</li></ol></li><li>Set <var>daysInMonth</var> to <emu-xref aoid="CalendarDaysInMonth" id="_ref_105"><a href="#sec-temporal-calendardaysinmonth">CalendarDaysInMonth</a></emu-xref>(<var>calendar</var>, <var>resolvedYear</var>, <var>resolvedMonth</var>).</li></ol></li><li>Return the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { <var class="field">[[Year]]</var>: <var>resolvedYear</var>, <var class="field">[[Month]]</var>: <var>resolvedMonth</var>, <var class="field">[[Day]]</var>: <var>resolvedDay</var>&nbsp;}.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-nonisodatesurpasses" type="abstract operation" aoid="NonISODateSurpasses">
+      <h1><span class="secnum">4.1.17</span> NonISODateSurpasses ( <var>calendar</var>, <var>sign</var>, <var>fromIsoDate</var>, <var>toIsoDate</var>, <var>years</var>, <var>months</var>, <var>weeks</var>, <var>days</var> )</h1>
+      <p>The abstract operation NonISODateSurpasses takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_106"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>sign</var> (-1 or 1), <var>fromIsoDate</var> (an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>), <var>toIsoDate</var> (an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>), <var>years</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), <var>months</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), <var>weeks</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>), and <var>days</var> (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns a Boolean. 
+          The return value indicates whether the date <var>date1</var>, the result of adding the duration denoted by <var>years</var>, <var>months</var>, <var>weeks</var>, and <var>days</var> to <var>fromIsoDate</var> in the calendar system denoted by <var>calendar</var>, surpasses <var>toIsoDate</var> in the direction denoted by <var>sign</var>.
+          If <var>weeks</var> and <var>days</var> are both zero, then <var>date1</var> need not exist (for example, it could be February 30).
+        </p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>parts</var> be <emu-xref aoid="CalendarISOToDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate">CalendarISOToDate</a></emu-xref>(<var>calendar</var>, <var>fromIsoDate</var>).</li><li>Let <var>y0</var> be <var>parts</var>.<var class="field">[[Year]]</var> + <var>years</var>.</li><li>Let <var>m0</var> be <emu-xref aoid="MonthCodeToOrdinal" id="_ref_107"><a href="#sec-temporal-monthcodetoordinal">MonthCodeToOrdinal</a></emu-xref>(<var>calendar</var>, <var>y0</var>, !&nbsp;<emu-xref aoid="ConstrainMonthCode" id="_ref_108"><a href="#sec-temporal-constrainmonthcode">ConstrainMonthCode</a></emu-xref>(<var>calendar</var>, <var>y0</var>, <var>parts</var>.<var class="field">[[MonthCode]]</var>, <emu-const>constrain</emu-const>)).</li><li>Let <var>endOfMonth</var> be <emu-xref aoid="BalanceNonISODate" id="_ref_109"><a href="#sec-temporal-balancenonisodate">BalanceNonISODate</a></emu-xref>(<var>calendar</var>, <var>y0</var>, <var>m0</var> + <var>months</var> + 1, 0).</li><li>Let <var>baseDay</var> be <var>parts</var>.<var class="field">[[Day]]</var>.</li><li>If <var>weeks</var> is not 0 or <var>days</var> is not 0, then<ol><li>If <var>baseDay</var> ≤ <var>endOfMonth</var>.<var class="field">[[Day]]</var>, then<ol><li>Let <var>regulatedDay</var> be <var>baseDay</var>.</li></ol></li><li>Else,<ol><li>Let <var>regulatedDay</var> be <var>endOfMonth</var>.<var class="field">[[Day]]</var>.</li></ol></li><li>Let <var>daysInWeek</var> be 7 (the number of days in a week for all supported calendars).</li><li>Let <var>balancedDate</var> be <emu-xref aoid="BalanceNonISODate" id="_ref_110"><a href="#sec-temporal-balancenonisodate">BalanceNonISODate</a></emu-xref>(<var>calendar</var>, <var>endOfMonth</var>.<var class="field">[[Year]]</var>, <var>endOfMonth</var>.<var class="field">[[Month]]</var>, <var>regulatedDay</var> + <var>daysInWeek</var> * <var>weeks</var> + <var>days</var>).</li><li>Let <var>y1</var> be <var>balancedDate</var>.<var class="field">[[Year]]</var>.</li><li>Let <var>m1</var> be <var>balancedDate</var>.<var class="field">[[Month]]</var>.</li><li>Let <var>d1</var> be <var>balancedDate</var>.<var class="field">[[Day]]</var>.</li></ol></li><li>Else,<ol><li>Let <var>y1</var> be <var>endOfMonth</var>.<var class="field">[[Year]]</var>.</li><li>Let <var>m1</var> be <var>endOfMonth</var>.<var class="field">[[Month]]</var>.</li><li>Let <var>d1</var> be <var>baseDay</var>.</li></ol></li><li>Let <var>calDate2</var> be <emu-xref aoid="CalendarISOToDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate">CalendarISOToDate</a></emu-xref>(<var>calendar</var>, <var>toIsoDate</var>).</li><li>If <var>y1</var> ≠ <var>calDate2</var>.<var class="field">[[Year]]</var>, then<ol><li>If <var>sign</var> × (<var>y1</var> - <var>calDate2</var>.<var class="field">[[Year]]</var>) &gt; 0, return <emu-val>true</emu-val>.</li></ol></li><li>Else if <var>m1</var> ≠ <var>calDate2</var>.<var class="field">[[Month]]</var>, then<ol><li>If <var>sign</var> × (<var>m1</var> - <var>calDate2</var>.<var class="field">[[Month]]</var>) &gt; 0, return <emu-val>true</emu-val>.</li></ol></li><li>Else if <var>d1</var> ≠ <var>calDate2</var>.<var class="field">[[Day]]</var>, then<ol><li>If <var>sign</var> × (<var>d1</var> - <var>calDate2</var>.<var class="field">[[Day]]</var>) &gt; 0, return <emu-val>true</emu-val>.</li></ol></li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-nonisodateadd" type="abstract operation" aoid="NonISODateAdd">
+      <h1><span class="secnum">4.1.18</span> NonISODateAdd ( <var>calendar</var>, <var>isoDate</var>, <var>duration</var>, <var>overflow</var> )</h1>
+      <p>The abstract operation NonISODateAdd takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_111"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>isoDate</var> (an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>), <var>duration</var> (a <emu-xref href="#sec-temporal-date-duration-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-date-duration-records">Date Duration Record</a></emu-xref>), and <var>overflow</var> (<emu-const>constrain</emu-const> or <emu-const>reject</emu-const>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. 
+          The operation performs processing to add <var>duration</var> to <var>date</var> in the context of the calendar represented by <var>calendar</var> and returns the corresponding day, month and year of the result in the ISO 8601 calendar values as an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>.
+          It may throw a <emu-val>RangeError</emu-val> exception if <var>overflow</var> is <emu-const>reject</emu-const> and the resulting month or day would need to be clamped in order to form a valid date in <var>calendar</var>.
+        </p>
+      <p>All calendars follow the steps given here, which is a generalization of the precise algorithm specified in CalendarDateAdd for <emu-val>"iso8601"</emu-val>.</p>
+      <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-nonisodateadd"><a href="https://tc39.es/proposal-temporal/#sec-temporal-nonisodateadd">Temporal, 12.2.6</a></emu-xref>.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>parts</var> be <emu-xref aoid="CalendarISOToDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate">CalendarISOToDate</a></emu-xref>(<var>calendar</var>, <var>isoDate</var>).</li><li>Let <var>y0</var> be <var>parts</var>.<var class="field">[[Year]]</var> + <var>duration</var>.<var class="field">[[Years]]</var>.</li><li>Let <var>m0</var> be <emu-xref aoid="MonthCodeToOrdinal" id="_ref_112"><a href="#sec-temporal-monthcodetoordinal">MonthCodeToOrdinal</a></emu-xref>(<var>calendar</var>, <var>y0</var>, ?&nbsp;<emu-xref aoid="ConstrainMonthCode" id="_ref_113"><a href="#sec-temporal-constrainmonthcode">ConstrainMonthCode</a></emu-xref>(<var>calendar</var>, <var>y0</var>, <var>parts</var>.<var class="field">[[MonthCode]]</var>, <var>overflow</var>)).</li><li>Let <var>endOfMonth</var> be <emu-xref aoid="BalanceNonISODate" id="_ref_114"><a href="#sec-temporal-balancenonisodate">BalanceNonISODate</a></emu-xref>(<var>calendar</var>, <var>y0</var>, <var>m0</var> + <var>duration</var>.<var class="field">[[Months]]</var> + 1, 0).</li><li>Let <var>baseDay</var> be <var>parts</var>.<var class="field">[[Day]]</var>.</li><li>If <var>baseDay</var> ≤ <var>endOfMonth</var>.<var class="field">[[Day]]</var>, then<ol><li>Let <var>regulatedDay</var> be <var>baseDay</var>.</li></ol></li><li>Else,<ol><li>If <var>overflow</var> is <emu-const>reject</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>regulatedDay</var> be <var>endOfMonth</var>.<var class="field">[[Day]]</var>.</li></ol></li><li>Let <var>balancedDate</var> be <emu-xref aoid="BalanceNonISODate" id="_ref_115"><a href="#sec-temporal-balancenonisodate">BalanceNonISODate</a></emu-xref>(<var>calendar</var>, <var>endOfMonth</var>.<var class="field">[[Year]]</var>, <var>endOfMonth</var>.<var class="field">[[Month]]</var>, <var>regulatedDay</var> + 7 * <var>duration</var>.<var class="field">[[Weeks]]</var> + <var>duration</var>.<var class="field">[[Days]]</var>).</li><li>Let <var>result</var> be ?&nbsp;<emu-xref aoid="CalendarIntegersToISO" id="_ref_116"><a href="#sec-temporal-calendarintegerstoiso">CalendarIntegersToISO</a></emu-xref>(<var>calendar</var>, <var>balancedDate</var>.<var class="field">[[Year]]</var>, <var>balancedDate</var>.<var class="field">[[Month]]</var>, <var>balancedDate</var>.<var class="field">[[Day]]</var>).</li><li>If <emu-xref aoid="ISODateWithinLimits"><a href="https://tc39.es/proposal-temporal/#sec-temporal-isodatewithinlimits">ISODateWithinLimits</a></emu-xref>(<var>result</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Return <var>result</var>.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-nonisodateuntil" type="abstract operation" aoid="NonISODateUntil">
+      <h1><span class="secnum">4.1.19</span> NonISODateUntil ( <var>calendar</var>, <var>one</var>, <var>two</var>, <var>largestUnit</var> )</h1>
+      <p>The abstract operation NonISODateUntil takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_117"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>one</var> (an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>), <var>two</var> (an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref>), and <var>largestUnit</var> (a date unit) and returns a <emu-xref href="#sec-temporal-date-duration-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-date-duration-records">Date Duration Record</a></emu-xref>. 
+          It determines the difference between the dates <var>one</var> and <var>two</var> using the years, months, and weeks reckoning of <var>calendar</var>.
+          No fields larger than <var>largestUnit</var> will be non-zero in the resulting <emu-xref href="#sec-temporal-date-duration-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-date-duration-records">Date Duration Record</a></emu-xref>.
+        </p>
+      <p>All calendars follow the steps given here, which is a generalization of the precise algorithm specified in CalendarDateUntil for <emu-val>"iso8601"</emu-val>.</p>
+      <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-nonisodateuntil"><a href="https://tc39.es/proposal-temporal/#sec-temporal-nonisodateuntil">Temporal, 12.2.8</a></emu-xref>.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>sign</var> be -1 × <emu-xref aoid="CompareISODate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-compareisodate">CompareISODate</a></emu-xref>(<var>one</var>, <var>two</var>).</li><li>If <var>sign</var> = 0, return <emu-xref aoid="ZeroDateDuration"><a href="https://tc39.es/proposal-temporal/#sec-temporal-zerodateduration">ZeroDateDuration</a></emu-xref>().</li><li>Let <var>years</var> be 0.</li><li>If <var>largestUnit</var> is <emu-const>year</emu-const>, then<ol><li>Let <var>candidateYears</var> be <var>sign</var>.</li><li>Repeat, while <emu-xref aoid="NonISODateSurpasses" id="_ref_118"><a href="#sec-temporal-nonisodatesurpasses">NonISODateSurpasses</a></emu-xref>(<var>calendar</var>, <var>sign</var>, <var>one</var>, <var>two</var>, <var>candidateYears</var>, 0, 0, 0) is <emu-val>false</emu-val>,<ol><li>Set <var>years</var> to <var>candidateYears</var>.</li><li>Set <var>candidateYears</var> to <var>candidateYears</var> + <var>sign</var>.</li></ol></li></ol></li><li>Let <var>months</var> be 0.</li><li>If <var>largestUnit</var> is <emu-const>year</emu-const> or <var>largestUnit</var> is <emu-const>month</emu-const>, then<ol><li>Let <var>candidateMonths</var> be <var>sign</var>.</li><li>Repeat, while <emu-xref aoid="NonISODateSurpasses" id="_ref_119"><a href="#sec-temporal-nonisodatesurpasses">NonISODateSurpasses</a></emu-xref>(<var>calendar</var>, <var>sign</var>, <var>one</var>, <var>two</var>, <var>years</var>, <var>candidateMonths</var>, 0, 0) is <emu-val>false</emu-val>,<ol><li>Set <var>months</var> to <var>candidateMonths</var>.</li><li>Set <var>candidateMonths</var> to <var>candidateMonths</var> + <var>sign</var>.</li></ol></li></ol></li><li>Let <var>weeks</var> be 0.</li><li>If <var>largestUnit</var> is <emu-const>week</emu-const>, then<ol><li>Let <var>candidateWeeks</var> be <var>sign</var>.</li><li>Repeat, while <emu-xref aoid="NonISODateSurpasses" id="_ref_120"><a href="#sec-temporal-nonisodatesurpasses">NonISODateSurpasses</a></emu-xref>(<var>calendar</var>, <var>sign</var>, <var>one</var>, <var>two</var>, <var>years</var>, <var>months</var>, <var>candidateWeeks</var>, 0) is <emu-val>false</emu-val>,<ol><li>Set <var>weeks</var> to <var>candidateWeeks</var>.</li><li>Set <var>candidateWeeks</var> to <var>candidateWeeks</var> + sign.</li></ol></li></ol></li><li>Let <var>days</var> be 0.</li><li>Let <var>candidateDays</var> be <var>sign</var>.</li><li>Repeat, while <emu-xref aoid="NonISODateSurpasses" id="_ref_121"><a href="#sec-temporal-nonisodatesurpasses">NonISODateSurpasses</a></emu-xref>(<var>calendar</var>, <var>sign</var>, <var>one</var>, <var>two</var>, <var>years</var>, <var>months</var>, <var>weeks</var>, <var>candidateDays</var>) is <emu-val>false</emu-val>,<ol><li>Set <var>days</var> to <var>candidateDays</var>.</li><li>Set <var>candidateDays</var> to <var>candidateDays</var> + <var>sign</var>.</li></ol></li><li>Return !&nbsp;<emu-xref aoid="CreateDateDurationRecord"><a href="https://tc39.es/proposal-temporal/#sec-temporal-createdatedurationrecord">CreateDateDurationRecord</a></emu-xref>(<var>years</var>, <var>months</var>, <var>weeks</var>, <var>days</var>).</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-nonisocalendardatetoiso" type="abstract operation" aoid="NonISOCalendarDateToISO">
+      <h1><span class="secnum">4.1.20</span> NonISOCalendarDateToISO ( <var>calendar</var>, <var>fields</var>, <var>overflow</var> )</h1>
+      <p>The abstract operation NonISOCalendarDateToISO takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_122"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>fields</var> (a Calendar Fields <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>), and <var>overflow</var> (<emu-const>constrain</emu-const> or <emu-const>reject</emu-const>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. 
+          It converts <var>fields</var>, which represents either a date or a year and month in the built-in calendar identified by <var>calendar</var>, to a corresponding representative date in the ISO 8601 calendar, subject to overflow correction specified by <var>overflow</var>.
+          For <emu-const>reject</emu-const>, values that do not form a valid date cause an exception to be thrown, as described below.
+          For <emu-const>constrain</emu-const>, values that do not form a valid date are clamped to their respective valid range.
+        </p>
+      <p>Like <emu-xref aoid="RegulateISODate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-regulateisodate">RegulateISODate</a></emu-xref>, the operation throws a <emu-val>RangeError</emu-val> exception when <var>overflow</var> is <emu-const>reject</emu-const> and the date described by <var>fields</var> does not exist.</p>
+      <p><emu-xref href="#clamping"><a href="https://tc39.es/ecma262/#clamping">Clamping</a></emu-xref> an invalid date to the correct range when <var>overflow</var> is <emu-const>constrain</emu-const> is a behaviour specific to each calendar other than <emu-val>"iso8601"</emu-val>, but all calendars follow this guideline.</p>
+      <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-nonisocalendardatetoiso"><a href="https://tc39.es/proposal-temporal/#sec-temporal-nonisocalendardatetoiso">Temporal, 12.2.21</a></emu-xref>.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>fields</var>.<var class="field">[[Year]]</var>, <var>fields</var>.<var class="field">[[Month]]</var>, and <var>fields</var>.<var class="field">[[Day]]</var> are not <emu-const>unset</emu-const>.</li><li>If <var>fields</var>.<var class="field">[[MonthCode]]</var> is not <emu-const>unset</emu-const>, then<ol><li>Perform ?&nbsp;<emu-xref aoid="ConstrainMonthCode" id="_ref_123"><a href="#sec-temporal-constrainmonthcode">ConstrainMonthCode</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>fields</var>.<var class="field">[[MonthCode]]</var>, <var>overflow</var>).</li></ol></li><li>Let <var>daysInMonth</var> be <emu-xref aoid="CalendarDaysInMonth" id="_ref_124"><a href="#sec-temporal-calendardaysinmonth">CalendarDaysInMonth</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>fields</var>.<var class="field">[[Month]]</var>).</li><li>If <var>fields</var>.<var class="field">[[Day]]</var> &gt; <var>daysInMonth</var>, then<ol><li>If <var>overflow</var> is <emu-const>reject</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>day</var> be <var>daysInMonth</var>.</li></ol></li><li>Else,<ol><li>Let <var>day</var> be <var>fields</var>.<var class="field">[[Day]]</var>.</li></ol></li><li>Return ?&nbsp;<emu-xref aoid="CalendarIntegersToISO" id="_ref_125"><a href="#sec-temporal-calendarintegerstoiso">CalendarIntegersToISO</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>fields</var>.<var class="field">[[Month]]</var>, <var>day</var>).</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-nonisomonthdaytoisoreferencedate" type="implementation-defined abstract operation" aoid="NonISOMonthDayToISOReferenceDate">
+      <h1><span class="secnum">4.1.21</span> NonISOMonthDayToISOReferenceDate ( <var>calendar</var>, <var>fields</var>, <var>overflow</var> )</h1>
+      <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation NonISOMonthDayToISOReferenceDate takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_126"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>fields</var> (a Calendar Fields <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>), and <var>overflow</var> (<emu-const>constrain</emu-const> or <emu-const>reject</emu-const>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. 
+          It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to convert <var>fields</var>, which represents a calendar date without a year (i.e., month code and day pair, or equivalent) in the built-in calendar identified by <var>calendar</var>, to a corresponding reference date in the ISO 8601 calendar as described below, subject to overflow correction specified by <var>overflow</var>.
+          For <emu-const>reject</emu-const>, values that do not form a valid date cause an exception to be thrown.
+          For <emu-const>constrain</emu-const>, values that do not form a valid date are clamped to their respective valid range as in <emu-xref aoid="CalendarDateToISO"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendardatetoiso">CalendarDateToISO</a></emu-xref>.
+        </p>
+      <p>
+        The fields of the returned <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> represent a reference date in the ISO 8601 calendar that, when converted to <var>calendar</var>, corresponds to the month code and day of <var>fields</var> in an arbitrary but deterministically chosen reference year.
+        The reference date is the latest ISO 8601 date corresponding to the calendar date that is between January 1, 1900 and December 31, 1972 inclusive. If there is no such date, it is the earliest ISO 8601 date corresponding to the calendar date between January 1, 1973 and December 31, 2035 inclusive.
+        The reference year is almost always 1972 (the first ISO 8601 leap year after the epoch), with exceptions for calendars where some dates (e.g. leap days or days in leap months) didn't occur during that ISO 8601 year. For example, Hebrew calendar leap month Adar I occurred in calendar years 5730 and 5733 (respectively overlapping ISO 8601 February/March 1970 and February/March 1973), but did not occur between them, so the reference year for days of that month is 1970.
+      </p>
+      <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-nonisomonthdaytoisoreferencedate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-nonisomonthdaytoisoreferencedate">Temporal, 12.3.23</a></emu-xref>.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>fields</var>.<var class="field">[[Month]]</var> and <var>fields</var>.<var class="field">[[Day]]</var> are not <emu-const>unset</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: If <var>fields</var>.<var class="field">[[MonthCode]]</var> is <emu-const>unset</emu-const>, <var>fields</var>.<var class="field">[[Year]]</var> is not <emu-const>unset</emu-const>.</li><li>Let <var>monthCode</var> be <var>fields</var>.<var class="field">[[MonthCode]]</var>.</li><li>If <var>fields</var>.<var class="field">[[Year]]</var> is not <emu-const>unset</emu-const>, then<ol><li declared="isoDate">If there exists no combination of inputs such that !&nbsp;<emu-xref aoid="CalendarIntegersToISO" id="_ref_127"><a href="#sec-temporal-calendarintegerstoiso">CalendarIntegersToISO</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, ..., ...) would return an <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> <var>isoDate</var> for which <emu-xref aoid="ISODateWithinLimits"><a href="https://tc39.es/proposal-temporal/#sec-temporal-isodatewithinlimits">ISODateWithinLimits</a></emu-xref>(<var>isoDate</var>) is <emu-val>true</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>NOTE: The above step exists so as not to require calculating whether the month and day described in <var>fields</var> exist in user-provided years arbitrarily far in the future or past.</li><li>If <var>monthCode</var> is not <emu-const>unset</emu-const>, then<ol><li>Set <var>monthCode</var> to ?&nbsp;<emu-xref aoid="ConstrainMonthCode" id="_ref_128"><a href="#sec-temporal-constrainmonthcode">ConstrainMonthCode</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>monthCode</var>, <var>overflow</var>).</li></ol></li><li>Let <var>daysInMonth</var> be <emu-xref aoid="CalendarDaysInMonth" id="_ref_129"><a href="#sec-temporal-calendardaysinmonth">CalendarDaysInMonth</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>fields</var>.<var class="field">[[Month]]</var>).</li></ol></li><li>Else,<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>monthCode</var> is not <emu-const>unset</emu-const>.</li><li>If <var>calendar</var> is <emu-val>"chinese"</emu-val> or <emu-val>"dangi"</emu-val>, then<ol><li>NOTE: This special case handles combinations of month and day that theoretically could occur but are not known to have occurred historically and cannot be accurately calculated to occur in the future, even if it may be possible to construct a PlainDate with such combinations due to inaccurate approximations. This is explicitly mentioned here because as time goes on, these dates may become known to have occurred historically, or may be more accurately calculated to occur in the future.</li><li>Let <var>row</var> be the row in in <emu-xref href="#chinese-dangi-iso-reference-years" id="_ref_25"><a href="#chinese-dangi-iso-reference-years">Table 6</a></emu-xref> with a value in the "Month Code" column matching <var>monthCode</var>.</li><li>If the "Reference Year (Days 1–29)" column of <var>row</var> is "—", or <var>fields</var>.<var class="field">[[Day]]</var> ≥ 30 and the "Reference Year (<emu-not-ref>Day</emu-not-ref> 30)" column of <var>row</var> is "—", then<ol><li>If <var>overflow</var> is <emu-const>reject</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>monthCode</var> to <emu-xref aoid="CreateMonthCode"><a href="https://tc39.es/proposal-temporal/#sec-temporal-createmonthcode">CreateMonthCode</a></emu-xref>(! <emu-xref aoid="ParseMonthCode"><a href="https://tc39.es/proposal-temporal/#sec-temporal-parsemonthcode">ParseMonthCode</a></emu-xref>(<var>monthCode</var>).<var class="field">[[MonthNumber]]</var>, <emu-val>false</emu-val>).</li></ol></li><li>Let <var>daysInMonth</var> be 30.</li></ol></li><li>Else,<ol><li>Let <var>daysInMonth</var> be the maximum number of days in the month described by <var>monthCode</var> in any year.</li></ol></li></ol></li><li>If <var>fields</var>.<var class="field">[[Day]]</var> &gt; <var>daysInMonth</var>, then<ol><li>If <var>overflow</var> is <emu-const>reject</emu-const>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>day</var> be <var>daysInMonth</var>.</li></ol></li><li>Else,<ol><li>Let <var>day</var> be <var>fields</var>.<var class="field">[[Day]]</var>.</li></ol></li><li>If <var>monthCode</var> is <emu-const>unset</emu-const>, then<ol><li>Let <var>fieldsISODate</var> be !&nbsp;<emu-xref aoid="CalendarIntegersToISO" id="_ref_130"><a href="#sec-temporal-calendarintegerstoiso">CalendarIntegersToISO</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>fields</var>.<var class="field">[[Month]]</var>, <var>day</var>).</li><li>Set <var>monthCode</var> to <emu-xref aoid="NonISOCalendarISOToDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-nonisocalendarisotodate">NonISOCalendarISOToDate</a></emu-xref>(<var>calendar</var>, <var>fieldsISODate</var>).<var class="field">[[MonthCode]]</var>.</li></ol></li><li>Let <var>referenceYear</var> be the ISO reference year for <var>monthCode</var> and <var>day</var> as described above. If <var>calendar</var> is <emu-val>"chinese"</emu-val> or <emu-val>"dangi"</emu-val>, the reference years in <emu-xref href="#chinese-dangi-iso-reference-years" id="_ref_26"><a href="#chinese-dangi-iso-reference-years">Table 6</a></emu-xref> are to be used.</li><li>Return the latest possible <emu-xref href="#sec-temporal-iso-date-records"><a href="https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records">ISO Date Record</a></emu-xref> <var>isoDate</var> such that <var>isoDate</var>.<var class="field">[[Year]]</var> = <var>referenceYear</var> and <emu-xref aoid="NonISOCalendarISOToDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-nonisocalendarisotodate">NonISOCalendarISOToDate</a></emu-xref>(<var>calendar</var>, <var>isoDate</var>) returns a <emu-xref href="#sup-temporal-calendar-date-records" id="_ref_131"><a href="#sup-temporal-calendar-date-records">Calendar Date Record</a></emu-xref> whose <var class="field">[[MonthCode]]</var> and <var class="field">[[Day]]</var> field values respectively equal <var>monthCode</var> and <var>day</var>.</li></ol></emu-alg>
+
+      <emu-table id="chinese-dangi-iso-reference-years"><figure><figcaption>Table 6: <emu-val>"chinese"</emu-val> and <emu-val>"dangi"</emu-val> Calendars ISO Reference Years</figcaption>
+        
+        <table>
+          <thead>
+            <tr>
+              <th>Month Code</th>
+              <th>Reference Year (Days 1–29)</th>
+              <th>Reference Year (<emu-not-ref>Day</emu-not-ref> 30)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>M01</td>
+              <td>1972</td>
+              <td>1970</td>
+            </tr>
+            <tr>
+              <td>M01L</td>
+              <td>—</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M02</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M02L</td>
+              <td>1947</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M03</td>
+              <td>1972</td>
+              <td><emu-val>"chinese"</emu-val>: 1966<br><emu-val>"dangi"</emu-val>: 1968</td>
+            </tr>
+            <tr>
+              <td>M03L</td>
+              <td>1966</td>
+              <td>1955</td>
+            </tr>
+            <tr>
+              <td>M04</td>
+              <td>1972</td>
+              <td>1970</td>
+            </tr>
+            <tr>
+              <td>M04L</td>
+              <td>1963</td>
+              <td>1944</td>
+            </tr>
+            <tr>
+              <td>M05</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M05L</td>
+              <td>1971</td>
+              <td>1952</td>
+            </tr>
+            <tr>
+              <td>M06</td>
+              <td>1972</td>
+              <td>1971</td>
+            </tr>
+            <tr>
+              <td>M06L</td>
+              <td>1960</td>
+              <td>1941</td>
+            </tr>
+            <tr>
+              <td>M07</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M07L</td>
+              <td>1968</td>
+              <td>1938</td>
+            </tr>
+            <tr>
+              <td>M08</td>
+              <td>1972</td>
+              <td>1971</td>
+            </tr>
+            <tr>
+              <td>M08L</td>
+              <td>1957</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M09</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M09L</td>
+              <td>2014</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M10</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M10L</td>
+              <td>1984</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M11</td>
+              <td>1972</td>
+              <td>1970</td>
+            </tr>
+            <tr>
+              <td>M11L</td>
+              <td>Days 1–10: 2033<br>Days 11–29: 2034</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M12</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M12L</td>
+              <td>—</td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </figure></emu-table>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-calendarextrafields" type="implementation-defined abstract operation" aoid="CalendarExtraFields">
+      <h1><span class="secnum">4.1.22</span> CalendarExtraFields ( <var>calendar</var>, <var>fields</var> )</h1>
+      <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation CalendarExtraFields takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_132"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref>) and <var>fields</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the "Enumeration Key" column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>) and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the "Enumeration Key" column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>. It characterizes calendar-specific fields that are relevant for the provided <var>fields</var> in the built-in calendar identified by <var>calendar</var>.</p>
+      <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-calendarextrafields"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarextrafields">Temporal, 12.2.27</a></emu-xref>.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li>If <var>calendar</var> is not listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_27"><a href="#table-calendar-types">Table 1</a></emu-xref>, return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li><li>If <var>fields</var> contains an element equal to <emu-const>year</emu-const> and <emu-xref aoid="CalendarSupportsEra" id="_ref_133"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val>, then<ol><li>Return « <emu-const>era</emu-const>, <emu-const>era-year</emu-const>&nbsp;».</li></ol></li><li>Return an empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-nonisofieldkeystoignore" type="implementation-defined abstract operation" aoid="NonISOFieldKeysToIgnore">
+      <h1><span class="secnum">4.1.23</span> NonISOFieldKeysToIgnore ( <var>calendar</var>, <var>keys</var> )</h1>
+      <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation NonISOFieldKeysToIgnore takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_134"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>) and <var>keys</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the "Enumeration Key" column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>) and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of values from the "Enumeration Key" column of <emu-xref href="#table-temporal-calendar-fields-record-fields"><a href="https://tc39.es/proposal-temporal/#table-temporal-calendar-fields-record-fields">Table 19</a></emu-xref>. 
+          It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to determine which calendar date fields changing any of the fields named in <var>keys</var> can potentially conflict with or invalidate, for the given <var>calendar</var>.
+          A field always invalidates at least itself.
+        </p>
+      <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-nonisofieldkeystoignore"><a href="https://tc39.es/proposal-temporal/#sec-temporal-nonisofieldkeystoignore">Temporal, 12.2.28</a></emu-xref>.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li>If <var>calendar</var> is not listed in the "Calendar Type" column of <emu-xref href="#table-calendar-types" id="_ref_28"><a href="#table-calendar-types">Table 1</a></emu-xref>, return an <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> value.</li><li>Let <var>ignoredKeys</var> be a copy of <var>keys</var>.</li><li>For each element <var>key</var> of <var>keys</var>, do<ol><li>If <var>key</var> is <emu-const>month</emu-const>, append <emu-const>month-code</emu-const> to <var>ignoredKeys</var>.</li><li>If <var>key</var> is <emu-const>month-code</emu-const>, append <emu-const>month</emu-const>.</li><li>If <var>key</var> is one of <emu-const>era</emu-const>, <emu-const>era-year</emu-const>, or <emu-const>year</emu-const> and <emu-xref aoid="CalendarSupportsEra" id="_ref_135"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val>, then<ol><li>Append <emu-const>era</emu-const>, <emu-const>era-year</emu-const>, and <emu-const>year</emu-const> to <var>ignoredKeys</var>.</li></ol></li><li>If <var>key</var> is one of <emu-const>day</emu-const>, <emu-const>month</emu-const>, or <emu-const>month-code</emu-const> and <emu-xref aoid="CalendarHasMidYearEras" id="_ref_136"><a href="#sec-temporal-calendarhasmidyeareras">CalendarHasMidYearEras</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val>, then<ol><li>Append <emu-const>era</emu-const> and <emu-const>era-year</emu-const> to <var>ignoredKeys</var>.</li></ol></li></ol></li><li>NOTE: While <var>ignoredKeys</var> can have duplicate elements, this is not intended to be meaningful. This specification only checks whether particular keys are or are not members of the list.</li><li>Return <var>ignoredKeys</var>.</li></ol></emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-nonisoresolvefields" type="implementation-defined abstract operation" aoid="NonISOResolveFields">
+      <h1><span class="secnum">4.1.24</span> NonISOResolveFields ( <var>calendar</var>, <var>fields</var>, <var>type</var> )</h1>
+      <p>The <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> abstract operation NonISOResolveFields takes arguments <var>calendar</var> (a <emu-xref href="#sec-ecma402-calendar-types" id="_ref_137"><a href="#sec-ecma402-calendar-types">calendar type</a></emu-xref> that is not <emu-val>"iso8601"</emu-val>), <var>fields</var> (a Calendar Fields <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>), and <var>type</var> (<emu-const>date</emu-const>, <emu-const>year-month</emu-const>, or <emu-const>month-day</emu-const>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> <emu-const>unused</emu-const> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. 
+          It performs <emu-xref href="#implementation-defined"><a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a></emu-xref> processing to validate that <var>fields</var> (which describes a date or partial date in the built-in calendar identified by <var>calendar</var>) is sufficiently complete to satisfy <var>type</var> and not internally inconsistent, and mutates <var>fields</var> into acceptable input for <emu-xref aoid="CalendarDateToISO"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendardatetoiso">CalendarDateToISO</a></emu-xref> or <emu-xref aoid="CalendarMonthDayToISOReferenceDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarmonthdaytoisoreferencedate">CalendarMonthDayToISOReferenceDate</a></emu-xref> by merging data that can be represented in multiple forms into standard fields and removing redundant fields (for example, merging <var class="field">[[Era]]</var> and <var class="field">[[EraYear]]</var> into <var class="field">[[Year]]</var>).
+        </p>
+      <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-nonisoresolvefields"><a href="https://tc39.es/proposal-temporal/#sec-temporal-nonisoresolvefields">Temporal, 12.3.30</a></emu-xref>.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg><ol><li>Let <var>needsYear</var> be <emu-val>false</emu-val>.</li><li>If <var>type</var> is <emu-const>date</emu-const> or <var>type</var> is <emu-const>year-month</emu-const>, set <var>needsYear</var> to <emu-val>true</emu-val>.</li><li>If <var>fields</var>.<var class="field">[[MonthCode]]</var> is <emu-const>unset</emu-const>, set <var>needsYear</var> to <emu-val>true</emu-val>.</li><li>If <var>fields</var>.<var class="field">[[Month]]</var> is not <emu-const>unset</emu-const>, set <var>needsYear</var> to <emu-val>true</emu-val>.</li><li>Let <var>needsDay</var> be <emu-val>false</emu-val>.</li><li>If <var>type</var> is <emu-const>date</emu-const> or <var>type</var> is <emu-const>month-day</emu-const>, set <var>needsDay</var> to <emu-val>true</emu-val>.</li><li>If <var>needsYear</var> is <emu-val>true</emu-val>, then<ol><li>If <var>fields</var>.<var class="field">[[Year]]</var> is <emu-const>unset</emu-const>, then<ol><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_138"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>false</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>fields</var>.<var class="field">[[Era]]</var> is <emu-const>unset</emu-const> or <var>fields</var>.<var class="field">[[EraYear]]</var> is <emu-const>unset</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li></ol></li><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_139"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val>, then<ol><li>If <var>fields</var>.<var class="field">[[Era]]</var> is not <emu-const>unset</emu-const> and <var>fields</var>.<var class="field">[[EraYear]]</var> is <emu-const>unset</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>fields</var>.<var class="field">[[EraYear]]</var> is not <emu-const>unset</emu-const> and <var>fields</var>.<var class="field">[[Era]]</var> is <emu-const>unset</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</li></ol></li><li>If <var>needsDay</var> is <emu-val>true</emu-val> and <var>fields</var>.<var class="field">[[Day]]</var> is <emu-const>unset</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>fields</var>.<var class="field">[[Month]]</var> is <emu-const>unset</emu-const> and <var>fields</var>.<var class="field">[[MonthCode]]</var> is <emu-const>unset</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <emu-xref aoid="CalendarSupportsEra" id="_ref_140"><a href="#sec-temporal-calendarsupportsera">CalendarSupportsEra</a></emu-xref>(<var>calendar</var>) is <emu-val>true</emu-val> and <var>fields</var>.<var class="field">[[EraYear]]</var> is not <emu-const>unset</emu-const>, then<ol><li>Let <var>canonicalEra</var> be <emu-xref aoid="CanonicalizeEraInCalendar" id="_ref_141"><a href="#sec-temporal-canonicalizeeraincalendar">CanonicalizeEraInCalendar</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Era]]</var>).</li><li>If <var>canonicalEra</var> is <emu-val>undefined</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>arithmeticYear</var> be <emu-xref aoid="CalendarDateArithmeticYearForEraYear" id="_ref_142"><a href="#sec-temporal-calendardatearithmeticyearforerayear">CalendarDateArithmeticYearForEraYear</a></emu-xref>(<var>calendar</var>, <var>canonicalEra</var>, <var>fields</var>.<var class="field">[[EraYear]]</var>).</li><li>If <var>fields</var>.<var class="field">[[Year]]</var> is not <emu-const>unset</emu-const>, and <var>fields</var>.<var class="field">[[Year]]</var> ≠ <var>arithmeticYear</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>fields</var>.<var class="field">[[Year]]</var> to <var>arithmeticYear</var>.</li></ol></li><li>Set <var>fields</var>.<var class="field">[[Era]]</var> to <emu-const>unset</emu-const>.</li><li>Set <var>fields</var>.<var class="field">[[EraYear]]</var> to <emu-const>unset</emu-const>.</li><li>NOTE: <var>fields</var>.<var class="field">[[Era]]</var> and <var>fields</var>.<var class="field">[[EraYear]]</var> are erased in order to allow a lenient interpretation of out-of-bounds values, which is particularly useful for consistent interpretation of dates in calendars with regnal eras.</li><li>If <var>fields</var>.<var class="field">[[MonthCode]]</var> is not <emu-const>unset</emu-const>, then<ol><li>If <emu-xref aoid="IsValidMonthCodeForCalendar" id="_ref_143"><a href="#sec-temporal-isvalidmonthcodeforcalendar">IsValidMonthCodeForCalendar</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[MonthCode]]</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>If <var>fields</var>.<var class="field">[[Year]]</var> is not <emu-const>unset</emu-const>, then<ol><li>If <emu-xref aoid="YearContainsMonthCode" id="_ref_144"><a href="#sec-temporal-yearcontainsmonthcode">YearContainsMonthCode</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>fields</var>.<var class="field">[[MonthCode]]</var>) is <emu-val>true</emu-val>, let <var>constrainedMonthCode</var> be <var>fields</var>.<var class="field">[[MonthCode]]</var>; else let <var>constrainedMonthCode</var> be !&nbsp;<emu-xref aoid="ConstrainMonthCode" id="_ref_145"><a href="#sec-temporal-constrainmonthcode">ConstrainMonthCode</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>fields</var>.<var class="field">[[MonthCode]]</var>, <emu-const>constrain</emu-const>).</li><li>Let <var>month</var> be <emu-xref aoid="MonthCodeToOrdinal" id="_ref_146"><a href="#sec-temporal-monthcodetoordinal">MonthCodeToOrdinal</a></emu-xref>(<var>calendar</var>, <var>fields</var>.<var class="field">[[Year]]</var>, <var>constrainedMonthCode</var>).</li><li>If <var>fields</var>.<var class="field">[[Month]]</var> is not <emu-const>unset</emu-const> and <var>fields</var>.<var class="field">[[Month]]</var> ≠ <var>month</var>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>fields</var>.<var class="field">[[Month]]</var> to <var>month</var>.</li><li>NOTE: <var>fields</var>.<var class="field">[[MonthCode]]</var> is intentionally not overwritten with <var>constrainedMonthCode</var>. Pending the "overflow" parameter in <emu-xref aoid="CalendarDateToISO"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendardatetoiso">CalendarDateToISO</a></emu-xref> or <emu-xref aoid="CalendarMonthDayToISOReferenceDate"><a href="https://tc39.es/proposal-temporal/#sec-temporal-calendarmonthdaytoisoreferencedate">CalendarMonthDayToISOReferenceDate</a></emu-xref>, a month code not occurring in <var>fields</var>.<var class="field">[[Year]]</var> may cause that operation to throw. However, if <var>fields</var>.<var class="field">[[Month]]</var> is present, it must agree with the constrained month code.</li></ol></li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>fields</var>.<var class="field">[[Era]]</var> and <var>fields</var>.<var class="field">[[EraYear]]</var> are <emu-const>unset</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: If <var>needsYear</var> is <emu-val>true</emu-val>, <var>fields</var>.<var class="field">[[Year]]</var> is not <emu-const>unset</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>fields</var>.<var class="field">[[Month]]</var> is not <emu-const>unset</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: If <var>needsDay</var> is <emu-val>true</emu-val>, <var>fields</var>.<var class="field">[[Day]]</var> is not <emu-const>unset</emu-const>.</li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="normative-references">
+  <h1><span class="secnum">5</span> Normative References</h1>
+  <p>The following referenced documents are required for the application of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
+
+  <p>
+    ECMAScript 2026 Language Specification (<dfn id="ecma262" tabindex="-1">ECMA-262</dfn> 17<sup>th</sup> Edition, or successor).<br>
+    <a href="https://www.ecma-international.org/publications/standards/Ecma-262.htm">https://www.ecma-international.org/publications/standards/Ecma-262.htm</a>
+  </p>
+
+  <ul>
+    <li>
+      ISO/IEC 10646:2014: Information Technology – Universal Multiple-Octet Coded Character Set (UCS) plus Amendment 1:2015 and Amendment 2, plus additional amendments and corrigenda, or successor
+      <ul>
+        <li><a href="https://www.iso.org/iso/catalogue_detail.htm?csnumber=63182">https://www.iso.org/iso/catalogue_detail.htm?csnumber=63182</a></li>
+        <li><a href="https://www.iso.org/iso/catalogue_detail.htm?csnumber=65047">https://www.iso.org/iso/catalogue_detail.htm?csnumber=65047</a></li>
+        <li><a href="https://www.iso.org/iso/catalogue_detail.htm?csnumber=66791">https://www.iso.org/iso/catalogue_detail.htm?csnumber=66791</a></li>
+      </ul>
+    </li>
+    <li>
+      <a href="https://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=64758">ISO 4217:2015, Codes for the representation of currencies and funds, or successor</a>
+    </li>
+    <li>
+      <a href="https://tools.ietf.org/html/rfc4647">IETF RFC 4647, Matching of Language Tags, or successor</a>
+    </li>
+    <li>
+      <a href="https://www.iana.org/time-zones/">IANA Time Zone Database</a>
+    </li>
+    <li>
+      <a href="https://unicode.org/versions/latest">The Unicode Standard</a>
+    </li>
+    <li>
+      <a href="https://unicode.org/reports/tr29/">Unicode Standard Annex #29: Unicode Text Segmentation</a>
+    </li>
+    <li>
+      <a href="https://unicode.org/reports/tr10/">Unicode Technical Standard #10: Unicode Collation Algorithm</a>
+    </li>
+    <li>
+      <a href="https://unicode.org/reports/tr35/">Unicode Technical Standard #35: Unicode Locale Data Markup Language (LDML)</a>
+      <ul>
+        <li>
+          <a href="https://unicode.org/reports/tr35/#Unicode_Language_and_Locale_Identifiers">Part 1 Core, Section 3 Unicode Language and Locale Identifiers</a>
+        </li>
+        <li>
+          <a href="https://unicode.org/reports/tr35/tr35-general.html#Unit_Identifiers">Part 2 General, Section 6.2 Unit Identifiers</a>
+        </li>
+        <li>
+          <a href="https://unicode.org/reports/tr35/tr35-numbers.html#Operands">Part 3 Numbers, Section 5.1.1 Operands</a>
+        </li>
+        <li>
+          <ins><a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Data">Part 4 Dates, Calendar Data</a></ins>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <emu-note><span class="note">Note</span><div class="note-contents">
+    Sections of this specification that depend on these references are updated on a best-effort basis, but are not guaranteed to be up-to-date with those standards.
+  </div></emu-note>
+</emu-clause><emu-annex id="sec-copyright-and-software-license" back-matter="">
+        <h1>Copyright &amp; Software License</h1>
+        
+        <div class="copyright-notice" id="copyright-notice"><h2>Copyright Notice</h2>
+<p>© 2026 Google, Ecma International</p>
+</div>
+        <h2>Software License</h2>
+        <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
+
+<p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
+
+<ol>
+  <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+  <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
+  <li>Neither the name of the authors nor Ecma International may be used to endorse or promote products derived from this software without specific prior written permission.</li>
+</ol>
+
+<p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+
+      </emu-annex>
+</div></body>

--- a/spec.emu
+++ b/spec.emu
@@ -434,7 +434,7 @@ contributors: Google, Ecma International
             <td>6</td>
             <td>45</td>
             <td>~offset~</td>
-            <td>1873</td>
+            <td>1868</td>
           </tr>
           <tr>
             <td>*"japanese"*</td>


### PR DESCRIPTION
fix #86 

Previously the spec listed just the ISO year 1868 as start of the Meiji era. This change explicitly states that the Meiji era started on 1868-10-23.