### PR TITLE
Editorial: Refine calendar implementation notes

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -117,7 +117,7 @@ contributors: Google, Ecma International
           </tr>
           <tr>
             <td>*"persian"*</td>
-            <td><a href="https://en.wikipedia.org/wiki/Solar_Hijri_calendar">Persian (or Solar Hijri) calendar</a>. There is one era.</td>
+            <td><a href="https://en.wikipedia.org/wiki/Solar_Hijri_calendar">Persian (or Solar Hijri) calendar</a>. There is one era. Solar calendar using leap years as <a href="https://calendar.ut.ac.ir/documents/2139738/7092644/Kabise+Shamsi+1206-1498.pdf">published by the Iranian calendar authority</a> for dates between 1206 AP and 1498 AP, falling back to an implementation-defined approximation outside that range.</td>
           </tr>
           <tr>
             <td>*"roc"*</td>


### PR DESCRIPTION
Addresses remaining comments on #64.

- Adds language to make the "proleptic" requirement more explicit, with an example.
- Adds an informational link to the Wikipedia article on each calendar, in particular to provide some background on the calendars, such as Gregorian, that aren't maintained by a single organization.
- For the Persian calendar, adds a link to the Iranian governmental calendar authority's published list of leap years and the range that it covers, ~~along with a requirement for which of the two popular approximations to use outside of that range (the 33-year one, not the 2820-year one.)~~

Closes: #64