### PR TITLE
Provide hardcoded table of reference years for Chinese and Dangi leap months

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -78,6 +78,11 @@
                 "id": "sec-temporal-nonisocalendardatetoiso"
             },
             {
+                "type": "op",
+                "aoid": "NonISOCalendarISOToDate",
+                "id": "sec-temporal-nonisocalendarisotodate"
+            },
+            {
                 "type": "clause",
                 "number": "Temporal, 12.2.6",
                 "id": "sec-temporal-nonisodateadd"
@@ -91,6 +96,11 @@
                 "type": "clause",
                 "number": "Temporal, 12.2.28",
                 "id": "sec-temporal-nonisofieldkeystoignore"
+            },
+            {
+                "type": "clause",
+                "number": "Temporal, 12.3.23",
+                "id": "sec-temporal-nonisomonthdaytoisoreferencedate"
             },
             {
                 "type": "clause",

--- a/spec.emu
+++ b/spec.emu
@@ -1265,6 +1265,192 @@ contributors: Google, Ecma International
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sup-temporal-nonisomonthdaytoisoreferencedate" type="implementation-defined abstract operation">
+      <h1>
+        NonISOMonthDayToISOReferenceDate (
+          _calendar_: a calendar type that is not *"iso8601"*,
+          _fields_: a Calendar Fields Record,
+          _overflow_: ~constrain~ or ~reject~,
+        ): either a normal completion containing an ISO Date Record or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It performs implementation-defined processing to convert _fields_, which represents a calendar date without a year (i.e., month code and day pair, or equivalent) in the built-in calendar identified by _calendar_, to a corresponding reference date in the ISO 8601 calendar as described below, subject to overflow correction specified by _overflow_.
+          For ~reject~, values that do not form a valid date cause an exception to be thrown.
+          For ~constrain~, values that do not form a valid date are clamped to their respective valid range as in CalendarDateToISO.
+        </dd>
+      </dl>
+      <p>
+        The fields of the returned ISO Date Record represent a reference date in the ISO 8601 calendar that, when converted to _calendar_, corresponds to the month code and day of _fields_ in an arbitrary but deterministically chosen reference year.
+        The reference date is the latest ISO 8601 date corresponding to the calendar date that is between January 1, 1900 and December 31, 1972 inclusive. If there is no such date, it is the earliest ISO 8601 date corresponding to the calendar date between January 1, 1973 and December 31, 2035 inclusive.
+        The reference year is almost always 1972 (the first ISO 8601 leap year after the epoch), with exceptions for calendars where some dates (e.g. leap days or days in leap months) didn't occur during that ISO 8601 year. For example, Hebrew calendar leap month Adar I occurred in calendar years 5730 and 5733 (respectively overlapping ISO 8601 February/March 1970 and February/March 1973), but did not occur between them, so the reference year for days of that month is 1970.
+      </p>
+      <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-nonisomonthdaytoisoreferencedate"></emu-xref>.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg>
+        1. Assert: _fields_.[[Month]] and _fields_.[[Day]] are not ~unset~.
+        1. Assert: If _fields_.[[MonthCode]] is ~unset~, _fields_.[[Year]] is not ~unset~.
+        1. Let _monthCode_ be _fields_.[[MonthCode]].
+        1. If _fields_.[[Year]] is not ~unset~, then
+          1. [declared="isoDate"] If there exists no combination of inputs such that ! CalendarIntegersToISO(_calendar_, _fields_.[[Year]], ..., ...) would return an ISO Date Record _isoDate_ for which ISODateWithinLimits(_isoDate_) is *true*, throw a *RangeError* exception.
+          1. NOTE: The above step exists so as not to require calculating whether the month and day described in _fields_ exist in user-provided years arbitrarily far in the future or past.
+          1. If _monthCode_ is not ~unset~, then
+            1. Set _monthCode_ to ? ConstrainMonthCode(_calendar_, _fields_.[[Year]], _monthCode_, _overflow_).
+          1. Let _daysInMonth_ be CalendarDaysInMonth(_calendar_, _fields_.[[Year]], _fields_.[[Month]]).
+        1. Else,
+          1. Assert: _monthCode_ is not ~unset~.
+          1. If _calendar_ is *"chinese"* or *"dangi"*, then
+            1. NOTE: This special case handles combinations of month and day that theoretically could occur but are not known to have occurred historically and cannot be accurately calculated to occur in the future, even if it may be possible to construct a PlainDate with such combinations due to inaccurate approximations. This is explicitly mentioned here because as time goes on, these dates may become known to have occurred historically, or may be more accurately calculated to occur in the future.
+            1. Let _row_ be the row in in <emu-xref href="#chinese-dangi-iso-reference-years"></emu-xref> with a value in the "Month Code" column matching _monthCode_.
+            1. If the "Reference Year (Days 1–29)" column of _row_ is "—", or _fields_.[[Day]] ≥ 30 and the "Reference Year (<emu-not-ref>Day</emu-not-ref> 30)" column of _row_ is "—", then
+              1. If _overflow_ is ~reject~, throw a *RangeError* exception.
+              1. Set _monthCode_ to CreateMonthCode(! ParseMonthCode(_monthCode_).[[MonthNumber]], *false*).
+            1. Let _daysInMonth_ be 30.
+          1. Else,
+            1. Let _daysInMonth_ be the maximum number of days in the month described by _monthCode_ in any year.
+        1. If _fields_.[[Day]] > _daysInMonth_, then
+          1. If _overflow_ is ~reject~, throw a *RangeError* exception.
+          1. Let _day_ be _daysInMonth_.
+        1. Else,
+          1. Let _day_ be _fields_.[[Day]].
+        1. If _monthCode_ is ~unset~, then
+          1. Let _fieldsISODate_ be ! CalendarIntegersToISO(_calendar_, _fields_.[[Year]], _fields_.[[Month]], _day_).
+          1. Set _monthCode_ to NonISOCalendarISOToDate(_calendar_, _fieldsISODate_).[[MonthCode]].
+        1. Let _referenceYear_ be the ISO reference year for _monthCode_ and _day_ as described above. If _calendar_ is *"chinese"* or *"dangi"*, the reference years in <emu-xref href="#chinese-dangi-iso-reference-years"></emu-xref> are to be used.
+        1. Return the latest possible ISO Date Record _isoDate_ such that _isoDate_.[[Year]] = _referenceYear_ and NonISOCalendarISOToDate(_calendar_, _isoDate_) returns a Calendar Date Record whose [[MonthCode]] and [[Day]] field values respectively equal _monthCode_ and _day_.
+      </emu-alg>
+
+      <emu-table id="chinese-dangi-iso-reference-years">
+        <emu-caption>*"chinese"* and *"dangi"* Calendars ISO Reference Years</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Month Code</th>
+              <th>Reference Year (Days 1–29)</th>
+              <th>Reference Year (<emu-not-ref>Day</emu-not-ref> 30)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>M01</td>
+              <td>1972</td>
+              <td>1970</td>
+            </tr>
+            <tr>
+              <td>M01L</td>
+              <td>—</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M02</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M02L</td>
+              <td>1947</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M03</td>
+              <td>1972</td>
+              <td>*"chinese"*: 1966<br/>*"dangi"*: 1968</td>
+            </tr>
+            <tr>
+              <td>M03L</td>
+              <td>1966</td>
+              <td>1955</td>
+            </tr>
+            <tr>
+              <td>M04</td>
+              <td>1972</td>
+              <td>1970</td>
+            </tr>
+            <tr>
+              <td>M04L</td>
+              <td>1963</td>
+              <td>1944</td>
+            </tr>
+            <tr>
+              <td>M05</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M05L</td>
+              <td>1971</td>
+              <td>1952</td>
+            </tr>
+            <tr>
+              <td>M06</td>
+              <td>1972</td>
+              <td>1971</td>
+            </tr>
+            <tr>
+              <td>M06L</td>
+              <td>1960</td>
+              <td>1941</td>
+            </tr>
+            <tr>
+              <td>M07</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M07L</td>
+              <td>1968</td>
+              <td>1938</td>
+            </tr>
+            <tr>
+              <td>M08</td>
+              <td>1972</td>
+              <td>1971</td>
+            </tr>
+            <tr>
+              <td>M08L</td>
+              <td>1957</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M09</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M09L</td>
+              <td>2014</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M10</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M10L</td>
+              <td>1984</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M11</td>
+              <td>1972</td>
+              <td>1970</td>
+            </tr>
+            <tr>
+              <td>M11L</td>
+              <td>Days 1–10: 2033<br/>Days 11–29: 2034</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M12</td>
+              <td colspan="2">1972</td>
+            </tr>
+            <tr>
+              <td>M12L</td>
+              <td>—</td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+
     <emu-clause id="sup-temporal-calendarextrafields" type="implementation-defined abstract operation">
       <h1>
         CalendarExtraFields (


### PR DESCRIPTION
fix https://github.com/tc39/proposal-intl-era-monthcode/issues/60

Certain rare leap months and leap days within leap months *can* occur in the Chinese and Dangi calendars, but haven't actually occurred for centuries -- since before those calendars can be said to have been meaningfully standardized. This PR provides a hardcoded list of reference years for those rare month and day combinations.

Note that this is editorial, rather than normative, because it clarifies the algorithm described in `NonISOMonthDayToISOReferenceDate` when using these two calendars.