### PR TITLE
Editorial: Provide override of NonISODateLastDayOfMonth

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -73,6 +73,11 @@
                 "id": "sec-temporal-nonisocalendardatetoiso"
             },
             {
+                "type": "op",
+                "aoid": "NonISOCalendarISOToDate",
+                "id": "sec-temporal-nonisocalendarisotodate"
+            },
+            {
                 "type": "clause",
                 "number": "Temporal, 12.2.6",
                 "id": "sec-temporal-nonisodateadd"

--- a/spec.emu
+++ b/spec.emu
@@ -1255,6 +1255,8 @@ contributors: Google, Ecma International
           For ~reject~, values that do not form a valid date cause an exception to be thrown, as described below.
           For ~constrain~, values that do not form a valid date are clamped to their respective valid range.
         </dd>
+        <dt>skip global checks</dt>
+        <dd>true</dd>
       </dl>
       <p>Like RegulateISODate, the operation throws a *RangeError* exception when _overflow_ is ~reject~ and the date described by _fields_ does not exist.</p>
       <p>Clamping an invalid date to the correct range when _overflow_ is ~constrain~ is a behaviour specific to each calendar other than *"iso8601"*, but all calendars follow this guideline.</p>
@@ -1336,6 +1338,27 @@ contributors: Google, Ecma International
             1. Append ~era~ and ~era-year~ to _ignoredKeys_.
         1. NOTE: While _ignoredKeys_ can have duplicate elements, this is not intended to be meaningful. This specification only checks whether particular keys are or are not members of the list.
         1. Return _ignoredKeys_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sup-temporal-nonisodatelastdayofmonth" type="abstract operation">
+      <h1>
+        NonISODateLastDayOfMonth (
+          _calendar_: a calendar type that is not *"iso8601"*,
+          _isoDate_: an ISO Date Record,
+        ): an ISO Date Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          The operation performs implementation-defined processing to determine the last day of the month denoted by _isoDate_.
+          It returns an ISO Date Record representing a date in the reckoning of _calendar_ that has the the same year and month as _isoDate_, and the day set to the last day of the month.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _calendarDate_ be NonISOCalendarISOToDate(_calendar_, _isoDate_).
+        1. Let _endOfMonth_ be BalanceNonISODate(_calendar_, _calendarDate_.[[Year]], _calendarDate_.[[Month]] + 1, 0).
+        1. Return ! NonISOCalendarDateToISO(_calendar_, _endOfMonth_, ~constrain~).
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
See https://github.com/tc39/proposal-temporal/pull/3208. This would be the corresponding definition of NonISODateLastDayOfMonth using the calendar-specific operations defined in this proposal.