### PR TITLE
Editorial: Fix assertion in MonthCodeToOrdinal

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -676,7 +676,7 @@ contributors: Google, Ecma International
         1. Assert: The following loop will terminate.
         1. Repeat, while _number_ &le; 12,
           1. Let _currentMonthCode_ be CreateMonthCode(_number_, _isLeap_).
-          1. If YearContainsMonthCode(_calendar_, _arithmeticYear_, _currentMonthCode_), then
+          1. If IsValidMonthCodeForCalendar(_calendar_, _currentMonthCode_) is *true* and YearContainsMonthCode(_calendar_, _arithmeticYear_, _currentMonthCode_) is *true*, then
             1. Set _monthsBefore_ to _monthsBefore_ + 1.
           1. If _currentMonthCode_ is _monthCode_, then
             1. Return _monthsBefore_.


### PR DESCRIPTION
YearContainsMonthCode asserts that the month code is valid for the calendar. MonthCodeToOrdinal needs to check if that is the case before calling YearContainsMonthCode.

Closes: #111