### PR TITLE
Editorial: Various forms of PlainMonthDay reference year table

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1290,7 +1290,7 @@ contributors: Google, Ecma International
       <p>
         The fields of the returned ISO Date Record represent a reference date in the ISO 8601 calendar that, when converted to _calendar_, corresponds to the month code and day of _fields_ in an arbitrary but deterministically chosen reference year.
         The reference year is almost always 1972 (the first ISO 8601 leap year after the epoch), with exceptions for calendars where some dates (e.g. leap days or days in leap months) didn't occur during that ISO 8601 year.
-        These exceptions are listed in <emu-xref href="#iso-reference-years"></emu-xref>.
+        These exceptions are listed in <emu-xref href="#reference-arithmetic-years"></emu-xref> in the form of arithmetic years in each calendar.
       </p>
       <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-nonisomonthdaytoisoreferencedate"></emu-xref>.</p>
       <p>It performs the following steps when called:</p>
@@ -1312,7 +1312,7 @@ contributors: Google, Ecma International
             1. If _monthCode_ is ~unset~, then
               1. Let _fieldsISODate_ be ! CalendarIntegersToISO(_calendar_, _fields_.[[Year]], _fields_.[[Month]], _day_).
               1. Set _monthCode_ to NonISOCalendarISOToDate(_calendar_, _fieldsISODate_).[[MonthCode]].
-          1. Let _row_ be the row in <emu-xref href="#iso-reference-years"></emu-xref> with a value matching _calendar_ in the "Calendar Type" column and a value in the "Month Code" column matching _monthCode_.
+          1. Let _row_ be the row in <emu-xref href="#reference-arithmetic-years"></emu-xref> with a value matching _calendar_ in the "Calendar Type" column and a value in the "Month Code" column matching _monthCode_.
           1. If the "Reference Year (Days 1-29)" column of _row_ is "—", or _day_ = 30 and the "Reference Year (<emu-not-ref>Day</emu-not-ref> 30)" column of _row_ is "—", then
             1. If _overflow_ is ~reject~, throw a *RangeError* exception.
             1. Set _monthCode_ to CreateMonthCode(! ParseMonthCode(_monthCode_).[[MonthNumber]], *false*).
@@ -1333,14 +1333,15 @@ contributors: Google, Ecma International
           1. If _monthCode_ is ~unset~, then
             1. Let _fieldsISODate_ be ! CalendarIntegersToISO(_calendar_, _fields_.[[Year]], _fields_.[[Month]], _day_).
             1. Set _monthCode_ to NonISOCalendarISOToDate(_calendar_, _fieldsISODate_).[[MonthCode]].
-        1. Let _row_ be the row in <emu-xref href="#iso-reference-years"></emu-xref> with a value matching _calendar_ in the "Calendar Type" column and a value in the "Month Code" column matching _monthCode_ (or "any" or "others" if there is no row matching _monthCode_ exactly).
+        1. Let _row_ be the row in <emu-xref href="#reference-arithmetic-years"></emu-xref> with a value matching _calendar_ in the "Calendar Type" column and a value in the "Month Code" column matching _monthCode_ (or "any" if there is no row matching _monthCode_ exactly).
         1. Assert: _monthCode_ and _day_ do not match an entry in _row_ that is "—".
-        1. Let _referenceYear_ be the ISO reference year for _monthCode_ and _day_ as described in _row_.
-        1. Return the latest possible ISO Date Record _isoDate_ such that _isoDate_.[[Year]] = _referenceYear_ and NonISOCalendarISOToDate(_calendar_, _isoDate_) returns a Calendar Date Record whose [[MonthCode]] and [[Day]] field values respectively equal _monthCode_ and _day_.
+        1. Let _arithmeticYear_ be the reference arithmetic year for _monthCode_ and _day_ as described in _row_.
+        1. Let _ordinalMonth_ be MonthCodeToOrdinal(_calendar_, _arithmeticYear_, _monthCode_).
+        1. Return ! CalendarIntegersToISO(_calendar_, _arithmeticYear_, _ordinalMonth_, _day_).
       </emu-alg>
 
-      <emu-table id="iso-reference-years">
-        <emu-caption>ISO Reference Years</emu-caption>
+      <emu-table id="reference-arithmetic-years">
+        <emu-caption>Reference Arithmetic Years</emu-caption>
         <table>
           <thead>
             <tr>
@@ -1352,9 +1353,9 @@ contributors: Google, Ecma International
           </thead>
           <tbody>
             <tr>
-              <td>*"buddhist"*, *"gregory"*, *"indian"*, *"japanese"*, *"persian"*, *"roc"*</td>
+              <td>*"buddhist"*</td>
               <td>any</td>
-              <td colspan="2">Any day including 31: 1972</td>
+              <td colspan="2">Any day including 31: 2515</td>
             </tr>
             <tr>
               <td rowspan="24">*"chinese"*, *"dangi"*</td>
@@ -1454,17 +1455,17 @@ contributors: Google, Ecma International
             </tr>
             <tr>
               <td>M11</td>
-              <td>1972</td>
-              <td>1970</td>
+              <td>Days 1–26: 1972<br/>Days 27–29: 1971</td>
+              <td>1969</td>
             </tr>
             <tr>
               <td>M11L</td>
-              <td>Days 1–10: 2033<br/>Days 11–29: 2034</td>
+              <td>2033</td>
               <td>—</td>
             </tr>
             <tr>
               <td>M12</td>
-              <td colspan="2">1972</td>
+              <td colspan="2">1971</td>
             </tr>
             <tr>
               <td>M12L</td>
@@ -1472,98 +1473,202 @@ contributors: Google, Ecma International
               <td>—</td>
             </tr>
             <tr>
-              <td rowspan="2">*"coptic"*, *"ethioaa"*, *"ethiopic"*</td>
+              <td rowspan="4">*"coptic"*</td>
+              <td>M01–M03</td>
+              <td colspan="2">1689</td>
+            </tr>
+            <tr>
+              <td>M04</td>
+              <td>Days 1–22: 1689<br/>Days 23–29: 1688</td>
+              <td>1688</td>
+            </tr>
+            <tr>
+              <td>M05–M12</td>
+              <td colspan="2">1688</td>
+            </tr>
+            <tr>
               <td>M13</td>
-              <td>Days 1–5: 1972<br><emu-not-ref>Day</emu-not-ref> 6: 1971<br>Days 7–29: —</td>
+              <td>Days 1–5: 1688<br/><emu-not-ref>Day</emu-not-ref> 6: 1687<br/>Days 7–29: —</td>
               <td>—</td>
             </tr>
             <tr>
-              <td>others</td>
-              <td colspan="2">1972</td>
+              <td rowspan="4">*"ethioaa"*</td>
+              <td>M01–M03</td>
+              <td colspan="2">7465</td>
             </tr>
             <tr>
-              <td rowspan="4">*"hebrew"*</td>
+              <td>M04</td>
+              <td>Days 1–22: 7465<br/>Days 23–29: 7464</td>
+              <td>7464</td>
+            </tr>
+            <tr>
+              <td>M05–M12</td>
+              <td colspan="2">7464</td>
+            </tr>
+            <tr>
+              <td>M13</td>
+              <td>Days 1–5: 7464<br/><emu-not-ref>Day</emu-not-ref> 6: 7463<br/>Days 7–29: —</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td rowspan="4">*"ethiopic"*</td>
+              <td>M01–M03</td>
+              <td colspan="2">1965</td>
+            </tr>
+            <tr>
+              <td>M04</td>
+              <td>Days 1–22: 1965<br/>Days 23–29: 1964</td>
+              <td>1964</td>
+            </tr>
+            <tr>
+              <td>M05–M12</td>
+              <td colspan="2">1964</td>
+            </tr>
+            <tr>
+              <td>M13</td>
+              <td>Days 1–5: 1964<br/><emu-not-ref>Day</emu-not-ref> 6: 1963<br/>Days 7–29: —</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>*"gregory"*, *"japanese"*</td>
+              <td>any</td>
+              <td colspan="2">Any day including 31: 1972</td>
+            </tr>
+            <tr>
+              <td rowspan="7">*"hebrew"*</td>
+              <td>M01</td>
+              <td colspan="2">5733</td>
+            </tr>
+            <tr>
               <td>M02</td>
-              <td>1972</td>
-              <td>1971</td>
+              <td>5733</td>
+              <td>5732</td>
             </tr>
             <tr>
               <td>M03</td>
-              <td>1972</td>
-              <td>1971</td>
+              <td>5733</td>
+              <td>5732</td>
+            </tr>
+            <tr>
+              <td>M04</td>
+              <td>Days 1–26: 5733<br/>Days 27–29: 5732</td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>M05</td>
+              <td colspan="2">5732</td>
             </tr>
             <tr>
               <td>M05L</td>
-              <td colspan="2">1970</td>
+              <td colspan="2">5730</td>
             </tr>
             <tr>
-              <td>others</td>
-              <td colspan="2">1972</td>
+              <td>M06–M12</td>
+              <td colspan="2">5732</td>
             </tr>
             <tr>
-              <td rowspan="2">*"islamic-civil"*, *"islamic-tbla"*</td>
+              <td rowspan="3">*"indian"*</td>
+              <td>M01–M09</td>
+              <td colspan="2">Any day including 31: 1894</td>
+            </tr>
+            <tr>
+              <td>M10</td>
+              <td>Days 1–10: 1894<br/>Days 11–29: 1893</td>
+              <td>1893</td>
+            </tr>
+            <tr>
+              <td>M11, M12</td>
+              <td colspan="2">1893</td>
+            </tr>
+            <tr>
+              <td rowspan="3">*"islamic-civil"*, *"islamic-tbla"*</td>
+              <td>M01–M10</td>
+              <td colspan="2">1392</td>
+            </tr>
+            <tr>
+              <td>M11</td>
+              <td>Days 1–25: 1392<br/><emu-not-ref>Day</emu-not-ref> 26 (*"islamic-civil"*): 1391<br/><emu-not-ref>Day</emu-not-ref> 26 (*"islamic-tbla"*): 1392<br/>Days 27–29: 1391</td>
+              <td>1391</td>
+            </tr>
+            <tr>
               <td>M12</td>
-              <td>1972</td>
-              <td>1971</td>
-            </tr>
-            <tr>
-              <td>others</td>
-              <td colspan="2">1972</td>
+              <td>1391</td>
+              <td>1390</td>
             </tr>
             <tr>
               <td rowspan="12">*"islamic-umalqura"*</td>
               <td>M01</td>
-              <td colspan="2">1972</td>
+              <td colspan="2">1392</td>
             </tr>
             <tr>
               <td>M02</td>
-              <td>1972</td>
-              <td>1970</td>
+              <td>1392</td>
+              <td>1390</td>
             </tr>
             <tr>
               <td>M03</td>
-              <td>1972</td>
-              <td>1971</td>
+              <td>1392</td>
+              <td>1391</td>
             </tr>
             <tr>
               <td>M04</td>
-              <td colspan="2">1972</td>
+              <td colspan="2">1392</td>
             </tr>
             <tr>
               <td>M05</td>
-              <td>1972</td>
-              <td>1971</td>
+              <td>1392</td>
+              <td>1391</td>
             </tr>
             <tr>
               <td>M06</td>
-              <td colspan="2">1972</td>
+              <td colspan="2">1392</td>
             </tr>
             <tr>
               <td>M07</td>
-              <td>1972</td>
-              <td>1969</td>
+              <td>1392</td>
+              <td>1389</td>
             </tr>
             <tr>
               <td>M08</td>
-              <td colspan="2">1972</td>
+              <td colspan="2">1392</td>
             </tr>
             <tr>
               <td>M09</td>
-              <td colspan="2">1972</td>
+              <td colspan="2">1392</td>
             </tr>
             <tr>
               <td>M10</td>
-              <td>1972</td>
-              <td>1970</td>
+              <td>1392</td>
+              <td>1390</td>
             </tr>
             <tr>
               <td>M11</td>
-              <td colspan="2">1972</td>
+              <td>Days 1–25: 1392<br/>Days 26–29: 1391</td>
+              <td>1391</td>
             </tr>
             <tr>
               <td>M12</td>
-              <td>1972</td>
-              <td>1971</td>
+              <td>1391</td>
+              <td>1390</td>
+            </tr>
+            <tr>
+              <td rowspan="3">*"persian"*</td>
+              <td>M01–M09</td>
+              <td colspan="2">Any day including 31: 1351</td>
+            </tr>
+            <tr>
+              <td>M10</td>
+              <td>Days 1–10: 1351<br/>Days 11–29: 1350</td>
+              <td>1350</td>
+            </tr>
+            <tr>
+              <td>M11, M12</td>
+              <td colspan="2">1350</td>
+            </tr>
+            <tr>
+              <td>*"roc"*</td>
+              <td>any</td>
+              <td colspan="2">Any day including 31: 61</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
The first commit (https://github.com/tc39/proposal-intl-era-monthcode/pull/120/changes/891efb7adf6fb40697a17cd0c2d3f35be33071d5) expands the PlainMonthDay reference year table to cover all supported calendars. This allows deleting the language about how the reference years are chosen, since (1) implementations can now just pick them out of the table and (2) the process for choosing them is still in Temporal.

The second commit (https://github.com/tc39/proposal-intl-era-monthcode/pull/120/changes/e68e07f6def03386da151f1643fb63828a80a1de) converts the table to use arithmetic years instead of ISO years. In other words, moving the table from ISO space into calendar space. This slightly simplifies the algorithm but makes the table more complicated and about twice as long.

Closes: #114